### PR TITLE
test(e2e): add end-to-end suite exercising the real veil binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,13 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y shellcheck
           shellcheck scripts/*.sh
+
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.25'
+      - name: End-to-end tests (real binary over a socket)
+        run: go test -tags e2e ./test/e2e/... -count=1 -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to Veil will be documented in this file.
 - Added an SPDX SBOM and keyless cosign signatures for release checksums and SBOM.
 - Added an OpenAPI 3.1 specification for the Panel HTTP API at `docs/openapi.yaml`.
 - Added a hardening guide at `docs/HARDENING.md` and documentation index in the README.
+- Added a black-box end-to-end test suite (`test/e2e`, behind the `e2e` build tag) that compiles the real `veil` binary, runs `serve` over a live socket, and verifies health/readiness, bearer-auth gating, the full inbound→client-link→apply flow with on-disk generated config, duplicate-username rejection, state persistence across restarts, graceful shutdown, and the `config validate`/`version`/`doctor` CLIs.
 - Expanded CI and release quality gates to enforce gofmt, `go mod tidy`, staticcheck, govulncheck, shellcheck, the race detector, and coverage reporting.
 - Added end-to-end Mieru Inbounds, generated config, client artifacts, managed runtime metadata, firewall planning, apply validation, live promotion, repair, and uninstall coverage.
 - Added optional HTTPS Panel access through Caddy with a random Web base path.

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,13 @@ DOCKER_IMAGE?=veil-panel/veil
 GOARCH?=$(shell go env GOARCH)
 MAINTAINER?=Veil Maintainers <veil@users.noreply.github.com>
 
-.PHONY: test build tidy docker release-check dist package package-deb package-rpm package-apk sbom
+.PHONY: test build tidy docker release-check dist package package-deb package-rpm package-apk sbom e2e
 
 test:
 	go test ./...
+
+e2e:
+	go test -tags e2e ./test/e2e/... -count=1
 
 build:
 	mkdir -p bin
@@ -47,6 +50,7 @@ tidy:
 release-check:
 	go vet ./...
 	go test ./... -count=1
+	go test -tags e2e ./test/e2e/... -count=1
 	make build
 	bash -n scripts/install.sh scripts/uninstall.sh
 	bash scripts/install.sh --help >/dev/null

--- a/README.md
+++ b/README.md
@@ -134,3 +134,12 @@ docker run -d --name veil --network host \
   -v veil-state:/var/lib/veil -v veil-etc:/etc/veil \
   veil-panel/veil:latest serve
 ```
+
+## Testing
+
+```bash
+make test    # unit + in-process integration tests
+make e2e     # end-to-end tests: real veil binary launched over a socket
+```
+
+The end-to-end suite (`test/e2e/`, guarded by the `e2e` build tag) compiles the `veil` binary, runs `veil serve` as a subprocess bound to a real port, and drives it over HTTP — covering the readiness lifecycle, API auth gating, graceful shutdown, state persistence across restarts, the full inbound-to-apply flow, and the CLI subcommands.

--- a/internal/cli/release_check_test.go
+++ b/internal/cli/release_check_test.go
@@ -42,3 +42,29 @@ func TestMakefileDefinesReleaseCheck(t *testing.T) {
 		}
 	}
 }
+
+func TestCiWorkflowRunsE2ESuite(t *testing.T) {
+	body, err := os.ReadFile("../../.github/workflows/ci.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workflow := strings.ReplaceAll(string(body), "\r\n", "\n")
+	for _, want := range []string{"e2e:", "go test -tags e2e ./test/e2e/..."} {
+		if !strings.Contains(workflow, want) {
+			t.Fatalf("ci.yml missing required e2e gate %q:\n%s", want, workflow)
+		}
+	}
+}
+
+func TestMakefileDefinesE2ETarget(t *testing.T) {
+	body, err := os.ReadFile("../../Makefile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	makefile := string(body)
+	for _, want := range []string{"e2e:", "go test -tags e2e ./test/e2e/... -count=1"} {
+		if !strings.Contains(makefile, want) {
+			t.Fatalf("Makefile missing e2e target %q:\n%s", want, makefile)
+		}
+	}
+}

--- a/test/e2e/harness_test.go
+++ b/test/e2e/harness_test.go
@@ -1,0 +1,305 @@
+//go:build e2e
+
+// Package e2e contains end-to-end tests that exercise a real `veil` binary:
+// it is compiled once, launched as a subprocess bound to a real OS socket,
+// driven over HTTP, and shut down gracefully. These tests are guarded by the
+// `e2e` build tag so they do not run as part of the default `go test ./...`.
+//
+// Run with: go test -tags e2e ./test/e2e/...
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// buildOnce compiles the veil binary a single time per test process.
+var (
+	buildOnce   sync.Once
+	builtBinary string
+	buildErr    error
+)
+
+// veilBinary builds (once) and returns the path to a freshly compiled veil
+// binary for the current module.
+func veilBinary(t *testing.T) string {
+	t.Helper()
+	buildOnce.Do(func() {
+		dir, err := os.MkdirTemp("", "veil-e2e-bin-")
+		if err != nil {
+			buildErr = err
+			return
+		}
+		bin := filepath.Join(dir, "veil")
+		// The e2e package lives at <module>/test/e2e, so the module root is two
+		// directories up. Build the CLI entrypoint from there.
+		cmd := exec.Command("go", "build", "-o", bin, "./cmd/veil")
+		cmd.Dir = moduleRoot(dir)
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			buildErr = fmt.Errorf("build veil: %v: %s", err, stderr.String())
+			return
+		}
+		builtBinary = bin
+	})
+	if buildErr != nil {
+		t.Fatalf("build veil binary: %v", buildErr)
+	}
+	return builtBinary
+}
+
+// moduleRoot resolves the module root relative to this test file's working
+// directory. `go test` runs with the working directory set to the package
+// directory (test/e2e), so the module root is two levels up.
+func moduleRoot(_ string) string {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "../.."
+	}
+	return filepath.Clean(filepath.Join(wd, "..", ".."))
+}
+
+// freePort asks the kernel for an unused TCP port and returns it. There is an
+// inherent race between closing the listener and the server re-binding, but in
+// practice it is reliable for local test orchestration.
+func freePort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve free port: %v", err)
+	}
+	defer ln.Close()
+	return ln.Addr().(*net.TCPAddr).Port
+}
+
+// serverProc is a running veil serve subprocess under test.
+type serverProc struct {
+	t         *testing.T
+	cmd       *exec.Cmd
+	baseURL   string
+	token     string
+	statePath string
+	applyRoot string
+	logBuf    *syncBuffer
+	waitErr   chan error
+}
+
+// serverOptions configures a serve subprocess.
+type serverOptions struct {
+	// token is the API bearer token. Empty means auth disabled.
+	token string
+	// seedState, when non-empty, is written to the state file before launch.
+	seedState string
+}
+
+// startServer launches `veil serve` on a free port with a private temp state
+// directory and waits until it is accepting connections.
+func startServer(t *testing.T, opts serverOptions) *serverProc {
+	t.Helper()
+	bin := veilBinary(t)
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "state.json")
+	applyRoot := filepath.Join(dir, "apply")
+	keyPath := filepath.Join(dir, "state.key")
+	if opts.seedState != "" {
+		if err := os.WriteFile(statePath, []byte(opts.seedState), 0o600); err != nil {
+			t.Fatalf("seed state: %v", err)
+		}
+	}
+	port := freePort(t)
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+
+	cmd := exec.Command(bin, "serve")
+	cmd.Env = append(os.Environ(),
+		"VEIL_LISTEN="+addr,
+		"VEIL_STATE_PATH="+statePath,
+		"VEIL_APPLY_ROOT="+applyRoot,
+		"VEIL_KEY_PATH="+keyPath,
+	)
+	if opts.token != "" {
+		cmd.Env = append(cmd.Env, "VEIL_API_TOKEN="+opts.token)
+	}
+	logBuf := &syncBuffer{}
+	cmd.Stdout = logBuf
+	cmd.Stderr = logBuf
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start veil serve: %v", err)
+	}
+
+	p := &serverProc{
+		t:         t,
+		cmd:       cmd,
+		baseURL:   "http://" + addr,
+		token:     opts.token,
+		statePath: statePath,
+		applyRoot: applyRoot,
+		logBuf:    logBuf,
+		waitErr:   make(chan error, 1),
+	}
+	go func() { p.waitErr <- cmd.Wait() }()
+	t.Cleanup(p.stop)
+	p.waitUntilListening()
+	return p
+}
+
+// waitUntilListening blocks until the server accepts a TCP connection or the
+// deadline elapses.
+func (p *serverProc) waitUntilListening() {
+	p.t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		select {
+		case err := <-p.waitErr:
+			p.t.Fatalf("server exited before listening: %v\nlogs:\n%s", err, p.logBuf.String())
+		default:
+		}
+		conn, err := net.DialTimeout("tcp", strings.TrimPrefix(p.baseURL, "http://"), 250*time.Millisecond)
+		if err == nil {
+			conn.Close()
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	p.t.Fatalf("server did not start listening within deadline\nlogs:\n%s", p.logBuf.String())
+}
+
+// do issues an HTTP request against the server, attaching the bearer token
+// when one is configured.
+func (p *serverProc) do(method, path, body string) *http.Response {
+	p.t.Helper()
+	var rdr io.Reader
+	if body != "" {
+		rdr = strings.NewReader(body)
+	}
+	req, err := http.NewRequest(method, p.baseURL+path, rdr)
+	if err != nil {
+		p.t.Fatalf("build request %s %s: %v", method, path, err)
+	}
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if p.token != "" {
+		req.Header.Set("Authorization", "Bearer "+p.token)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		p.t.Fatalf("request %s %s: %v", method, path, err)
+	}
+	return resp
+}
+
+// doNoAuth issues a request without the bearer token, for auth-gating checks.
+func (p *serverProc) doNoAuth(method, path string) *http.Response {
+	p.t.Helper()
+	req, err := http.NewRequest(method, p.baseURL+path, nil)
+	if err != nil {
+		p.t.Fatalf("build request %s %s: %v", method, path, err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		p.t.Fatalf("request %s %s: %v", method, path, err)
+	}
+	return resp
+}
+
+// readJSON decodes a response body into a generic map and closes the body.
+func readJSON(t *testing.T, resp *http.Response) map[string]any {
+	t.Helper()
+	defer resp.Body.Close()
+	var out map[string]any
+	data, _ := io.ReadAll(resp.Body)
+	if len(data) == 0 {
+		return out
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("decode JSON: %v (body: %s)", err, string(data))
+	}
+	return out
+}
+
+// drain reads and closes a response body.
+func drain(resp *http.Response) {
+	if resp == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+}
+
+// stop sends SIGINT and asserts the process exits cleanly within the drain
+// window. Safe to call multiple times.
+func (p *serverProc) stop() {
+	if p.cmd.Process == nil {
+		return
+	}
+	_ = p.cmd.Process.Signal(os.Interrupt)
+	select {
+	case err := <-p.waitErr:
+		if err != nil {
+			p.t.Errorf("server did not shut down cleanly: %v\nlogs:\n%s", err, p.logBuf.String())
+		}
+	case <-time.After(10 * time.Second):
+		_ = p.cmd.Process.Kill()
+		p.t.Errorf("server did not exit after SIGINT within deadline\nlogs:\n%s", p.logBuf.String())
+	}
+	p.cmd.Process = nil
+}
+
+// gracefulShutdown signals the server and verifies it exits with code 0 and
+// logs a clean stop. Returns the captured logs.
+func (p *serverProc) gracefulShutdown() string {
+	p.t.Helper()
+	_ = p.cmd.Process.Signal(os.Interrupt)
+	select {
+	case err := <-p.waitErr:
+		if err != nil {
+			p.t.Fatalf("graceful shutdown failed (expected exit 0): %v\nlogs:\n%s", err, p.logBuf.String())
+		}
+	case <-time.After(10 * time.Second):
+		_ = p.cmd.Process.Kill()
+		p.t.Fatalf("server did not exit after SIGINT\nlogs:\n%s", p.logBuf.String())
+	}
+	p.cmd.Process = nil
+	return p.logBuf.String()
+}
+
+// runCLI runs the veil binary with the given args and returns combined output.
+func runCLI(t *testing.T, env []string, args ...string) (string, error) {
+	t.Helper()
+	bin := veilBinary(t)
+	cmd := exec.CommandContext(context.Background(), bin, args...)
+	cmd.Env = append(os.Environ(), env...)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// syncBuffer is a goroutine-safe buffer for capturing subprocess output.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}

--- a/test/e2e/management_flow_test.go
+++ b/test/e2e/management_flow_test.go
@@ -1,0 +1,157 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestFullInboundToApplyFlow drives the complete management lifecycle over a
+// real socket: configure settings, create two Mieru inbounds, fetch client
+// links, then stage an apply and confirm generated config artifacts land on
+// disk under the apply root.
+func TestFullInboundToApplyFlow(t *testing.T) {
+	srv := startServer(t, serverOptions{token: "e2e-secret-token"})
+
+	resp := srv.do(http.MethodPut, "/api/settings", `{"panelListen":"127.0.0.1:2096","mode":"dev","domain":"vpn.example.com"}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("settings expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp))
+	}
+	drain(resp)
+
+	resp = srv.do(http.MethodPost, "/api/inbounds", `{"name":"mieru-tcp","protocol":"mieru","transport":"tcp","port":8443,"enabled":true,"profiles":[{"name":"alice","password":"alice-pass","enabled":true}]}`)
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("inbound 1 expected 201, got %d: %v", resp.StatusCode, readJSON(t, resp))
+	}
+	drain(resp)
+
+	resp = srv.do(http.MethodPost, "/api/inbounds", `{"name":"mieru-udp","protocol":"mieru","transport":"udp","port":8443,"enabled":true,"password":"udp-pass"}`)
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("inbound 2 expected 201, got %d: %v", resp.StatusCode, readJSON(t, resp))
+	}
+	drain(resp)
+
+	// Client links should aggregate the enabled Mieru transports.
+	resp = srv.do(http.MethodGet, "/api/client-links", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("client links expected 200, got %d", resp.StatusCode)
+	}
+	links := readJSON(t, resp)
+	if count, ok := links["count"].(float64); !ok || count < 1 {
+		t.Fatalf("expected at least one client link, got %v", links["count"])
+	}
+
+	// Plan, then apply; expect generated mieru config under the apply root.
+	resp = srv.do(http.MethodPost, "/api/apply/plan", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("apply plan expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp))
+	}
+	drain(resp)
+
+	resp = srv.do(http.MethodPost, "/api/apply", `{"confirm":true}`)
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusConflict {
+		t.Fatalf("apply expected 200/409, got %d: %v", resp.StatusCode, readJSON(t, resp))
+	}
+	drain(resp)
+
+	// A generated mieru config artifact should exist somewhere under the
+	// apply root after staging.
+	found := false
+	_ = filepath.Walk(srv.applyRoot, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return nil
+		}
+		if strings.Contains(strings.ToLower(path), "mieru") {
+			found = true
+		}
+		return nil
+	})
+	if !found {
+		t.Fatalf("expected a generated mieru artifact under apply root %s", srv.applyRoot)
+	}
+}
+
+// TestRejectsDuplicateMieruUsernamesEndToEnd confirms the aggregation
+// safeguard (duplicate user names across enabled Mieru inbounds) surfaces as
+// an apply/plan error over the real HTTP surface rather than silently writing
+// a broken config.
+func TestRejectsDuplicateMieruUsernamesEndToEnd(t *testing.T) {
+	srv := startServer(t, serverOptions{token: "tok"})
+
+	resp := srv.do(http.MethodPut, "/api/settings", `{"panelListen":"127.0.0.1:2096","mode":"dev"}`)
+	drain(resp)
+
+	// Two Mieru inbounds whose sole client profile shares the same name.
+	resp = srv.do(http.MethodPost, "/api/inbounds", `{"name":"dup","protocol":"mieru","transport":"tcp","port":8443,"enabled":true,"password":"pw1"}`)
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("inbound 1 expected 201, got %d: %v", resp.StatusCode, readJSON(t, resp))
+	}
+	drain(resp)
+	resp = srv.do(http.MethodPost, "/api/inbounds", `{"name":"dup","protocol":"mieru","transport":"udp","port":8443,"enabled":true,"password":"pw2"}`)
+	// The catalog may reject the duplicate name at creation, or the conflict
+	// may surface at plan/apply time. Either is an acceptable safeguard; what
+	// matters is that it never silently succeeds end-to-end.
+	if resp.StatusCode == http.StatusCreated {
+		drain(resp)
+		planResp := srv.do(http.MethodPost, "/api/apply/plan", "")
+		planBody := readJSON(t, planResp)
+		if planResp.StatusCode == http.StatusOK {
+			// If plan is OK, apply must fail with the duplicate-user error.
+			applyResp := srv.do(http.MethodPost, "/api/apply", `{"confirm":true}`)
+			if applyResp.StatusCode == http.StatusOK {
+				t.Fatalf("expected duplicate mieru user names to be rejected, but apply succeeded: %v", planBody)
+			}
+			drain(applyResp)
+		}
+		return
+	}
+	if resp.StatusCode < 400 {
+		t.Fatalf("expected duplicate inbound to be rejected, got %d: %v", resp.StatusCode, readJSON(t, resp))
+	}
+	drain(resp)
+}
+
+// TestConfigValidateCLI exercises the `veil config validate` subcommand
+// against the real binary with both a valid and an invalid state file.
+func TestConfigValidateCLI(t *testing.T) {
+	dir := t.TempDir()
+	good := filepath.Join(dir, "good.json")
+	if err := os.WriteFile(good, []byte(`{"settings":{"panelListen":"127.0.0.1:2096","mode":"dev"},"inbounds":[],"routingRules":[]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out, err := runCLI(t, nil, "config", "validate", "--state", good)
+	if err != nil {
+		t.Fatalf("valid state should pass, got err=%v out=%s", err, out)
+	}
+
+	bad := filepath.Join(dir, "bad.json")
+	if err := os.WriteFile(bad, []byte(`{"settings":{"panelListen":"127.0.0.1:2096","mode":"dev"},"inbounds":[{"name":"x","protocol":"mieru","transport":"tcp","port":70000}],"routingRules":[]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out, err = runCLI(t, nil, "config", "validate", "--state", bad)
+	if err == nil {
+		t.Fatalf("invalid state should fail validation, out=%s", out)
+	}
+}
+
+// TestVersionAndDoctorCLI smoke-tests two read-only subcommands end-to-end.
+func TestVersionAndDoctorCLI(t *testing.T) {
+	out, err := runCLI(t, nil, "version")
+	if err != nil {
+		t.Fatalf("version failed: %v (%s)", err, out)
+	}
+	if strings.TrimSpace(out) == "" {
+		t.Fatal("version produced no output")
+	}
+
+	// doctor exits non-zero when required commands are missing; we only
+	// assert it produces JSON we can recognize when asked.
+	out, _ = runCLI(t, nil, "doctor", "--json")
+	if !strings.Contains(out, "\"ready\"") {
+		t.Fatalf("doctor --json missing readiness field: %s", out)
+	}
+}

--- a/test/e2e/serve_lifecycle_test.go
+++ b/test/e2e/serve_lifecycle_test.go
@@ -1,0 +1,133 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestServeHealthLifecycle verifies the readiness endpoint reflects state
+// presence: 503 before the state file exists, 200 after a settings write
+// persists it.
+func TestServeHealthLifecycle(t *testing.T) {
+	srv := startServer(t, serverOptions{token: "e2e-secret-token"})
+
+	// /healthz is public (no auth) and unhealthy until state is persisted.
+	resp := srv.doNoAuth(http.MethodGet, "/healthz")
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		drain(resp)
+		t.Fatalf("expected 503 before state exists, got %d", resp.StatusCode)
+	}
+	body := readJSON(t, resp)
+	if body["status"] != "unhealthy" {
+		t.Fatalf("expected unhealthy status, got %v", body)
+	}
+
+	// Persist settings -> state file is created -> health flips to ok.
+	resp = srv.do(http.MethodPut, "/api/settings", `{"panelListen":"127.0.0.1:2096","mode":"dev"}`)
+	if resp.StatusCode != http.StatusOK {
+		body := readJSON(t, resp)
+		t.Fatalf("settings write expected 200, got %d: %v", resp.StatusCode, body)
+	}
+	drain(resp)
+
+	resp = srv.doNoAuth(http.MethodGet, "/healthz")
+	if resp.StatusCode != http.StatusOK {
+		drain(resp)
+		t.Fatalf("expected 200 after state exists, got %d", resp.StatusCode)
+	}
+	if got := readJSON(t, resp); got["status"] != "ok" {
+		t.Fatalf("expected ok status, got %v", got)
+	}
+}
+
+// TestServeAuthGate verifies bearer-token enforcement on /api/* over a real
+// socket: missing token => 401 with WWW-Authenticate, valid token => 200,
+// while public routes stay open.
+func TestServeAuthGate(t *testing.T) {
+	srv := startServer(t, serverOptions{token: "e2e-secret-token"})
+
+	resp := srv.doNoAuth(http.MethodGet, "/api/status")
+	if resp.StatusCode != http.StatusUnauthorized {
+		drain(resp)
+		t.Fatalf("expected 401 without token, got %d", resp.StatusCode)
+	}
+	if h := resp.Header.Get("WWW-Authenticate"); !strings.Contains(h, "Bearer") {
+		t.Fatalf("expected Bearer challenge header, got %q", h)
+	}
+	drain(resp)
+
+	// Valid token => 200.
+	req := srv.do(http.MethodGet, "/api/status", "")
+	if req.StatusCode != http.StatusOK {
+		drain(req)
+		t.Fatalf("expected 200 with valid token, got %d", req.StatusCode)
+	}
+	drain(req)
+}
+
+// TestServeAuthDisabled verifies that with no token configured, /api/* is
+// reachable without credentials and the startup log says auth is disabled.
+func TestServeAuthDisabled(t *testing.T) {
+	srv := startServer(t, serverOptions{})
+
+	resp := srv.doNoAuth(http.MethodGet, "/api/status")
+	if resp.StatusCode != http.StatusOK {
+		drain(resp)
+		t.Fatalf("expected 200 with auth disabled, got %d", resp.StatusCode)
+	}
+	drain(resp)
+
+	logs := srv.gracefulShutdown()
+	if !strings.Contains(logs, "API auth: disabled") {
+		t.Fatalf("expected 'API auth: disabled' in logs, got:\n%s", logs)
+	}
+}
+
+// TestGracefulShutdownExitsClean verifies SIGINT triggers a clean drain and
+// exit-0 with the expected lifecycle log lines.
+func TestGracefulShutdownExitsClean(t *testing.T) {
+	srv := startServer(t, serverOptions{token: "tok"})
+	resp := srv.doNoAuth(http.MethodGet, "/healthz")
+	drain(resp)
+	logs := srv.gracefulShutdown()
+	for _, want := range []string{"Shutting down", "Server stopped"} {
+		if !strings.Contains(logs, want) {
+			t.Fatalf("expected %q in shutdown logs, got:\n%s", want, logs)
+		}
+	}
+}
+
+// TestStatePersistsAcrossRestart verifies that configuration written through
+// one serve process is durable: a second process started against the same
+// state file serves the same inbound.
+func TestStatePersistsAcrossRestart(t *testing.T) {
+	srv := startServer(t, serverOptions{token: "tok"})
+	resp := srv.do(http.MethodPut, "/api/settings", `{"panelListen":"127.0.0.1:2096","mode":"dev"}`)
+	drain(resp)
+	resp = srv.do(http.MethodPost, "/api/inbounds", `{"name":"persist-me","protocol":"mieru","transport":"tcp","port":9443,"enabled":true,"password":"pw"}`)
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("inbound expected 201, got %d", resp.StatusCode)
+	}
+	drain(resp)
+	statePath := srv.statePath
+	srv.gracefulShutdown()
+
+	// Read the seed from the now-stopped server's state file and relaunch.
+	seed, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	srv2 := startServer(t, serverOptions{token: "tok", seedState: string(seed)})
+	resp = srv2.do(http.MethodGet, "/api/inbounds", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("inbounds expected 200, got %d", resp.StatusCode)
+	}
+	raw, _ := os.ReadFile(srv2.statePath)
+	if !strings.Contains(string(raw), "persist-me") {
+		t.Fatalf("expected persisted inbound 'persist-me' after restart in %s", srv2.statePath)
+	}
+}


### PR DESCRIPTION
Compile the veil binary once, launch `veil serve` as a subprocess bound to a
real OS socket, drive it over HTTP, and shut it down gracefully. Guarded by
the `e2e` build tag so the default `go test ./...` is unaffected.

Coverage:
- serve health/readiness lifecycle (/healthz 503 before state, 200 after)
- API auth gating (401 without token, 200 with; disabled mode)
- graceful shutdown on SIGINT (clean exit, drained server)
- state persistence across a restart
- full settings -> inbounds -> client-links -> plan -> apply flow with
  generated mieru artifact landing under the apply root
- duplicate-mieru-username safeguard over the real HTTP surface
- config validate / version / doctor CLI smoke tests

Wire the suite into CI (new e2e job) and `make e2e` / `release-check`.
