### PR TITLE
fix(mieru): reject duplicate usernames across aggregated inbounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to Veil will be documented in this file.
 
 - Bumped `golang.org/x/net`, `golang.org/x/crypto`, and `golang.org/x/text` and raised the Go toolchain to 1.25 to clear all `govulncheck`-reported vulnerabilities in called code.
 
+### Fixed
+
+- Mieru generated config now rejects duplicate usernames across aggregated enabled Inbounds (including generated client profiles) instead of emitting a config the `mieru` server would reject at load time.
+
 ### Added
 
 - Added native `.deb`, `.rpm`, and `.apk` packages (built with nfpm) attached to releases, installing the Panel binary and managed systemd units.

--- a/internal/generatedconfig/mieru_model.go
+++ b/internal/generatedconfig/mieru_model.go
@@ -1,6 +1,10 @@
 package generatedconfig
 
-import "github.com/veil-panel/veil/internal/renderer"
+import (
+	"fmt"
+
+	"github.com/veil-panel/veil/internal/renderer"
+)
 
 type MieruGeneratedConfigModel struct {
 	settings Settings
@@ -12,6 +16,15 @@ func NewMieruGeneratedConfigModel(settings Settings) MieruGeneratedConfigModel {
 
 func (m MieruGeneratedConfigModel) Build(inbounds []Inbound) (renderer.MieruConfig, bool, error) {
 	config := renderer.MieruConfig{}
+	seen := map[string]struct{}{}
+	addUser := func(name, password string) error {
+		if _, exists := seen[name]; exists {
+			return fmt.Errorf("duplicate mieru user name %q across enabled mieru inbounds", name)
+		}
+		seen[name] = struct{}{}
+		config.Users = append(config.Users, renderer.MieruUser{Name: name, Password: password})
+		return nil
+	}
 	for _, inbound := range inbounds {
 		if !m.includes(inbound) {
 			continue
@@ -22,11 +35,15 @@ func (m MieruGeneratedConfigModel) Build(inbounds []Inbound) (renderer.MieruConf
 			return renderer.MieruConfig{}, false, err
 		}
 		if len(credentials) == 0 {
-			config.Users = append(config.Users, renderer.MieruUser{Name: inbound.Name, Password: inbound.Password})
+			if err := addUser(inbound.Name, inbound.Password); err != nil {
+				return renderer.MieruConfig{}, false, err
+			}
 			continue
 		}
 		for _, credential := range credentials {
-			config.Users = append(config.Users, renderer.MieruUser{Name: credential.Username, Password: credential.Password})
+			if err := addUser(credential.Username, credential.Password); err != nil {
+				return renderer.MieruConfig{}, false, err
+			}
 		}
 	}
 	if len(config.PortBindings) == 0 {

--- a/internal/generatedconfig/mieru_model_test.go
+++ b/internal/generatedconfig/mieru_model_test.go
@@ -29,3 +29,36 @@ func TestMieruGeneratedConfigModelReturnsNotRenderableWhenNoEnabledMieru(t *test
 		t.Fatalf("ok=%v err=%v", ok, err)
 	}
 }
+
+func TestMieruGeneratedConfigModelRejectsDuplicateUsernamesAcrossInbounds(t *testing.T) {
+	_, _, err := NewMieruGeneratedConfigModel(Settings{}).Build([]Inbound{
+		{Name: "shared", Protocol: "mieru", Transport: "tcp", Port: 443, Enabled: true, Password: "p1"},
+		{Name: "shared", Protocol: "mieru", Transport: "udp", Port: 444, Enabled: true, Password: "p2"},
+	})
+	if err == nil {
+		t.Fatal("expected duplicate username error across aggregated mieru inbounds")
+	}
+}
+
+func TestMieruGeneratedConfigModelRejectsDuplicateProfileUsernames(t *testing.T) {
+	_, _, err := NewMieruGeneratedConfigModel(Settings{}).Build([]Inbound{
+		{Name: "a", Protocol: "mieru", Transport: "tcp", Port: 443, Enabled: true, Profiles: []ClientProfile{{Name: "alice", Password: "x", Enabled: true}}},
+		{Name: "b", Protocol: "mieru", Transport: "udp", Port: 444, Enabled: true, Profiles: []ClientProfile{{Name: "alice", Password: "y", Enabled: true}}},
+	})
+	if err == nil {
+		t.Fatal("expected duplicate profile username error across aggregated mieru inbounds")
+	}
+}
+
+func TestMieruGeneratedConfigModelAllowsDistinctUsernames(t *testing.T) {
+	config, ok, err := NewMieruGeneratedConfigModel(Settings{}).Build([]Inbound{
+		{Name: "a", Protocol: "mieru", Transport: "tcp", Port: 443, Enabled: true, Password: "x"},
+		{Name: "b", Protocol: "mieru", Transport: "udp", Port: 444, Enabled: true, Password: "y"},
+	})
+	if err != nil || !ok {
+		t.Fatalf("ok=%v err=%v", ok, err)
+	}
+	if len(config.Users) != 2 {
+		t.Fatalf("users = %+v", config.Users)
+	}
+}


### PR DESCRIPTION
## Что сделано

Закрыт пробел корректности в агрегации Mieru: при нескольких включённых Mieru-inbound, объединяемых в один Generated config set, дублирующиеся имена пользователей раньше попадали в конфиг молча. Mieru-сервер отверг бы такой конфиг (или повёл себя недетерминированно), но Veil обнаруживал это в лучшем случае на этапе внешней валидации.

Теперь `MieruGeneratedConfigModel.Build` отслеживает имена и возвращает понятную ошибку `duplicate mieru user name %q across enabled mieru inbounds` — как для прямых паролей inbound, так и для имён из Client profile. Это срабатывает на этапе рендеринга, до записи staged-файла, и подхватывается Apply workflow как ошибка валидации с откатом.

## Изменения

- `internal/generatedconfig/mieru_model.go` — дедупликация имён пользователей при сборке агрегированного Mieru-конфига.
- `internal/generatedconfig/mieru_model_test.go` — тесты: дубликат по паролям inbound, дубликат по именам Client profile, и что разные имена по-прежнему агрегируются.
- `CHANGELOG.md` — запись в разделе Fixed.

## Проверки

- `go build ./...` — ок
- `go test ./...` — 40/40 пакетов проходят
- `gofmt -l` — чисто, `go vet` — чисто, `staticcheck ./...` — 0, `govulncheck ./...` — 0 вызываемых уязвимостей

## Заметка по базе

Ветка построена поверх `chore/hardening` (PR #1), поэтому diff чистый только если сначала влить #1. Если #1 ещё не смержен — мержить эту после него, либо я перебазирую на `main`.
