### PR TITLE
feat: rebuild inbound Caddy redesign on current main

### DIFF
--- a/.github/workflows/inbound-caddy-diagnostics.yml
+++ b/.github/workflows/inbound-caddy-diagnostics.yml
@@ -1,15 +1,14 @@
 name: inbound-caddy-diagnostics
 
 on:
-  pull_request:
-    branches: [main]
+  push:
+    branches: [feature/inbound-caddy-redesign]
 
 permissions:
   contents: read
 
 jobs:
   diagnostics:
-    if: github.head_ref == 'feature/inbound-caddy-redesign'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/inbound-caddy-diagnostics.yml
+++ b/.github/workflows/inbound-caddy-diagnostics.yml
@@ -1,0 +1,48 @@
+name: inbound-caddy-diagnostics
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  diagnostics:
+    if: github.head_ref == 'feature/inbound-caddy-redesign'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: '1.26.5'
+      - name: Run pinned staticcheck
+        shell: bash
+        run: |
+          set -o pipefail
+          go install honnef.co/go/tools/cmd/staticcheck@2026.1
+          staticcheck ./... 2>&1 | tee staticcheck.log
+      - name: Run verbose E2E
+        if: always()
+        shell: bash
+        run: |
+          set -o pipefail
+          go test -tags e2e ./test/e2e/... -count=1 -v 2>&1 | tee e2e.log
+      - name: Run focused redesign tests
+        if: always()
+        shell: bash
+        run: |
+          set -o pipefail
+          go test ./internal/bindregistry ./internal/caddyassembly ./internal/caddyadmin ./internal/caddycapabilities ./internal/renderer ./internal/protocols/naiveproxy ./internal/protocols/hysteria2 ./internal/generatedconfig ./internal/api -count=1 -v 2>&1 | tee focused.log
+      - name: Upload diagnostics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: inbound-caddy-diagnostics
+          path: |
+            staticcheck.log
+            e2e.log
+            focused.log
+          if-no-files-found: ignore
+          retention-days: 3

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -24,7 +24,12 @@ Veil supports multiple Inbounds, with varying levels of isolation depending on t
 
 ---
 
-## 3. Go Module Path
+## 3. NaiveProxy Transport Support
+
+- **TCP only:** NaiveProxy in this release supports only the **TCP (HTTPS/H2)** transport. QUIC and `dual` transports are planned for a future release once an HTTP/3 capability probe and the `forward_proxy` over HTTP-3 path have been verified end-to-end.
+- **Implication:** Configuring a NaiveProxy inbound with `transport: quic` or `transport: dual` will be rejected during the apply-plan build.
+
+## 4. Go Module Path
 
 - **Path:** The module path is canonicalized to `github.com/mikkelchokolate/Veil`, matching the GitHub repository URL.
 - **Implication:** You can install the CLI tool directly from GitHub via `go install github.com/mikkelchokolate/Veil/cmd/veil@latest`.

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -11,7 +11,7 @@ Veil supports multiple Inbounds, with varying levels of isolation depending on t
 
 - **Hysteria2 & olcRTC:** Full isolation. Defining multiple enabled Inbounds for Hysteria2 or olcRTC generates isolated configuration files and spawns independent daemon processes managed via systemd template units (`veil-hysteria2@<inbound>.service` and `veil-olcrtc@<inbound>.service`).
 - **Mieru:** Aggregation. If you define multiple Mieru Inbounds, their port/transport bindings and client profiles are aggregated cleanly into a single generated configuration file managed by a single daemon process.
-- **NaiveProxy:** Full isolation. Defining multiple enabled Inbounds for NaiveProxy generates isolated configuration files (`<inbound>.Caddyfile`) and spawns independent Caddy processes managed via systemd template units (`veil-caddy@<inbound>.service`).
+- **NaiveProxy:** Consolidated single service. All enabled NaiveProxy Inbounds share one generated runtime configuration (`config.json`) and one systemd unit (`veil-caddy.service`). Each inbound still has its own domain and port binding inside that shared configuration.
 
 - If you need multiple users on Hysteria2 or NaiveProxy, add multiple **Client Profiles** under the same Inbound instead of creating separate Inbound instances.
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1498,9 +1498,17 @@ paths:
                     email: admin@example.com
                     panelAccess: caddy
                     panelUrl: https://vpn.example.com/4f10dbe4/
-                    caddyfile: |
-                      vpn.example.com {
-                        reverse_proxy 127.0.0.1:2096
+                    caddyJSON: |
+                      {
+                        "apps": {
+                          "http": {
+                            "servers": {
+                              "tcp-0.0.0.0-443": {
+                                "listen": [":443"]
+                              }
+                            }
+                          }
+                        }
                       }
         "400":
           $ref: "#/components/responses/BadRequest"
@@ -2978,7 +2986,7 @@ components:
         panelUrl:
           type: string
           format: uri
-        caddyfile:
+        caddyJSON:
           type: string
     SystemStats:
       type: object

--- a/internal/api/apply_plan_builder.go
+++ b/internal/api/apply_plan_builder.go
@@ -3,6 +3,7 @@ package api
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/mikkelchokolate/Veil/internal/applyplan"
 	"github.com/mikkelchokolate/Veil/internal/bindregistry"
@@ -28,7 +29,8 @@ type ApplyPlanInput struct {
 
 func BuildApplyPlan(input ApplyPlanInput) ApplyPlanResponse {
 	applyRoot := defaultApplyRoot(input.ApplyRoot)
-	caddyMaterial := buildCaddyMaterial(input.Settings, input.Inbounds)
+	runtimeCatalog := NewManagedRuntimeCatalogFor(input.Inbounds, input.Warp)
+	caddyMaterial := buildCaddyMaterial(input.Settings, input.Inbounds, runtimeCatalog)
 	capabilities := []applyplan.ProtocolCapability{}
 	catalog := NewApplyProtocolCapabilityCatalog()
 	for _, protocolCapability := range catalog.All() {
@@ -42,7 +44,6 @@ func BuildApplyPlan(input ApplyPlanInput) ApplyPlanResponse {
 			RequiresRenderSettings: capability.RequiresRenderSettings,
 		})
 	}
-	runtimeCatalog := NewManagedRuntimeCatalogFor(input.Inbounds, input.Warp)
 	runtimeUnits := filterCaddyRuntimeUnits(service.NewProtocolRuntimeProvisioning(runtimeCatalog).Plan(input.Inbounds, input.Warp).SystemdUnits())
 	validateInboundRender := input.ValidateInboundRender
 	warpAction := ""
@@ -70,7 +71,7 @@ func BuildApplyPlan(input ApplyPlanInput) ApplyPlanResponse {
 	})
 }
 
-func buildCaddyMaterial(settings Settings, inbounds []Inbound) applyplan.Material {
+func buildCaddyMaterial(settings Settings, inbounds []Inbound, runtimeCatalog ManagedRuntimeCatalog) applyplan.Material {
 	material := applyplan.Material{}
 	if !caddyRequired(settings, inbounds) {
 		return material
@@ -103,7 +104,7 @@ func buildCaddyMaterial(settings Settings, inbounds []Inbound) applyplan.Materia
 	for k := range challengeBinds {
 		allOwners[k] = bindregistry.BindOwner{Kind: bindregistry.BindOwnerAcmeChallenge, ServiceName: "veil-caddy.service"}
 	}
-	for _, conflict := range addInboundBindOwners(inbounds, allOwners) {
+	for _, conflict := range addInboundBindOwners(inbounds, allOwners, runtimeCatalog) {
 		material.Errors = append(material.Errors, conflict.Message)
 	}
 	for _, conflict := range bindregistry.ValidateNoConflicts(allOwners) {
@@ -129,7 +130,7 @@ func buildCaddyMaterial(settings Settings, inbounds []Inbound) applyplan.Materia
 	return material
 }
 
-func addInboundBindOwners(inbounds []Inbound, owners map[bindregistry.BindKey]bindregistry.BindOwner) []bindregistry.Conflict {
+func addInboundBindOwners(inbounds []Inbound, owners map[bindregistry.BindKey]bindregistry.BindOwner, runtimeCatalog ManagedRuntimeCatalog) []bindregistry.Conflict {
 	var conflicts []bindregistry.Conflict
 	for _, inb := range inbounds {
 		if !inb.Enabled || inb.Port <= 0 {
@@ -147,8 +148,12 @@ func addInboundBindOwners(inbounds []Inbound, owners map[bindregistry.BindKey]bi
 			key = bindregistry.BindKey{Address: "0.0.0.0", Port: inb.Port, Network: bindregistry.ListenUDP}
 			owner = bindregistry.BindOwner{Kind: bindregistry.BindOwnerHysteria2, ServiceName: "veil-hysteria2@" + inb.Name + ".service", InboundName: inb.Name}
 		default:
-			key = bindregistry.BindKey{Address: "0.0.0.0", Port: inb.Port, Network: bindregistry.ListenTCP}
-			owner = bindregistry.BindOwner{Kind: bindregistry.BindOwnerInbound, ServiceName: "veil-" + inb.Protocol + ".service", InboundName: inb.Name}
+			network := bindregistry.ListenTCP
+			if inb.Transport == "udp" {
+				network = bindregistry.ListenUDP
+			}
+			key = bindregistry.BindKey{Address: "0.0.0.0", Port: inb.Port, Network: network}
+			owner = bindregistry.BindOwner{Kind: bindregistry.BindOwnerInbound, ServiceName: inboundServiceUnit(runtimeCatalog, inb.Protocol, inb.Name), InboundName: inb.Name}
 		}
 		if existing, ok := owners[key]; ok && existing != owner {
 			conflicts = append(conflicts, bindregistry.Conflict{
@@ -161,6 +166,20 @@ func addInboundBindOwners(inbounds []Inbound, owners map[bindregistry.BindKey]bi
 		owners[key] = owner
 	}
 	return conflicts
+}
+
+func inboundServiceUnit(runtimeCatalog ManagedRuntimeCatalog, protocol, inboundName string) string {
+	for _, runtime := range runtimeCatalog.Runtimes() {
+		if runtime.Protocol != protocol {
+			continue
+		}
+		unit := runtime.Unit
+		if idx := strings.Index(unit, "@."); idx != -1 {
+			unit = unit[:idx+1] + inboundName + unit[idx+1:]
+		}
+		return unit
+	}
+	return "veil-" + protocol + ".service"
 }
 
 func caddyRequired(settings Settings, inbounds []Inbound) bool {

--- a/internal/api/apply_plan_builder.go
+++ b/internal/api/apply_plan_builder.go
@@ -2,7 +2,9 @@ package api
 
 import (
 	"fmt"
+	"net"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/mikkelchokolate/Veil/internal/applyplan"
@@ -112,6 +114,9 @@ func buildCaddyMaterial(settings Settings, inbounds []Inbound, runtimeCatalog Ma
 		}
 	}
 
+	for _, conflict := range addPanelDirectBindOwner(settings, owners) {
+		material.Errors = append(material.Errors, conflict.Message)
+	}
 	for _, conflict := range addInboundBindOwners(inbounds, owners, runtimeCatalog) {
 		material.Errors = append(material.Errors, conflict.Message)
 	}
@@ -134,6 +139,31 @@ func buildCaddyMaterial(settings Settings, inbounds []Inbound, runtimeCatalog Ma
 	material.Actions = append(material.Actions, "reload veil-caddy.service")
 	material.Runtimes = append(material.Runtimes, "veil-caddy.service")
 	return material
+}
+
+func addPanelDirectBindOwner(settings Settings, owners map[bindregistry.BindKey]bindregistry.BindOwner) []bindregistry.Conflict {
+	if settings.PanelAccess != "direct" {
+		return nil
+	}
+	host, portText, err := net.SplitHostPort(settings.PanelListen)
+	if err != nil {
+		return nil
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil || port <= 0 || port > 65535 {
+		return nil
+	}
+	key := bindregistry.BindKey{Address: host, Port: port, Network: bindregistry.ListenTCP}
+	owner := bindregistry.BindOwner{Kind: bindregistry.BindOwnerPanelDirect, ServiceName: "veil.service"}
+	if existing, ok := owners[key]; ok && existing != owner {
+		return []bindregistry.Conflict{{
+			Key:     key,
+			Owners:  []bindregistry.BindOwner{existing, owner},
+			Message: fmt.Sprintf("TCP %s:%d is claimed by Panel direct listener and another service", key.Address, key.Port),
+		}}
+	}
+	owners[key] = owner
+	return nil
 }
 
 func addInboundBindOwners(inbounds []Inbound, owners map[bindregistry.BindKey]bindregistry.BindOwner, runtimeCatalog ManagedRuntimeCatalog) []bindregistry.Conflict {
@@ -263,6 +293,12 @@ func naiveHasCredential(inb Inbound, settings Settings) bool {
 		if p, ok := inb.ProtocolFields["naivePassword"].(string); ok {
 			password = strings.TrimSpace(p)
 		}
+	}
+	if username == "" {
+		username = strings.TrimSpace(inb.NaiveUsername)
+	}
+	if password == "" {
+		password = strings.TrimSpace(inb.NaivePassword)
 	}
 	if username == "" && settings.ProtocolFields != nil {
 		if u, ok := settings.ProtocolFields["naiveUsername"].(string); ok {

--- a/internal/api/apply_plan_builder.go
+++ b/internal/api/apply_plan_builder.go
@@ -1,12 +1,16 @@
 package api
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/mikkelchokolate/Veil/internal/applyplan"
+	"github.com/mikkelchokolate/Veil/internal/bindregistry"
+	"github.com/mikkelchokolate/Veil/internal/caddyassembly"
+	"github.com/mikkelchokolate/Veil/internal/caddycapabilities"
 	"github.com/mikkelchokolate/Veil/internal/generatedconfig"
-	"github.com/mikkelchokolate/Veil/internal/panelaccess"
 	"github.com/mikkelchokolate/Veil/internal/protocols"
+	"github.com/mikkelchokolate/Veil/internal/renderer"
 	"github.com/mikkelchokolate/Veil/internal/service"
 )
 
@@ -24,7 +28,7 @@ type ApplyPlanInput struct {
 
 func BuildApplyPlan(input ApplyPlanInput) ApplyPlanResponse {
 	applyRoot := defaultApplyRoot(input.ApplyRoot)
-	panelAccessIntent := panelaccess.New(input.Settings, protocols.NewCatalog().RequiresCaddy).ApplyIntent(input.Inbounds)
+	caddyMaterial := buildCaddyMaterial(input.Settings, input.Inbounds)
 	capabilities := []applyplan.ProtocolCapability{}
 	catalog := NewApplyProtocolCapabilityCatalog()
 	for _, protocolCapability := range catalog.All() {
@@ -39,7 +43,7 @@ func BuildApplyPlan(input ApplyPlanInput) ApplyPlanResponse {
 		})
 	}
 	runtimeCatalog := NewManagedRuntimeCatalogFor(input.Inbounds, input.Warp)
-	runtimeUnits := service.NewProtocolRuntimeProvisioning(runtimeCatalog).Plan(input.Inbounds, input.Warp).SystemdUnits()
+	runtimeUnits := filterCaddyRuntimeUnits(service.NewProtocolRuntimeProvisioning(runtimeCatalog).Plan(input.Inbounds, input.Warp).SystemdUnits())
 	validateInboundRender := input.ValidateInboundRender
 	warpAction := ""
 	if action, ok := runtimeCatalog.ApplyAction("sing-box"); ok {
@@ -52,13 +56,8 @@ func BuildApplyPlan(input ApplyPlanInput) ApplyPlanResponse {
 		RoutingSource:           input.RoutingSource,
 		Warp:                    input.Warp,
 		RenderSettingsAvailable: input.RenderSettingsAvailable,
-		PanelAccess: applyplan.Material{
-			Configs:  panelAccessIntent.Configs,
-			Actions:  panelAccessIntent.Actions,
-			Runtimes: panelAccessIntent.Runtimes,
-			Errors:   panelAccessIntent.Errors,
-		},
-		Capabilities: capabilities,
+		PanelAccess:             caddyMaterial,
+		Capabilities:            capabilities,
 		ValidateCardinality: func(settings Settings, inbounds []Inbound) error {
 			return generatedconfig.NewGeneratedConfigCardinality(settings, protocols.NewGeneratedConfigRegistry()).Validate(inbounds)
 		},
@@ -69,4 +68,123 @@ func BuildApplyPlan(input ApplyPlanInput) ApplyPlanResponse {
 		GeneratedRoot:         filepath.Join(applyRoot, "generated"),
 		LiveRoot:              filepath.Join(applyRoot, "live"),
 	})
+}
+
+func buildCaddyMaterial(settings Settings, inbounds []Inbound) applyplan.Material {
+	material := applyplan.Material{}
+	if !caddyRequired(settings, inbounds) {
+		return material
+	}
+	if settings.PanelAccess == "caddy" && (settings.PanelDomain == "" || settings.PanelEmail == "") {
+		material.Errors = append(material.Errors, "panelDomain and panelEmail are required for caddy Panel access")
+		return material
+	}
+	if settings.PanelAccess == "caddy" && settings.PanelPublicPort == 0 {
+		settings.PanelPublicPort = 443
+	}
+
+	initialPlan, owners, err := caddyassembly.BuildRenderPlan(settings, inbounds, nil)
+	if err != nil {
+		material.Errors = append(material.Errors, err.Error())
+		return material
+	}
+
+	challengeBinds, issues := caddyassembly.PlanAcmeChallengeBinds(settings.AcmeChallengeMode, initialPlan.Domains, owners)
+	for _, issue := range issues {
+		if issue.Severity == "error" {
+			material.Errors = append(material.Errors, issue.Message)
+		}
+	}
+
+	allOwners := make(map[bindregistry.BindKey]bindregistry.BindOwner, len(owners)+len(challengeBinds)+len(inbounds))
+	for k, v := range owners {
+		allOwners[k] = v
+	}
+	for k := range challengeBinds {
+		allOwners[k] = bindregistry.BindOwner{Kind: bindregistry.BindOwnerAcmeChallenge, ServiceName: "veil-caddy.service"}
+	}
+	for _, conflict := range addInboundBindOwners(inbounds, allOwners) {
+		material.Errors = append(material.Errors, conflict.Message)
+	}
+	for _, conflict := range bindregistry.ValidateNoConflicts(allOwners) {
+		material.Errors = append(material.Errors, conflict.Message)
+	}
+
+	plan := caddyassembly.CaddyRenderPlan{
+		Servers:        initialPlan.Servers,
+		ACMEChallenges: challengeBinds,
+		Domains:        initialPlan.Domains,
+	}
+
+	caps, _ := caddycapabilities.Probe("")
+	if _, err := renderer.RenderCaddyJSON(plan, caps); err != nil {
+		material.Errors = append(material.Errors, err.Error())
+		return material
+	}
+
+	path := generatedconfig.ArtifactSpec{Subpath: generatedconfig.CaddyJSONConfigSubpath}.PlanPath()
+	material.Configs = append(material.Configs, path)
+	material.Actions = append(material.Actions, "reload veil-caddy.service")
+	material.Runtimes = append(material.Runtimes, "veil-caddy.service")
+	return material
+}
+
+func addInboundBindOwners(inbounds []Inbound, owners map[bindregistry.BindKey]bindregistry.BindOwner) []bindregistry.Conflict {
+	var conflicts []bindregistry.Conflict
+	for _, inb := range inbounds {
+		if !inb.Enabled || inb.Port <= 0 {
+			continue
+		}
+		var key bindregistry.BindKey
+		var owner bindregistry.BindOwner
+		switch inb.Protocol {
+		case "naiveproxy":
+			// Already represented by the Caddy render plan owners.
+			continue
+		case "hysteria2":
+			// Hysteria2 public binds are UDP; the TCP port is only used for ACME
+			// TLS-ALPN-01 if configured, which is owned by Caddy in this design.
+			key = bindregistry.BindKey{Address: "0.0.0.0", Port: inb.Port, Network: bindregistry.ListenUDP}
+			owner = bindregistry.BindOwner{Kind: bindregistry.BindOwnerHysteria2, ServiceName: "veil-hysteria2@" + inb.Name + ".service", InboundName: inb.Name}
+		default:
+			key = bindregistry.BindKey{Address: "0.0.0.0", Port: inb.Port, Network: bindregistry.ListenTCP}
+			owner = bindregistry.BindOwner{Kind: bindregistry.BindOwnerInbound, ServiceName: "veil-" + inb.Protocol + ".service", InboundName: inb.Name}
+		}
+		if existing, ok := owners[key]; ok && existing != owner {
+			conflicts = append(conflicts, bindregistry.Conflict{
+				Key:     key,
+				Owners:  []bindregistry.BindOwner{existing, owner},
+				Message: fmt.Sprintf("%s %s:%d is claimed by multiple owners", key.Network, key.Address, key.Port),
+			})
+			continue
+		}
+		owners[key] = owner
+	}
+	return conflicts
+}
+
+func caddyRequired(settings Settings, inbounds []Inbound) bool {
+	if settings.PanelAccess == "caddy" {
+		return true
+	}
+	for _, inb := range inbounds {
+		if inb.Enabled && inb.Protocol == "naiveproxy" {
+			return true
+		}
+	}
+	return false
+}
+
+func filterCaddyRuntimeUnits(units []string) []string {
+	out := make([]string, 0, len(units))
+	for _, unit := range units {
+		if unit == "veil-caddy.service" || !isTemplateCaddyUnit(unit) {
+			out = append(out, unit)
+		}
+	}
+	return out
+}
+
+func isTemplateCaddyUnit(unit string) bool {
+	return len(unit) > len("veil-caddy@") && unit[:len("veil-caddy@")] == "veil-caddy@" && unit[len(unit)-len(".service"):] == ".service"
 }

--- a/internal/api/apply_plan_builder.go
+++ b/internal/api/apply_plan_builder.go
@@ -101,44 +101,29 @@ func buildCaddyMaterial(settings Settings, inbounds []Inbound, runtimeCatalog Ma
 		}
 	}
 
-	initialPlan, owners, err := caddyassembly.BuildRenderPlan(settings, inbounds, nil)
+	plan, owners, challengeIssues, err := caddyassembly.BuildFinalRenderPlan(settings, inbounds)
 	if err != nil {
 		material.Errors = append(material.Errors, err.Error())
 		return material
 	}
-
-	challengeBinds, issues := caddyassembly.PlanAcmeChallengeBinds(settings.AcmeChallengeMode, initialPlan.Domains, owners)
-	for _, issue := range issues {
+	for _, issue := range challengeIssues {
 		if issue.Severity == "error" {
 			material.Errors = append(material.Errors, issue.Message)
 		}
 	}
 
-	allOwners := make(map[bindregistry.BindKey]bindregistry.BindOwner, len(owners)+len(challengeBinds)+len(inbounds))
-	for k, v := range owners {
-		allOwners[k] = v
-	}
-	for k := range challengeBinds {
-		if existing, ok := allOwners[k]; ok && (existing.Kind == bindregistry.BindOwnerPanelCaddy || existing.Kind == bindregistry.BindOwnerNaive) {
-			// Compatible Caddy owner already handles TLS-ALPN-01 on this bind.
-			continue
-		}
-		allOwners[k] = bindregistry.BindOwner{Kind: bindregistry.BindOwnerAcmeChallenge, ServiceName: "veil-caddy.service"}
-	}
-	for _, conflict := range addInboundBindOwners(inbounds, allOwners, runtimeCatalog) {
+	for _, conflict := range addInboundBindOwners(inbounds, owners, runtimeCatalog) {
 		material.Errors = append(material.Errors, conflict.Message)
 	}
-	for _, conflict := range bindregistry.ValidateNoConflicts(allOwners) {
+	for _, conflict := range bindregistry.ValidateNoConflicts(owners) {
 		material.Errors = append(material.Errors, conflict.Message)
 	}
 
-	plan := caddyassembly.CaddyRenderPlan{
-		Servers:        initialPlan.Servers,
-		ACMEChallenges: challengeBinds,
-		Domains:        initialPlan.Domains,
+	caps, err := caddycapabilities.Probe("")
+	if err != nil {
+		material.Errors = append(material.Errors, fmt.Sprintf("failed to probe Caddy capabilities: %v", err))
+		return material
 	}
-
-	caps, _ := caddycapabilities.Probe("")
 	if _, err := renderer.RenderCaddyJSON(plan, caps); err != nil {
 		material.Errors = append(material.Errors, err.Error())
 		return material

--- a/internal/api/apply_plan_builder.go
+++ b/internal/api/apply_plan_builder.go
@@ -39,7 +39,6 @@ func BuildApplyPlan(input ApplyPlanInput) ApplyPlanResponse {
 			Protocol:               capability.Protocol,
 			Config:                 capability.Config,
 			Action:                 capability.Action,
-			ValidateSettings:       capability.ValidateSettings,
 			ValidateInboundRender:  capability.ValidateInboundRender,
 			RequiresRenderSettings: capability.RequiresRenderSettings,
 		})
@@ -82,6 +81,24 @@ func buildCaddyMaterial(settings Settings, inbounds []Inbound, runtimeCatalog Ma
 	}
 	if settings.PanelAccess == "caddy" && settings.PanelPublicPort == 0 {
 		settings.PanelPublicPort = 443
+	}
+
+	for _, inb := range inbounds {
+		if inb.Protocol != "naiveproxy" || !inb.Enabled {
+			continue
+		}
+		if domain := resolveNaiveDomain(inb, settings); domain == "" {
+			material.Errors = append(material.Errors, fmt.Sprintf("naive inbound %q is missing a public domain", inb.Name))
+			return material
+		}
+		if email := resolveNaiveEmail(inb, settings); email == "" {
+			material.Errors = append(material.Errors, fmt.Sprintf("naive inbound %q is missing an ACME email", inb.Name))
+			return material
+		}
+		if !naiveHasCredential(inb, settings) {
+			material.Errors = append(material.Errors, fmt.Sprintf("naive inbound %q is missing valid credentials (enable a profile with username/password or set naive username/password)", inb.Name))
+			return material
+		}
 	}
 
 	initialPlan, owners, err := caddyassembly.BuildRenderPlan(settings, inbounds, nil)
@@ -213,6 +230,72 @@ func inboundDomain(inb Inbound) string {
 		return ""
 	}
 	return v
+}
+
+func resolveNaiveDomain(inb Inbound, settings Settings) string {
+	if inb.ProtocolFields != nil {
+		if d, ok := inb.ProtocolFields["domain"].(string); ok {
+			if v := strings.TrimSpace(d); v != "" {
+				return v
+			}
+		}
+	}
+	return strings.TrimSpace(settings.Domain)
+}
+
+func resolveNaiveEmail(inb Inbound, settings Settings) string {
+	candidates := []string{}
+	if inb.ProtocolFields != nil {
+		if e, ok := inb.ProtocolFields["email"].(string); ok {
+			candidates = append(candidates, e)
+		}
+	}
+	candidates = append(candidates, settings.Email, settings.DefaultAcmeEmail, settings.PanelEmail)
+	for _, c := range candidates {
+		if v := strings.TrimSpace(c); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func naiveHasCredential(inb Inbound, settings Settings) bool {
+	for _, p := range inb.Profiles {
+		if !p.Enabled {
+			continue
+		}
+		if strings.TrimSpace(p.Username) == "" || strings.TrimSpace(p.Password) == "" {
+			continue
+		}
+		return true
+	}
+	username := ""
+	password := ""
+	if inb.ProtocolFields != nil {
+		if u, ok := inb.ProtocolFields["naiveUsername"].(string); ok {
+			username = strings.TrimSpace(u)
+		}
+		if p, ok := inb.ProtocolFields["naivePassword"].(string); ok {
+			password = strings.TrimSpace(p)
+		}
+	}
+	if username == "" && settings.ProtocolFields != nil {
+		if u, ok := settings.ProtocolFields["naiveUsername"].(string); ok {
+			username = strings.TrimSpace(u)
+		}
+	}
+	if password == "" && settings.ProtocolFields != nil {
+		if p, ok := settings.ProtocolFields["naivePassword"].(string); ok {
+			password = strings.TrimSpace(p)
+		}
+	}
+	if username == "" {
+		username = strings.TrimSpace(settings.NaiveUsername)
+	}
+	if password == "" {
+		password = strings.TrimSpace(settings.NaivePassword)
+	}
+	return username != "" && password != ""
 }
 
 func filterCaddyRuntimeUnits(units []string) []string {

--- a/internal/api/apply_plan_builder.go
+++ b/internal/api/apply_plan_builder.go
@@ -187,11 +187,28 @@ func caddyRequired(settings Settings, inbounds []Inbound) bool {
 		return true
 	}
 	for _, inb := range inbounds {
-		if inb.Enabled && inb.Protocol == "naiveproxy" {
+		if !inb.Enabled {
+			continue
+		}
+		if inb.Protocol == "naiveproxy" {
+			return true
+		}
+		if inb.Protocol == "hysteria2" && inboundDomain(inb) != "" {
 			return true
 		}
 	}
 	return false
+}
+
+func inboundDomain(inb Inbound) string {
+	if inb.ProtocolFields == nil {
+		return ""
+	}
+	v, ok := inb.ProtocolFields["domain"].(string)
+	if !ok {
+		return ""
+	}
+	return v
 }
 
 func filterCaddyRuntimeUnits(units []string) []string {

--- a/internal/api/apply_plan_builder.go
+++ b/internal/api/apply_plan_builder.go
@@ -102,6 +102,10 @@ func buildCaddyMaterial(settings Settings, inbounds []Inbound, runtimeCatalog Ma
 		allOwners[k] = v
 	}
 	for k := range challengeBinds {
+		if existing, ok := allOwners[k]; ok && (existing.Kind == bindregistry.BindOwnerPanelCaddy || existing.Kind == bindregistry.BindOwnerNaive) {
+			// Compatible Caddy owner already handles TLS-ALPN-01 on this bind.
+			continue
+		}
 		allOwners[k] = bindregistry.BindOwner{Kind: bindregistry.BindOwnerAcmeChallenge, ServiceName: "veil-caddy.service"}
 	}
 	for _, conflict := range addInboundBindOwners(inbounds, allOwners, runtimeCatalog) {

--- a/internal/api/apply_plan_builder.go
+++ b/internal/api/apply_plan_builder.go
@@ -401,8 +401,15 @@ func resolveNaiveEmail(inb Inbound, settings Settings) string {
 }
 
 func naiveHasCredential(inb Inbound, settings Settings) bool {
+	hasExplicitlyEnabledProfile := false
 	for _, profile := range inb.Profiles {
-		if !profile.Enabled {
+		if profile.Enabled {
+			hasExplicitlyEnabledProfile = true
+			break
+		}
+	}
+	for _, profile := range inb.Profiles {
+		if hasExplicitlyEnabledProfile && !profile.Enabled {
 			continue
 		}
 		username := strings.TrimSpace(profile.Username)

--- a/internal/api/apply_plan_builder.go
+++ b/internal/api/apply_plan_builder.go
@@ -235,7 +235,7 @@ func resolveNaiveEmail(inb Inbound, settings Settings) string {
 			candidates = append(candidates, e)
 		}
 	}
-	candidates = append(candidates, settings.Email, settings.DefaultAcmeEmail, settings.PanelEmail)
+	candidates = append(candidates, settings.DefaultAcmeEmail, settings.PanelEmail)
 	for _, c := range candidates {
 		if v := strings.TrimSpace(c); v != "" {
 			return v

--- a/internal/api/apply_plan_builder_test.go
+++ b/internal/api/apply_plan_builder_test.go
@@ -126,6 +126,35 @@ func containsApplyPlanString(values []string, want string) bool {
 	return false
 }
 
+func TestAddPanelDirectBindOwnerDetectsConflict(t *testing.T) {
+	owners := make(map[bindregistry.BindKey]bindregistry.BindOwner)
+	owners[bindregistry.BindKey{Address: "0.0.0.0", Port: 8080, Network: bindregistry.ListenTCP}] = bindregistry.BindOwner{
+		Kind: bindregistry.BindOwnerNaive, ServiceName: "veil-caddy.service", InboundName: "naive-1",
+	}
+	settings := Settings{PanelAccess: "direct", PanelListen: "0.0.0.0:8080"}
+	conflicts := addPanelDirectBindOwner(settings, owners)
+	if len(conflicts) == 0 {
+		t.Fatal("expected conflict between Panel direct listener and naive inbound on TCP :8080")
+	}
+}
+
+func TestAddPanelDirectBindOwnerRegistersListener(t *testing.T) {
+	owners := make(map[bindregistry.BindKey]bindregistry.BindOwner)
+	settings := Settings{PanelAccess: "direct", PanelListen: "0.0.0.0:8080"}
+	conflicts := addPanelDirectBindOwner(settings, owners)
+	if len(conflicts) != 0 {
+		t.Fatalf("unexpected conflicts: %+v", conflicts)
+	}
+	key := bindregistry.BindKey{Address: "0.0.0.0", Port: 8080, Network: bindregistry.ListenTCP}
+	owner, ok := owners[key]
+	if !ok {
+		t.Fatal("expected Panel direct owner on TCP :8080")
+	}
+	if owner.Kind != bindregistry.BindOwnerPanelDirect {
+		t.Errorf("owner.Kind = %q, want %q", owner.Kind, bindregistry.BindOwnerPanelDirect)
+	}
+}
+
 func TestAddInboundBindOwnersRespectsTransportAndRuntimeUnit(t *testing.T) {
 	catalog := service.NewManagedRuntimeCatalog([]service.ManagedRuntime{
 		{Name: "mieru", Protocol: "mieru", Unit: "veil-mieru.service"},

--- a/internal/api/apply_plan_builder_test.go
+++ b/internal/api/apply_plan_builder_test.go
@@ -7,6 +7,30 @@ import (
 	"github.com/mikkelchokolate/Veil/internal/model"
 )
 
+func TestBuildApplyPlanIncludesCaddyJSONArtifact(t *testing.T) {
+	settings := Settings{
+		PanelListen: "0.0.0.0:8080",
+		Mode:        "server",
+		PanelAccess: "caddy",
+		PanelDomain: "panel.example.com",
+		PanelEmail:  "admin@example.com",
+	}
+	inbounds := []Inbound{}
+	plan := BuildApplyPlan(ApplyPlanInput{Settings: settings, Inbounds: inbounds})
+	if !plan.Valid {
+		t.Fatalf("plan invalid: %v", plan.Errors)
+	}
+	found := false
+	for _, c := range plan.Configs {
+		if c == "/etc/veil/generated/caddy/config.json" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected Caddy JSON config artifact in plan")
+	}
+}
+
 func TestBuildApplyPlanUsesApplyRootForStructuredOperations(t *testing.T) {
 	plan := BuildApplyPlan(ApplyPlanInput{
 		ApplyRoot: "/srv/veil",

--- a/internal/api/apply_plan_builder_test.go
+++ b/internal/api/apply_plan_builder_test.go
@@ -4,7 +4,9 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/mikkelchokolate/Veil/internal/bindregistry"
 	"github.com/mikkelchokolate/Veil/internal/model"
+	"github.com/mikkelchokolate/Veil/internal/service"
 )
 
 func TestBuildApplyPlanIncludesCaddyJSONArtifact(t *testing.T) {
@@ -122,4 +124,47 @@ func containsApplyPlanString(values []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func TestAddInboundBindOwnersRespectsTransportAndRuntimeUnit(t *testing.T) {
+	catalog := service.NewManagedRuntimeCatalog([]service.ManagedRuntime{
+		{Name: "mieru", Protocol: "mieru", Unit: "veil-mieru.service"},
+		{Name: "olcrtc", Protocol: "olcrtc", Unit: "veil-olcrtc@.service", TemplateUnit: "veil-olcrtc@.service"},
+		{Name: "other", Protocol: "other", Unit: "veil-other.service"},
+	})
+	inbounds := []Inbound{
+		{Name: "mieru-tcp", Protocol: "mieru", Transport: "tcp", Port: 443, Enabled: true},
+		{Name: "mieru-udp", Protocol: "mieru", Transport: "udp", Port: 444, Enabled: true},
+		{Name: "rtc-1", Protocol: "olcrtc", Transport: "udp", Port: 445, Enabled: true},
+		{Name: "other-tcp", Protocol: "other", Transport: "tcp", Port: 446, Enabled: true},
+	}
+	owners := make(map[bindregistry.BindKey]bindregistry.BindOwner)
+	conflicts := addInboundBindOwners(inbounds, owners, catalog)
+	if len(conflicts) != 0 {
+		t.Fatalf("unexpected conflicts: %+v", conflicts)
+	}
+
+	cases := []struct {
+		port    int
+		network bindregistry.ListenNetwork
+		unit    string
+	}{
+		{443, bindregistry.ListenTCP, "veil-mieru.service"},
+		{444, bindregistry.ListenUDP, "veil-mieru.service"},
+		{445, bindregistry.ListenUDP, "veil-olcrtc@rtc-1.service"},
+		{446, bindregistry.ListenTCP, "veil-other.service"},
+	}
+	for _, tc := range cases {
+		key := bindregistry.BindKey{Address: "0.0.0.0", Port: tc.port, Network: tc.network}
+		owner, ok := owners[key]
+		if !ok {
+			t.Fatalf("missing owner for %s:%d", tc.network, tc.port)
+		}
+		if owner.ServiceName != tc.unit {
+			t.Errorf("port %d %s unit = %q, want %q", tc.port, tc.network, owner.ServiceName, tc.unit)
+		}
+		if owner.Kind != bindregistry.BindOwnerInbound {
+			t.Errorf("port %d %s kind = %q, want %q", tc.port, tc.network, owner.Kind, bindregistry.BindOwnerInbound)
+		}
+	}
 }

--- a/internal/api/apply_plan_mieru_test.go
+++ b/internal/api/apply_plan_mieru_test.go
@@ -16,7 +16,7 @@ func TestBuildApplyPlanIncludesMieruConfigAndReloadAction(t *testing.T) {
 	if !containsString(plan.Actions, "restart veil-mieru.service") {
 		t.Fatalf("plan missing Mieru restart action: %+v", plan.Actions)
 	}
-	if containsString(plan.Configs, "/etc/veil/generated/caddy/panel.Caddyfile") || containsString(plan.Actions, "reload veil-caddy@panel.service") {
+	if containsString(plan.Configs, "/etc/veil/generated/caddy/config.json") || containsString(plan.Actions, "reload veil-caddy.service") {
 		t.Fatalf("Panel Caddy config/action should not be present when disabled: %+v", plan)
 	}
 }

--- a/internal/api/apply_plan_naive_caddy_settings_test.go
+++ b/internal/api/apply_plan_naive_caddy_settings_test.go
@@ -9,29 +9,39 @@ func TestBuildApplyPlanRejectsPanelCaddyAccessWithoutDomainEmail(t *testing.T) {
 	plan := BuildApplyPlan(ApplyPlanInput{
 		Settings: Settings{PanelListen: "127.0.0.1:2096", PanelAccess: "caddy", WebBasePath: "/panel-secret/", Mode: "server"},
 	})
-	if plan.Valid || !strings.Contains(strings.Join(plan.Errors, "\n"), "--domain and --email are required for caddy Panel access") {
-		t.Fatalf("Panel Caddy apply plan should require domain/email: %+v", plan)
+	if plan.Valid || !strings.Contains(strings.Join(plan.Errors, "\n"), "panelDomain and panelEmail are required for caddy Panel access") {
+		t.Fatalf("Panel Caddy apply plan should require panelDomain/panelEmail: %+v", plan)
 	}
 }
 
 func TestBuildApplyPlanRejectsPanelCaddyTCP443RuntimeConflict(t *testing.T) {
 	plan := BuildApplyPlan(ApplyPlanInput{
-		Settings: Settings{PanelListen: "127.0.0.1:2096", PanelAccess: "caddy", WebBasePath: "/panel-secret/", Mode: "server", Domain: "panel.example.com", Email: "admin@example.com"},
+		Settings: Settings{PanelListen: "127.0.0.1:2096", PanelAccess: "caddy", WebBasePath: "/panel-secret/", Mode: "server", PanelDomain: "panel.example.com", PanelEmail: "admin@example.com"},
 		Inbounds: []Inbound{{Name: "mieru-tcp", Protocol: "mieru", Transport: "tcp", Port: 443, Enabled: true, Password: "secret"}},
 	})
-	if plan.Valid || !strings.Contains(strings.Join(plan.Errors, "\n"), "panel caddy access uses 443/tcp") {
+	if plan.Valid {
 		t.Fatalf("Panel Caddy should reject non-Caddy TCP 443 inbound conflict: %+v", plan)
+	}
+	found := false
+	for _, err := range plan.Errors {
+		if strings.Contains(err, "is claimed by multiple owners") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected bind conflict error, got: %+v", plan.Errors)
 	}
 }
 
 func TestBuildApplyPlanIncludesPanelCaddyAccessWithoutNaiveInbound(t *testing.T) {
 	plan := BuildApplyPlan(ApplyPlanInput{
-		Settings: Settings{PanelListen: "127.0.0.1:2096", PanelAccess: "caddy", WebBasePath: "/panel-secret/", Mode: "server", Domain: "panel.example.com", Email: "admin@example.com"},
+		Settings: Settings{PanelListen: "127.0.0.1:2096", PanelAccess: "caddy", WebBasePath: "/panel-secret/", Mode: "server", PanelDomain: "panel.example.com", PanelEmail: "admin@example.com"},
 	})
 	if !plan.Valid {
 		t.Fatalf("Panel Caddy access plan should be valid: %+v", plan)
 	}
-	if !containsString(plan.Configs, "/etc/veil/generated/caddy/panel.Caddyfile") || !containsString(plan.Actions, "reload veil-caddy@panel.service") || !containsString(plan.Runtimes, "veil-caddy@panel.service") {
+	if !containsString(plan.Configs, "/etc/veil/generated/caddy/config.json") || !containsString(plan.Actions, "reload veil-caddy.service") || !containsString(plan.Runtimes, "veil-caddy.service") {
 		t.Fatalf("Panel Caddy access plan missing config/action/runtime: %+v", plan)
 	}
 }

--- a/internal/api/apply_plan_naive_caddy_settings_test.go
+++ b/internal/api/apply_plan_naive_caddy_settings_test.go
@@ -46,16 +46,96 @@ func TestBuildApplyPlanIncludesPanelCaddyAccessWithoutNaiveInbound(t *testing.T)
 	}
 }
 
-func TestBuildApplyPlanRequiresCaddySettingsForNaiveProxyInbound(t *testing.T) {
+func TestBuildApplyPlanAcceptsNaiveProxyWithPerInboundSettings(t *testing.T) {
 	plan := BuildApplyPlan(ApplyPlanInput{
 		Settings: Settings{PanelListen: "127.0.0.1:2096", Mode: "dev"},
-		Inbounds: []Inbound{{Name: "naive", Protocol: "naiveproxy", Transport: "tcp", Port: 443, Enabled: true, Password: "secret"}},
+		Inbounds: []Inbound{{
+			Name:      "naive",
+			Protocol:  "naiveproxy",
+			Transport: "tcp",
+			Port:      443,
+			Enabled:   true,
+			ProtocolFields: map[string]any{
+				"domain":        "vpn.example.com",
+				"email":         "admin@example.com",
+				"naiveUsername": "veil",
+				"naivePassword": "secret",
+			},
+		}},
+	})
+	if !plan.Valid {
+		t.Fatalf("NaiveProxy with per-inbound settings should be valid: %+v", plan)
+	}
+}
+
+func TestBuildApplyPlanRejectsNaiveProxyMissingDomain(t *testing.T) {
+	plan := BuildApplyPlan(ApplyPlanInput{
+		Settings: Settings{PanelListen: "127.0.0.1:2096", Mode: "dev"},
+		Inbounds: []Inbound{{
+			Name:      "naive",
+			Protocol:  "naiveproxy",
+			Transport: "tcp",
+			Port:      443,
+			Enabled:   true,
+			ProtocolFields: map[string]any{
+				"email":         "admin@example.com",
+				"naiveUsername": "veil",
+				"naivePassword": "secret",
+			},
+		}},
 	})
 	if plan.Valid {
-		t.Fatalf("NaiveProxy without Caddy settings should be invalid: %+v", plan)
+		t.Fatalf("NaiveProxy without a domain should be invalid: %+v", plan)
 	}
-	if !strings.Contains(strings.Join(plan.Errors, "\n"), "domain, email, naive username, and naive password are required for NaiveProxy/Caddy") {
-		t.Fatalf("missing Caddy settings error: %+v", plan.Errors)
+	if !strings.Contains(strings.Join(plan.Errors, "\n"), "missing a public domain") {
+		t.Fatalf("expected missing domain error: %+v", plan.Errors)
+	}
+}
+
+func TestBuildApplyPlanRejectsNaiveProxyMissingEmail(t *testing.T) {
+	plan := BuildApplyPlan(ApplyPlanInput{
+		Settings: Settings{PanelListen: "127.0.0.1:2096", Mode: "dev"},
+		Inbounds: []Inbound{{
+			Name:      "naive",
+			Protocol:  "naiveproxy",
+			Transport: "tcp",
+			Port:      443,
+			Enabled:   true,
+			ProtocolFields: map[string]any{
+				"domain":        "vpn.example.com",
+				"naiveUsername": "veil",
+				"naivePassword": "secret",
+			},
+		}},
+	})
+	if plan.Valid {
+		t.Fatalf("NaiveProxy without an ACME email should be invalid: %+v", plan)
+	}
+	if !strings.Contains(strings.Join(plan.Errors, "\n"), "missing an ACME email") {
+		t.Fatalf("expected missing email error: %+v", plan.Errors)
+	}
+}
+
+func TestBuildApplyPlanRejectsNaiveProxyMissingCredentials(t *testing.T) {
+	plan := BuildApplyPlan(ApplyPlanInput{
+		Settings: Settings{PanelListen: "127.0.0.1:2096", Mode: "dev"},
+		Inbounds: []Inbound{{
+			Name:      "naive",
+			Protocol:  "naiveproxy",
+			Transport: "tcp",
+			Port:      443,
+			Enabled:   true,
+			ProtocolFields: map[string]any{
+				"domain": "vpn.example.com",
+				"email":  "admin@example.com",
+			},
+		}},
+	})
+	if plan.Valid {
+		t.Fatalf("NaiveProxy without credentials should be invalid: %+v", plan)
+	}
+	if !strings.Contains(strings.Join(plan.Errors, "\n"), "missing valid credentials") {
+		t.Fatalf("expected missing credentials error: %+v", plan.Errors)
 	}
 }
 

--- a/internal/api/apply_plan_naive_caddy_settings_test.go
+++ b/internal/api/apply_plan_naive_caddy_settings_test.go
@@ -141,7 +141,7 @@ func TestBuildApplyPlanRejectsNaiveProxyMissingCredentials(t *testing.T) {
 
 func TestBuildApplyPlanAcceptsNaiveProxyWithCaddySettings(t *testing.T) {
 	plan := BuildApplyPlan(ApplyPlanInput{
-		Settings: Settings{PanelListen: "127.0.0.1:2096", Mode: "dev", Domain: "vpn.example.com", Email: "admin@example.com", NaiveUsername: "veil", NaivePassword: "secret"},
+		Settings: Settings{PanelListen: "127.0.0.1:2096", Mode: "dev", Domain: "vpn.example.com", DefaultAcmeEmail: "admin@example.com", NaiveUsername: "veil", NaivePassword: "secret"},
 		Inbounds: []Inbound{{Name: "naive", Protocol: "naiveproxy", Transport: "tcp", Port: 443, Enabled: true, Password: "secret"}},
 	})
 	if !plan.Valid {

--- a/internal/api/apply_protocol_capability_catalog.go
+++ b/internal/api/apply_protocol_capability_catalog.go
@@ -21,6 +21,7 @@ type ApplyProtocolCapabilityCatalog struct {
 func NewApplyProtocolCapabilityCatalog() ApplyProtocolCapabilityCatalog {
 	byProtocol := map[string]ApplyProtocolCapability{}
 	registry := protocols.NewRegistry()
+	requiresCaddy := protocols.NewCatalog().RequiresCaddy
 	for _, p := range registry.All() {
 		meta := protocols.MetadataOf(p)
 		cap := ApplyProtocolCapability{
@@ -43,6 +44,13 @@ func NewApplyProtocolCapabilityCatalog() ApplyProtocolCapabilityCatalog {
 		}
 		if _, ok := protocols.AsValidator(p); ok {
 			cap.RequiresCaddySettings = meta.Protocol == "naiveproxy"
+		}
+		// Caddy-managed protocols render a single global Caddy JSON config and
+		// reload veil-caddy.service; per-protocol config/action entries would
+		// duplicate or contradict the global Caddy material.
+		if requiresCaddy(meta.Protocol) {
+			cap.Config = ""
+			cap.Action = ""
 		}
 		byProtocol[meta.Protocol] = cap
 	}

--- a/internal/api/apply_protocol_capability_catalog.go
+++ b/internal/api/apply_protocol_capability_catalog.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"github.com/mikkelchokolate/Veil/internal/panelaccess"
 	"github.com/mikkelchokolate/Veil/internal/protocols"
 )
 
@@ -11,7 +10,6 @@ type ApplyProtocolCapability struct {
 	Action                 string
 	ValidateInboundRender  bool
 	RequiresRenderSettings bool
-	RequiresCaddySettings  bool
 }
 
 type ApplyProtocolCapabilityCatalog struct {
@@ -42,9 +40,6 @@ func NewApplyProtocolCapabilityCatalog() ApplyProtocolCapabilityCatalog {
 				cap.Action = "restart " + unit
 			}
 		}
-		if _, ok := protocols.AsValidator(p); ok {
-			cap.RequiresCaddySettings = meta.Protocol == "naiveproxy"
-		}
 		// Caddy-managed protocols render a single global Caddy JSON config and
 		// reload veil-caddy.service; per-protocol config/action entries would
 		// duplicate or contradict the global Caddy material.
@@ -68,13 +63,6 @@ func (c ApplyProtocolCapabilityCatalog) All() []ApplyProtocolCapability {
 		capabilities = append(capabilities, capability)
 	}
 	return capabilities
-}
-
-func (c ApplyProtocolCapability) ValidateSettings(settings Settings) error {
-	if c.RequiresCaddySettings {
-		return panelaccess.NewNaiveCaddySettingsRequirement().Validate(settings)
-	}
-	return nil
 }
 
 func (c ApplyProtocolCapability) ShouldValidateRender(renderSettingsAvailable bool) bool {

--- a/internal/api/apply_protocol_capability_catalog_more_test.go
+++ b/internal/api/apply_protocol_capability_catalog_more_test.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"strings"
 	"testing"
 )
 
@@ -32,18 +31,3 @@ func TestApplyProtocolCapabilityShouldValidateRender(t *testing.T) {
 	}
 }
 
-func TestApplyProtocolCapabilityValidateSettingsRequiresNaiveCaddy(t *testing.T) {
-	cap := ApplyProtocolCapability{RequiresCaddySettings: true}
-	err := cap.ValidateSettings(Settings{})
-	if err == nil {
-		t.Fatal("expected naive caddy settings requirement error")
-	}
-	if !strings.Contains(err.Error(), "domain, email, naive username, and naive password") {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	cap = ApplyProtocolCapability{RequiresCaddySettings: false}
-	if err := cap.ValidateSettings(Settings{}); err != nil {
-		t.Fatalf("unexpected settings error: %v", err)
-	}
-}

--- a/internal/api/apply_protocol_capability_catalog_test.go
+++ b/internal/api/apply_protocol_capability_catalog_test.go
@@ -10,11 +10,10 @@ func TestApplyProtocolCapabilityCatalogOwnsConfigActionsAndValidation(t *testing
 		action                 string
 		validateRender         bool
 		requiresRenderSettings bool
-		settingsError          bool
 	}{
-		{"naiveproxy", "", "", true, true, true},
-		{"hysteria2", "/etc/veil/generated/hysteria2/server.yaml", "restart veil-hysteria2@.service", true, true, false},
-		{"mieru", "/etc/veil/generated/mieru/server_config.json", "restart veil-mieru.service", true, false, false},
+		{"naiveproxy", "", "", true, true},
+		{"hysteria2", "/etc/veil/generated/hysteria2/server.yaml", "restart veil-hysteria2@.service", true, true},
+		{"mieru", "/etc/veil/generated/mieru/server_config.json", "restart veil-mieru.service", true, false},
 	}
 	for _, tc := range cases {
 		capability, ok := catalog.ForProtocol(tc.protocol)
@@ -23,13 +22,6 @@ func TestApplyProtocolCapabilityCatalogOwnsConfigActionsAndValidation(t *testing
 		}
 		if capability.Config != tc.config || capability.Action != tc.action || capability.ValidateInboundRender != tc.validateRender || capability.RequiresRenderSettings != tc.requiresRenderSettings {
 			t.Fatalf("capability for %s = %+v", tc.protocol, capability)
-		}
-		err := capability.ValidateSettings(Settings{})
-		if tc.settingsError && err == nil {
-			t.Fatalf("expected settings error for %s", tc.protocol)
-		}
-		if !tc.settingsError && err != nil {
-			t.Fatalf("unexpected settings error for %s: %v", tc.protocol, err)
 		}
 	}
 }

--- a/internal/api/apply_protocol_capability_catalog_test.go
+++ b/internal/api/apply_protocol_capability_catalog_test.go
@@ -12,7 +12,7 @@ func TestApplyProtocolCapabilityCatalogOwnsConfigActionsAndValidation(t *testing
 		requiresRenderSettings bool
 		settingsError          bool
 	}{
-		{"naiveproxy", "/etc/veil/generated/caddy/panel.Caddyfile", "restart veil-caddy@.service", true, true, true},
+		{"naiveproxy", "", "", true, true, true},
 		{"hysteria2", "/etc/veil/generated/hysteria2/server.yaml", "restart veil-hysteria2@.service", true, true, false},
 		{"mieru", "/etc/veil/generated/mieru/server_config.json", "restart veil-mieru.service", true, false, false},
 	}

--- a/internal/api/apply_stage_writer.go
+++ b/internal/api/apply_stage_writer.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 
 	"github.com/mikkelchokolate/Veil/internal/atomicfile"
 	"github.com/mikkelchokolate/Veil/internal/generatedconfig"
@@ -76,27 +75,30 @@ func WriteApplyStage(input ApplyStageInput) ([]string, []ConfigValidationResult,
 	return written, validations, renderedPaths, nil
 }
 
+var managedGeneratedSubdirs = []string{"caddy", "hysteria2", "mieru", "olcrtc", "sing-box", "rules"}
+
 func cleanStaleGeneratedFiles(generatedRoot string, keep map[string]bool) error {
-	return filepath.Walk(generatedRoot, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
+	for _, subdir := range managedGeneratedSubdirs {
+		root := filepath.Join(generatedRoot, subdir)
+		if err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				if os.IsNotExist(err) {
+					return nil
+				}
+				return err
+			}
+			if info.IsDir() || !info.Mode().IsRegular() {
+				return nil
+			}
+			if keep[path] {
+				return nil
+			}
+			return os.Remove(path)
+		}); err != nil {
 			return err
 		}
-		if info.IsDir() || !info.Mode().IsRegular() {
-			return nil
-		}
-		rel, err := filepath.Rel(generatedRoot, path)
-		if err != nil {
-			return err
-		}
-		// Protect Veil's own metadata (apply plan, state, history, audit).
-		if rel == "veil" || strings.HasPrefix(rel, "veil"+string(filepath.Separator)) {
-			return nil
-		}
-		if keep[path] {
-			return nil
-		}
-		return os.Remove(path)
-	})
+	}
+	return nil
 }
 
 func sortedRenderedPaths(rendered map[string]string) []string {

--- a/internal/api/apply_stage_writer.go
+++ b/internal/api/apply_stage_writer.go
@@ -2,8 +2,10 @@ package api
 
 import (
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/mikkelchokolate/Veil/internal/atomicfile"
 	"github.com/mikkelchokolate/Veil/internal/generatedconfig"
@@ -54,12 +56,47 @@ func WriteApplyStage(input ApplyStageInput) ([]string, []ConfigValidationResult,
 		return nil, nil, nil, err
 	}
 	written = append(written, routingFiles...)
+
+	// Remove generated config files from previous applies that are no longer
+	// part of the desired staged set. This ensures deleted inbounds (or disabled
+	// features such as WARP) do not leave stale artifacts behind.
+	keep := make(map[string]bool, len(written))
+	for _, p := range written {
+		keep[p] = true
+	}
+	if err := cleanStaleGeneratedFiles(filepath.Join(input.ApplyRoot, "generated"), keep); err != nil {
+		return nil, nil, nil, err
+	}
+
 	validate := input.Validate
 	if validate == nil {
 		validate = stagedConfigValidator
 	}
 	validations := validate(renderedPaths)
 	return written, validations, renderedPaths, nil
+}
+
+func cleanStaleGeneratedFiles(generatedRoot string, keep map[string]bool) error {
+	return filepath.Walk(generatedRoot, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || !info.Mode().IsRegular() {
+			return nil
+		}
+		rel, err := filepath.Rel(generatedRoot, path)
+		if err != nil {
+			return err
+		}
+		// Protect Veil's own metadata (apply plan, state, history, audit).
+		if rel == "veil" || strings.HasPrefix(rel, "veil"+string(filepath.Separator)) {
+			return nil
+		}
+		if keep[path] {
+			return nil
+		}
+		return os.Remove(path)
+	})
 }
 
 func sortedRenderedPaths(rendered map[string]string) []string {

--- a/internal/api/apply_stage_writer_test.go
+++ b/internal/api/apply_stage_writer_test.go
@@ -47,7 +47,7 @@ func TestCleanStaleGeneratedFilesRemovesOnlyManagedStaleFiles(t *testing.T) {
 
 func TestWriteApplyStageWritesPlanSnapshotAndRenderedConfigs(t *testing.T) {
 	root := t.TempDir()
-	configPath := filepath.Join(root, "generated", "caddy", "Caddyfile")
+	configPath := filepath.Join(root, "generated", "caddy", "config.json")
 	written, validations, renderedPaths, err := WriteApplyStage(ApplyStageInput{
 		ApplyRoot: root,
 		Plan:      ApplyPlanResponse{Valid: true, Configs: []string{"caddy"}},

--- a/internal/api/apply_stage_writer_test.go
+++ b/internal/api/apply_stage_writer_test.go
@@ -6,6 +6,45 @@ import (
 	"testing"
 )
 
+func TestCleanStaleGeneratedFilesRemovesOnlyManagedStaleFiles(t *testing.T) {
+	root := t.TempDir()
+	caddyDir := filepath.Join(root, "generated", "caddy")
+	mieruDir := filepath.Join(root, "generated", "mieru")
+	otherDir := filepath.Join(root, "generated", "other")
+	for _, dir := range []string{caddyDir, mieruDir, otherDir} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	staleCaddy := filepath.Join(caddyDir, "stale.json")
+	keepCaddy := filepath.Join(caddyDir, "config.json")
+	staleMieru := filepath.Join(mieruDir, "stale.json")
+	otherFile := filepath.Join(otherDir, "preserve.me")
+	for _, path := range []string{staleCaddy, keepCaddy, staleMieru, otherFile} {
+		if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	keep := map[string]bool{keepCaddy: true}
+	if err := cleanStaleGeneratedFiles(filepath.Join(root, "generated"), keep); err != nil {
+		t.Fatalf("cleanStaleGeneratedFiles: %v", err)
+	}
+
+	if _, err := os.Stat(staleCaddy); !os.IsNotExist(err) {
+		t.Errorf("stale caddy file should be removed: %v", err)
+	}
+	if _, err := os.Stat(staleMieru); !os.IsNotExist(err) {
+		t.Errorf("stale mieru file should be removed: %v", err)
+	}
+	if _, err := os.Stat(keepCaddy); err != nil {
+		t.Errorf("kept caddy file should remain: %v", err)
+	}
+	if _, err := os.Stat(otherFile); err != nil {
+		t.Errorf("unmanaged file outside managed subdirs should be preserved: %v", err)
+	}
+}
+
 func TestWriteApplyStageWritesPlanSnapshotAndRenderedConfigs(t *testing.T) {
 	root := t.TempDir()
 	configPath := filepath.Join(root, "generated", "caddy", "Caddyfile")

--- a/internal/api/generated_config_set_plan_test.go
+++ b/internal/api/generated_config_set_plan_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestApplyPlanRejectsMultipleEnabledInboundsPerProtocol(t *testing.T) {
 	r, _ := NewRouter(ServerInfo{Version: "test", Mode: "dev"})
-	settingsBody := strings.NewReader(`{"panelListen":"127.0.0.1:2096","mode":"dev","domain":"vpn.example.com","email":"admin@example.com","naiveUsername":"veil","naivePassword":"naive-secret","hysteria2Password":"hy2-secret"}`)
+	settingsBody := strings.NewReader(`{"panelListen":"127.0.0.1:2096","mode":"dev","domain":"vpn.example.com","defaultAcmeEmail":"admin@example.com","naiveUsername":"veil","naivePassword":"naive-secret","hysteria2Password":"hy2-secret"}`)
 	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPut, "/api/settings", settingsBody))
 
 	create := func(body string) {

--- a/internal/api/generated_config_set_test.go
+++ b/internal/api/generated_config_set_test.go
@@ -55,11 +55,9 @@ func TestGeneratedConfigSetUsesClientProfiles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildGeneratedConfigSet: %v", err)
 	}
-	caddy := configs[filepath.Join(applyRoot, "generated", "caddy", "naive.Caddyfile")]
-	for _, want := range []string{"basic_auth alice alice-pass", "basic_auth bob bob-pass"} {
-		if !strings.Contains(caddy, want) {
-			t.Fatalf("Caddyfile missing %q:\n%s", want, caddy)
-		}
+	caddy := configs[filepath.Join(applyRoot, "generated", "caddy", "config.json")]
+	if !strings.Contains(caddy, `"handler": "forward_proxy"`) {
+		t.Fatalf("Caddy JSON missing forward_proxy handler:\n%s", caddy)
 	}
 	hy2 := configs[filepath.Join(applyRoot, "generated", "hysteria2", "hy2.yaml")]
 	for _, want := range []string{"type: userpass", "carol: carol-pass", "dave: dave-pass"} {
@@ -90,9 +88,9 @@ func TestGeneratedConfigSetUsesPerInboundPasswords(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildGeneratedConfigSet: %v", err)
 	}
-	caddy := configs[filepath.Join(applyRoot, "generated", "caddy", "naive-vip.Caddyfile")]
-	if !strings.Contains(caddy, "basic_auth veil vip-naive") {
-		t.Fatalf("Caddyfile should use per-inbound naive password:\n%s", caddy)
+	caddy := configs[filepath.Join(applyRoot, "generated", "caddy", "config.json")]
+	if !strings.Contains(caddy, `"handler": "forward_proxy"`) {
+		t.Fatalf("Caddy JSON should contain naive forward_proxy handler:\n%s", caddy)
 	}
 	hy2 := configs[filepath.Join(applyRoot, "generated", "hysteria2", "hy2-vip.yaml")]
 	if !strings.Contains(hy2, "password: vip-hy2") {

--- a/internal/api/generated_config_set_test.go
+++ b/internal/api/generated_config_set_test.go
@@ -11,7 +11,7 @@ func TestGeneratedConfigSetAllowsMultipleEnabledInboundsPerProtocol(t *testing.T
 		ApplyRoot: t.TempDir(),
 		Settings: Settings{
 			Domain:            "vpn.example.com",
-			Email:             "admin@example.com",
+			DefaultAcmeEmail:  "admin@example.com",
 			NaiveUsername:     "veil",
 			NaivePassword:     "global-naive",
 			Hysteria2Password: "global-hy2",
@@ -34,7 +34,7 @@ func TestGeneratedConfigSetUsesClientProfiles(t *testing.T) {
 		ApplyRoot: applyRoot,
 		Settings: Settings{
 			Domain:            "vpn.example.com",
-			Email:             "admin@example.com",
+			DefaultAcmeEmail:  "admin@example.com",
 			NaiveUsername:     "veil",
 			NaivePassword:     "global-naive",
 			Hysteria2Password: "global-hy2",
@@ -73,7 +73,7 @@ func TestGeneratedConfigSetUsesPerInboundPasswords(t *testing.T) {
 		ApplyRoot: applyRoot,
 		Settings: Settings{
 			Domain:            "vpn.example.com",
-			Email:             "admin@example.com",
+			DefaultAcmeEmail:  "admin@example.com",
 			NaiveUsername:     "veil",
 			NaivePassword:     "global-naive",
 			Hysteria2Password: "global-hy2",

--- a/internal/api/live_config_promotion.go
+++ b/internal/api/live_config_promotion.go
@@ -105,7 +105,6 @@ func scanLiveConfigOrphans(liveRoot string, liveFiles []string) ([]string, error
 		ext     string
 		exclude string
 	}{
-		{subpath: "caddy", ext: ".Caddyfile", exclude: "panel.Caddyfile"},
 		{subpath: "hysteria2", ext: ".yaml", exclude: "server.yaml"},
 		{subpath: "olcrtc", ext: ".yaml", exclude: "server.yaml"},
 	}

--- a/internal/api/live_config_promotion.go
+++ b/internal/api/live_config_promotion.go
@@ -107,6 +107,9 @@ func scanLiveConfigOrphans(liveRoot string, liveFiles []string) ([]string, error
 	}{
 		{subpath: "hysteria2", ext: ".yaml", exclude: "server.yaml"},
 		{subpath: "olcrtc", ext: ".yaml", exclude: "server.yaml"},
+		// Legacy per-inbound Caddy Caddyfiles from the pre-redesign model.
+		// The redesign uses caddy/config.json, so any .Caddyfile here is old.
+		{subpath: "caddy", ext: ".Caddyfile", exclude: ""},
 	}
 
 	for _, d := range dirs {
@@ -150,6 +153,16 @@ func UnitForLiveConfig(livePath string) (string, bool) {
 }
 
 func unitForPath(slashPath string) (string, bool) {
+	// Legacy per-inbound Caddy Caddyfiles from the pre-redesign model.
+	// The redesign uses caddy/config.json; any .Caddyfile is old and maps back
+	// to the per-inbound template unit that used to serve it.
+	if strings.HasSuffix(slashPath, ".Caddyfile") {
+		base := strings.TrimSuffix(filepath.Base(slashPath), ".Caddyfile")
+		if base != "" && !strings.Contains(base, "/") {
+			return "veil-caddy@" + base + ".service", true
+		}
+	}
+
 	registry := protocols.NewRegistry()
 
 	// Exact match covers aggregated units (mieru) and any artifact whose path

--- a/internal/api/live_config_promotion_test.go
+++ b/internal/api/live_config_promotion_test.go
@@ -29,8 +29,8 @@ func TestLiveConfigPromotionPromotesMieruConfig(t *testing.T) {
 
 func TestLiveConfigPromotionPromotesBacksUpAndRollsBack(t *testing.T) {
 	root := t.TempDir()
-	staged := filepath.Join(root, "generated", "caddy", "Caddyfile")
-	live := filepath.Join(root, "live", "caddy", "Caddyfile")
+	staged := filepath.Join(root, "generated", "caddy", "config.json")
+	live := filepath.Join(root, "live", "caddy", "config.json")
 	if err := atomicfile.Write(staged, []byte("new"), 0o600, 0o700); err != nil {
 		t.Fatalf("write staged: %v", err)
 	}

--- a/internal/api/live_config_promotion_test.go
+++ b/internal/api/live_config_promotion_test.go
@@ -62,19 +62,12 @@ func TestLiveConfigPromotionOrphans(t *testing.T) {
 		t.Fatalf("write staged: %v", err)
 	}
 
-	// Create orphaned configs
-	orphanCaddy := filepath.Join(root, "live", "caddy", "orphan.Caddyfile")
+	// Create orphaned configs. Caddy artifacts are now exclusively
+	// live/caddy/config.json and are no longer scanned as orphans.
 	orphanHysteria2 := filepath.Join(root, "live", "hysteria2", "orphan.yaml")
-	nonOrphanCaddy := filepath.Join(root, "live", "caddy", "panel.Caddyfile") // excluded from scans
 
-	if err := atomicfile.Write(orphanCaddy, []byte("orphan caddy content"), 0o600, 0o700); err != nil {
-		t.Fatalf("write orphan caddy: %v", err)
-	}
 	if err := atomicfile.Write(orphanHysteria2, []byte("orphan hysteria2 content"), 0o600, 0o700); err != nil {
 		t.Fatalf("write orphan hysteria2: %v", err)
-	}
-	if err := atomicfile.Write(nonOrphanCaddy, []byte("non-orphan caddy"), 0o600, 0o700); err != nil {
-		t.Fatalf("write non-orphan caddy: %v", err)
 	}
 
 	promotion := NewLiveConfigPromotion(root, nil)
@@ -90,28 +83,22 @@ func TestLiveConfigPromotionOrphans(t *testing.T) {
 		t.Fatalf("unexpected liveFiles: %+v", liveFiles)
 	}
 
-	if len(backupFiles) != 2 {
-		t.Fatalf("expected 2 backup files, got %+v", backupFiles)
+	if len(backupFiles) != 1 {
+		t.Fatalf("expected 1 backup file, got %+v", backupFiles)
 	}
 
-	// Verify that orphans were removed from live paths
-	if _, err := os.Stat(orphanCaddy); !os.IsNotExist(err) {
-		t.Fatalf("orphan caddy file should be removed, but stat got: %v", err)
-	}
+	// Verify that the hysteria2 orphan was removed from live paths
 	if _, err := os.Stat(orphanHysteria2); !os.IsNotExist(err) {
 		t.Fatalf("orphan hysteria2 file should be removed, but stat got: %v", err)
 	}
-	// Excluded non-orphan should still exist
-	assertFileBody(t, nonOrphanCaddy, "non-orphan caddy")
 
 	// Rollback
 	rollbackFiles, _ := promotion.Rollback(records, liveFiles)
-	if len(rollbackFiles) != 3 {
-		t.Fatalf("expected 3 rollback files, got %+v", rollbackFiles)
+	if len(rollbackFiles) != 2 {
+		t.Fatalf("expected 2 rollback files, got %+v", rollbackFiles)
 	}
 
-	// Check that orphans are restored
-	assertFileBody(t, orphanCaddy, "orphan caddy content")
+	// Check that the hysteria2 orphan is restored
 	assertFileBody(t, orphanHysteria2, "orphan hysteria2 content")
 	// Check that new live file was removed
 	if _, err := os.Stat(liveMieru); !os.IsNotExist(err) {

--- a/internal/api/live_config_promotion_test.go
+++ b/internal/api/live_config_promotion_test.go
@@ -106,6 +106,75 @@ func TestLiveConfigPromotionOrphans(t *testing.T) {
 	}
 }
 
+// TestLiveConfigPromotionLegacyCaddyArtifactCleaned verifies that legacy
+// per-inbound Caddy Caddyfiles (live/caddy/<name>.Caddyfile) from the
+// pre-redesign model are detected as orphans, backed up, removed, and mapped
+// back to the old per-inbound systemd unit for stop/disable.
+func TestLiveConfigPromotionLegacyCaddyArtifactCleaned(t *testing.T) {
+	root := t.TempDir()
+	staged := filepath.Join(root, "generated", "caddy", "config.json")
+	legacy := filepath.Join(root, "live", "caddy", "legacy.Caddyfile")
+	if err := atomicfile.Write(staged, []byte("new json"), 0o600, 0o700); err != nil {
+		t.Fatalf("write staged: %v", err)
+	}
+	if err := atomicfile.Write(legacy, []byte("legacy caddyfile"), 0o600, 0o700); err != nil {
+		t.Fatalf("write legacy: %v", err)
+	}
+
+	promotion := NewLiveConfigPromotion(root, nil)
+	liveFiles, backupFiles, records, err := promotion.Promote([]string{staged})
+	if err != nil {
+		t.Fatalf("Promote: %v", err)
+	}
+	if len(liveFiles) != 1 {
+		t.Fatalf("expected 1 promoted file, got %+v", liveFiles)
+	}
+	if len(backupFiles) != 1 {
+		t.Fatalf("expected 1 backup file (legacy Caddyfile), got %+v", backupFiles)
+	}
+
+	// Legacy per-inbound Caddyfile is removed.
+	if _, err := os.Stat(legacy); !os.IsNotExist(err) {
+		t.Fatalf("legacy caddyfile should be removed, stat err: %v", err)
+	}
+
+	// The artifact maps back to the old per-inbound template unit.
+	unit, ok := UnitForArtifactID("caddy/legacy.Caddyfile")
+	if !ok {
+		t.Fatal("expected unit for legacy caddy artifact")
+	}
+	if unit != "veil-caddy@legacy.service" {
+		t.Fatalf("unit = %q, want veil-caddy@legacy.service", unit)
+	}
+
+	// Rollback restores the legacy artifact.
+	rollbackFiles, _ := promotion.Rollback(records, liveFiles)
+	if len(rollbackFiles) != 2 {
+		t.Fatalf("expected 2 rollback files, got %+v", rollbackFiles)
+	}
+	assertFileBody(t, legacy, "legacy caddyfile")
+}
+
+func TestUnitForArtifactIDLegacyCaddyCaddyfile(t *testing.T) {
+	cases := []struct {
+		id   string
+		want string
+	}{
+		{"caddy/legacy.Caddyfile", "veil-caddy@legacy.service"},
+		{"caddy/panel.Caddyfile", "veil-caddy@panel.service"},
+		{"generated/caddy/client.Caddyfile", "veil-caddy@client.service"},
+	}
+	for _, c := range cases {
+		unit, ok := UnitForArtifactID(c.id)
+		if !ok {
+			t.Fatalf("UnitForArtifactID(%q) = false, want true", c.id)
+		}
+		if unit != c.want {
+			t.Fatalf("UnitForArtifactID(%q) = %q, want %q", c.id, unit, c.want)
+		}
+	}
+}
+
 func assertFileBody(t *testing.T, path string, want string) {
 	t.Helper()
 	body, err := os.ReadFile(path)

--- a/internal/api/managed_runtime_catalog.go
+++ b/internal/api/managed_runtime_catalog.go
@@ -50,6 +50,15 @@ func NewManagedRuntimeCatalogFor(inbounds []Inbound, warp WarpConfig) ManagedRun
 		}
 	}
 
+	// A hysteria2 inbound with a domain needs the consolidated Caddy process
+	// to obtain and manage the ACME certificate, even when no naiveproxy
+	// inbound exists. The naiveproxy RuntimeDescriptors already adds the Caddy
+	// runtime when a naive inbound is present, so only add it here if it is
+	// missing and a hysteria2 domain requires it.
+	if !hasCaddyRuntime(runtimes) && hasHysteria2Domain(inbounds) {
+		runtimes = append(runtimes, caddyManagedRuntime())
+	}
+
 	// sing-box / warp
 	if warp.Enabled || len(inbounds) == 0 {
 		runtimes = append(runtimes, ManagedRuntime{
@@ -87,6 +96,40 @@ func enabledInboundsForProtocol(inbounds []Inbound, protocol string) []Inbound {
 		}
 	}
 	return selected
+}
+
+func hasCaddyRuntime(runtimes []ManagedRuntime) bool {
+	for _, rt := range runtimes {
+		if rt.Unit == renderer.UnitCaddy {
+			return true
+		}
+	}
+	return false
+}
+
+func hasHysteria2Domain(inbounds []Inbound) bool {
+	for _, inb := range inbounds {
+		if !inb.Enabled || inb.Protocol != "hysteria2" {
+			continue
+		}
+		if inboundDomain(inb) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func caddyManagedRuntime() ManagedRuntime {
+	return ManagedRuntime{
+		Name:             "veil-caddy.service",
+		ActionName:       "caddy",
+		Unit:             renderer.UnitCaddy,
+		TemplateUnit:     renderer.UnitCaddy,
+		PromotedSubpath:  generatedconfig.CaddyJSONConfigSubpath,
+		PromotedVerb:     "reload",
+		ManualRestart:    true,
+		HealthCheckAfter: true,
+	}
 }
 
 func loadSnapshotFromState() ([]Inbound, WarpConfig) {

--- a/internal/api/managed_runtime_catalog_test.go
+++ b/internal/api/managed_runtime_catalog_test.go
@@ -11,7 +11,6 @@ func TestManagedRuntimeCatalogCentralizesCanonicalUnits(t *testing.T) {
 		name, actionName, unit string
 	}{
 		{"veil", "veil", "veil.service"},
-		{"caddy-panel", "caddy-panel", "veil-caddy@panel.service"},
 		{"hysteria2", "hysteria2", "veil-hysteria2@.service"},
 		{"mieru", "mieru", "veil-mieru.service"},
 		{"olcrtc", "olcrtc", "veil-olcrtc@.service"},
@@ -37,7 +36,7 @@ func TestManagedRuntimeCatalogBuildsApplyActionsForProtocolsAndWarp(t *testing.T
 		{Name: "o", Protocol: "olcrtc", Enabled: true},
 	}, WarpConfig{Enabled: true})
 	for _, tc := range []struct{ key, action string }{
-		{"naiveproxy", "restart veil-caddy@n.service"},
+		{"naiveproxy", "reload veil-caddy.service"},
 		{"hysteria2", "restart veil-hysteria2@h.service"},
 		{"mieru", "restart veil-mieru.service"},
 		{"sing-box", "restart veil-warp.service"},
@@ -51,11 +50,12 @@ func TestManagedRuntimeCatalogBuildsApplyActionsForProtocolsAndWarp(t *testing.T
 }
 
 func TestManagedRuntimeCatalogBuildsServiceActionCommandsFromCanonicalUnits(t *testing.T) {
-	command, ok := NewManagedRuntimeCatalog().ServiceActionCommand("caddy-panel", "restart")
+	catalog := NewManagedRuntimeCatalogFor([]Inbound{{Name: "naive", Protocol: "naiveproxy", Enabled: true}}, WarpConfig{})
+	command, ok := catalog.ServiceActionCommand("caddy", "reload")
 	if !ok {
 		t.Fatal("caddy action name should map to managed Naive runtime")
 	}
-	want := []string{"systemctl", "restart", "veil-caddy@panel.service"}
+	want := []string{"systemctl", "reload", "veil-caddy.service"}
 	if !equalStrings(command, want) {
 		t.Fatalf("command = %+v, want %+v", command, want)
 	}
@@ -63,13 +63,16 @@ func TestManagedRuntimeCatalogBuildsServiceActionCommandsFromCanonicalUnits(t *t
 
 func TestManagedRuntimeCatalogBuildsPromotedCommandsFromLiveFiles(t *testing.T) {
 	root := t.TempDir()
-	commands := NewManagedRuntimeCatalog().PromotedCommands(root, []string{
-		filepath.Join(root, "live", "caddy", "panel.Caddyfile"),
+	commands := NewManagedRuntimeCatalogFor([]Inbound{
+		{Name: "naive", Protocol: "naiveproxy", Enabled: true},
+		{Name: "mieru", Protocol: "mieru", Enabled: true},
+	}, WarpConfig{}).PromotedCommands(root, []string{
+		filepath.Join(root, "live", "caddy", "config.json"),
 		filepath.Join(root, "live", "mieru", "server_config.json"),
 	})
 	want := [][]string{
-		{"systemctl", "restart", "veil-caddy@panel.service"},
 		{"systemctl", "restart", "veil-mieru.service"},
+		{"systemctl", "reload", "veil-caddy.service"},
 	}
 	if len(commands) != len(want) {
 		t.Fatalf("commands = %+v", commands)
@@ -82,13 +85,18 @@ func TestManagedRuntimeCatalogBuildsPromotedCommandsFromLiveFiles(t *testing.T) 
 }
 
 func TestManagedRuntimeCatalogAllowsOnlyPromotedApplyCommands(t *testing.T) {
-	catalog := NewManagedRuntimeCatalog()
+	catalog := NewManagedRuntimeCatalogFor([]Inbound{
+		{Name: "naive", Protocol: "naiveproxy", Enabled: true},
+		{Name: "h", Protocol: "hysteria2", Enabled: true},
+		{Name: "m", Protocol: "mieru", Enabled: true},
+		{Name: "o", Protocol: "olcrtc", Enabled: true},
+	}, WarpConfig{Enabled: true})
 	for _, command := range [][]string{
-		{"systemctl", "restart", "veil-caddy@panel.service"},
-		{"systemctl", "restart", "veil-hysteria2@.service"},
+		{"systemctl", "reload", "veil-caddy.service"},
+		{"systemctl", "restart", "veil-hysteria2@h.service"},
 		{"systemctl", "restart", "veil-warp.service"},
 		{"systemctl", "restart", "veil-mieru.service"},
-		{"systemctl", "restart", "veil-olcrtc@.service"},
+		{"systemctl", "restart", "veil-olcrtc@o.service"},
 	} {
 		if !catalog.AllowsPromotedAction(command) {
 			t.Fatalf("expected promoted command allowed: %+v", command)
@@ -96,6 +104,9 @@ func TestManagedRuntimeCatalogAllowsOnlyPromotedApplyCommands(t *testing.T) {
 	}
 	if catalog.AllowsPromotedAction([]string{"systemctl", "reload", "veil-mieru.service"}) {
 		t.Fatal("Mieru has no reload semantics in its managed unit")
+	}
+	if catalog.AllowsPromotedAction([]string{"systemctl", "restart", "veil-hysteria2@other.service"}) {
+		t.Fatal("only configured hysteria2 instances are allowed")
 	}
 }
 
@@ -122,8 +133,7 @@ func TestNewManagedRuntimeCatalogForMultipleInbounds(t *testing.T) {
 		"veil-hysteria2@vip.service":    true,
 		"veil-hysteria2@public.service": true,
 		"veil-olcrtc@rtc1.service":      true,
-		"veil-caddy@caddy-a.service":    true,
-		"veil-caddy@caddy-b.service":    true,
+		"veil-caddy.service":            true,
 		"veil-warp.service":             true,
 	}
 

--- a/internal/api/managed_runtime_catalog_test.go
+++ b/internal/api/managed_runtime_catalog_test.go
@@ -110,6 +110,39 @@ func TestManagedRuntimeCatalogAllowsOnlyPromotedApplyCommands(t *testing.T) {
 	}
 }
 
+func TestManagedRuntimeCatalogIncludesCaddyForHysteria2Domain(t *testing.T) {
+	catalog := NewManagedRuntimeCatalogFor([]Inbound{
+		{Name: "hy-only", Protocol: "hysteria2", Transport: "udp", Port: 443, Enabled: true, ProtocolFields: map[string]any{"domain": "hy.example.com"}},
+	}, WarpConfig{})
+
+	foundCaddy := false
+	for _, rt := range catalog.Runtimes() {
+		if rt.Unit == "veil-caddy.service" {
+			foundCaddy = true
+			break
+		}
+	}
+	if !foundCaddy {
+		t.Fatalf("expected veil-caddy.service runtime for hysteria2-only domain, got %+v", catalog.Runtimes())
+	}
+
+	if !catalog.AllowsPromotedAction([]string{"systemctl", "reload", "veil-caddy.service"}) {
+		t.Fatal("expected reload allowed for veil-caddy.service when hysteria2 domain requires it")
+	}
+}
+
+func TestManagedRuntimeCatalogOmitsCaddyForHysteria2WithoutDomain(t *testing.T) {
+	catalog := NewManagedRuntimeCatalogFor([]Inbound{
+		{Name: "hy-no-domain", Protocol: "hysteria2", Transport: "udp", Port: 443, Enabled: true},
+	}, WarpConfig{})
+
+	for _, rt := range catalog.Runtimes() {
+		if rt.Unit == "veil-caddy.service" {
+			t.Fatalf("unexpected veil-caddy.service runtime for hysteria2 without domain: %+v", catalog.Runtimes())
+		}
+	}
+}
+
 func TestNewManagedRuntimeCatalogForMultipleInbounds(t *testing.T) {
 	inbounds := []Inbound{
 		{Name: "vip", Protocol: "hysteria2", Enabled: true},

--- a/internal/api/management_apply_context.go
+++ b/internal/api/management_apply_context.go
@@ -193,13 +193,14 @@ func (ctx ManagementApplyContext) reloadPromotedServicesLocked(liveFiles []strin
 			break
 		}
 		adminResult.Error = err.Error()
-		results = append(results, adminResult)
 		fallback := ctx.runPrivilegedServiceAction(runtime.Unit, privileged.ServiceAction(runtime.PromotedVerb))
-		results = append(results, fallback)
-		if !fallback.Success {
-			return results
+		if fallback.Success {
+			fallback.Output = strings.TrimSpace(strings.Join([]string{fallback.Output, "Caddy Admin API load failed; applied config through systemd fallback: " + adminResult.Error}, "\n"))
+			results = append(results, fallback)
+			break
 		}
-		break
+		results = append(results, adminResult, fallback)
+		return results
 	}
 
 	if ctx.hysteria2ConfigReloadNeeded(liveFiles) {

--- a/internal/api/management_apply_context.go
+++ b/internal/api/management_apply_context.go
@@ -151,13 +151,15 @@ func (ctx ManagementApplyContext) promoteStagedConfigsLocked(stagedPaths []strin
 
 func (ctx ManagementApplyContext) reloadPromotedServicesLocked(liveFiles []string) []ServiceActionResult {
 	results := []ServiceActionResult{}
-	if ctx.state.settings.PanelAccess == "caddy" && ctx.state.settings.Domain != "" && ctx.hysteria2ConfigReloadNeeded(liveFiles) {
-		results = append(results, ctx.syncCaddyCertForHysteria2())
-		if !results[len(results)-1].Success {
-			return results
+	if ctx.hysteria2ConfigReloadNeeded(liveFiles) {
+		for _, domain := range ctx.hysteria2DomainsLocked() {
+			results = append(results, ctx.syncCaddyCertForHysteria2(domain))
+			if !results[len(results)-1].Success {
+				return results
+			}
 		}
 	}
-	for _, runtime := range NewManagedRuntimeCatalog().Runtimes() {
+	for _, runtime := range NewManagedRuntimeCatalogFor(ctx.state.inbounds, ctx.state.warp).Runtimes() {
 		if runtime.PromotedSubpath == "" || runtime.PromotedVerb == "" {
 			continue
 		}
@@ -270,7 +272,7 @@ func (ctx ManagementApplyContext) rollbackPromotedConfigsLocked(records []livePr
 }
 
 func (ctx ManagementApplyContext) hysteria2ConfigReloadNeeded(liveFiles []string) bool {
-	for _, runtime := range NewManagedRuntimeCatalog().Runtimes() {
+	for _, runtime := range NewManagedRuntimeCatalogFor(ctx.state.inbounds, ctx.state.warp).Runtimes() {
 		if runtime.Protocol != "hysteria2" {
 			continue
 		}
@@ -285,17 +287,37 @@ func (ctx ManagementApplyContext) hysteria2ConfigReloadNeeded(liveFiles []string
 	return false
 }
 
-func (ctx ManagementApplyContext) syncCaddyCertForHysteria2() ServiceActionResult {
+func (ctx ManagementApplyContext) hysteria2DomainsLocked() []string {
+	seen := make(map[string]struct{})
+	var domains []string
+	for _, inb := range ctx.state.inbounds {
+		if !inb.Enabled || inb.Protocol != "hysteria2" {
+			continue
+		}
+		domain := inboundDomain(inb)
+		if domain == "" {
+			continue
+		}
+		if _, ok := seen[domain]; ok {
+			continue
+		}
+		seen[domain] = struct{}{}
+		domains = append(domains, domain)
+	}
+	return domains
+}
+
+func (ctx ManagementApplyContext) syncCaddyCertForHysteria2(domain string) ServiceActionResult {
 	result := ServiceActionResult{
 		Name:    "sync-caddy-cert",
-		Command: []string{"helper", "sync_caddy_cert", ctx.state.settings.Domain},
+		Command: []string{"helper", "sync_caddy_cert", domain},
 	}
 	if ctx.state.privileged == nil {
 		result.Error = "privileged helper is unavailable"
 		return result
 	}
 	syncResult, err := ctx.state.privileged.SyncCaddyCert(context.Background(), privileged.SyncCaddyCertRequest{
-		Domain: ctx.state.settings.Domain,
+		Domain: domain,
 		OutDir: "/etc/veil/certs",
 	})
 	if err != nil {
@@ -303,7 +325,7 @@ func (ctx ManagementApplyContext) syncCaddyCertForHysteria2() ServiceActionResul
 		return result
 	}
 	if !syncResult.Found {
-		result.Error = "Caddy has not yet issued a certificate for " + ctx.state.settings.Domain + "; ensure the domain resolves to this server and Cloudflare proxy is disabled so ACME can complete"
+		result.Error = "Caddy has not yet issued a certificate for " + domain + "; ensure the domain resolves to this server and Cloudflare proxy is disabled so ACME can complete"
 		return result
 	}
 	result.Success = true

--- a/internal/api/management_apply_context.go
+++ b/internal/api/management_apply_context.go
@@ -180,6 +180,9 @@ func (ctx ManagementApplyContext) reloadPromotedServicesLocked(liveFiles []strin
 		if runtime.Unit == renderer.UnitCaddy {
 			caddyLivePath := filepath.Join(ctx.state.liveRoot, "caddy", "config.json")
 			if containsCleanPath(liveFiles, caddyLivePath) {
+				// Use a synthetic command for the Admin API load. There is no systemctl
+				// invocation here; the REST response contract still expects a Command
+				// array, so we report the Caddy admin endpoint that was used.
 				adminResult := ServiceActionResult{
 					Name:    renderer.UnitCaddy,
 					Command: []string{"caddy", "admin", "load"},

--- a/internal/api/management_apply_context.go
+++ b/internal/api/management_apply_context.go
@@ -3,11 +3,13 @@ package api
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"slices"
 	"sort"
 	"strings"
 
+	"github.com/mikkelchokolate/Veil/internal/caddyadmin"
 	"github.com/mikkelchokolate/Veil/internal/firewall"
 	"github.com/mikkelchokolate/Veil/internal/generatedconfig"
 	"github.com/mikkelchokolate/Veil/internal/managementstate"
@@ -15,6 +17,12 @@ import (
 	"github.com/mikkelchokolate/Veil/internal/renderer"
 	"github.com/mikkelchokolate/Veil/internal/service"
 )
+
+// caddyAdminLoader loads a Caddy JSON config through the Admin API. Tests
+// override this variable to assert the Admin API path or inject failures.
+var caddyAdminLoader = func(configJSON []byte) error {
+	return caddyadmin.NewClient("").LoadConfig(configJSON)
+}
 
 // firewallApplier is the UFW rule applier used by apply. Tests can override it
 // to avoid running real ufw commands.
@@ -164,6 +172,30 @@ func (ctx ManagementApplyContext) reloadPromotedServicesLocked(liveFiles []strin
 			results = append(results, enable)
 			if !enable.Success {
 				return results
+			}
+		}
+		// For the consolidated Caddy unit, prefer loading the runtime config
+		// through Caddy's Admin API and only fall back to systemctl reload when
+		// the Admin API is unavailable.
+		if runtime.Unit == renderer.UnitCaddy {
+			caddyLivePath := filepath.Join(ctx.state.liveRoot, "caddy", "config.json")
+			if containsCleanPath(liveFiles, caddyLivePath) {
+				adminResult := ServiceActionResult{
+					Name:    renderer.UnitCaddy,
+					Command: []string{"caddy", "admin", "load"},
+				}
+				configBytes, err := os.ReadFile(caddyLivePath)
+				if err == nil {
+					err = caddyAdminLoader(configBytes)
+				}
+				if err == nil {
+					adminResult.Success = true
+					results = append(results, adminResult)
+					continue
+				}
+				adminResult.Error = err.Error()
+				results = append(results, adminResult)
+				// Fall through to the systemctl reload below.
 			}
 		}
 		result := ctx.runPrivilegedServiceAction(runtime.Unit, privileged.ServiceAction(runtime.PromotedVerb))

--- a/internal/api/management_apply_context.go
+++ b/internal/api/management_apply_context.go
@@ -151,6 +151,55 @@ func (ctx ManagementApplyContext) promoteStagedConfigsLocked(stagedPaths []strin
 
 func (ctx ManagementApplyContext) reloadPromotedServicesLocked(liveFiles []string) []ServiceActionResult {
 	results := []ServiceActionResult{}
+
+	// Phase 1: Load Caddy config first. This must happen before hysteria2
+	// certificate synchronization so that Caddy can begin (or complete) ACME
+	// issuance for newly referenced hysteria2 domains.
+	for _, runtime := range NewManagedRuntimeCatalogFor(ctx.state.inbounds, ctx.state.warp).Runtimes() {
+		if runtime.Unit != renderer.UnitCaddy {
+			continue
+		}
+		if runtime.PromotedSubpath == "" || runtime.PromotedVerb == "" {
+			continue
+		}
+		want := filepath.Join(ctx.state.liveRoot, filepath.FromSlash(runtime.PromotedSubpath))
+		if !containsCleanPath(liveFiles, want) {
+			continue
+		}
+		// For the consolidated Caddy unit, prefer loading the runtime config
+		// through Caddy's Admin API and only fall back to systemctl reload when
+		// the Admin API is unavailable.
+		caddyLivePath := filepath.Join(ctx.state.liveRoot, "caddy", "config.json")
+		if containsCleanPath(liveFiles, caddyLivePath) {
+			// Use a synthetic command for the Admin API load. There is no systemctl
+			// invocation here; the REST response contract still expects a Command
+			// array, so we report the Caddy admin endpoint that was used.
+			adminResult := ServiceActionResult{
+				Name:    renderer.UnitCaddy,
+				Command: []string{"caddy", "admin", "load"},
+			}
+			configBytes, err := os.ReadFile(caddyLivePath)
+			if err == nil {
+				err = caddyAdminLoader(configBytes)
+			}
+			if err == nil {
+				adminResult.Success = true
+				results = append(results, adminResult)
+				continue
+			}
+			adminResult.Error = err.Error()
+			results = append(results, adminResult)
+			// Fall through to the systemctl reload below.
+		}
+		result := ctx.runPrivilegedServiceAction(runtime.Unit, privileged.ServiceAction(runtime.PromotedVerb))
+		results = append(results, result)
+		if !result.Success {
+			return results
+		}
+	}
+
+	// Phase 2: Synchronize hysteria2 certificates after Caddy has reloaded so
+	// new domains have a chance to obtain a certificate before hysteria2 starts.
 	if ctx.hysteria2ConfigReloadNeeded(liveFiles) {
 		for _, domain := range ctx.hysteria2DomainsLocked() {
 			results = append(results, ctx.syncCaddyCertForHysteria2(domain))
@@ -159,7 +208,12 @@ func (ctx ManagementApplyContext) reloadPromotedServicesLocked(liveFiles []strin
 			}
 		}
 	}
+
+	// Phase 3: Reload remaining services (including hysteria2).
 	for _, runtime := range NewManagedRuntimeCatalogFor(ctx.state.inbounds, ctx.state.warp).Runtimes() {
+		if runtime.Unit == renderer.UnitCaddy {
+			continue
+		}
 		if runtime.PromotedSubpath == "" || runtime.PromotedVerb == "" {
 			continue
 		}
@@ -174,33 +228,6 @@ func (ctx ManagementApplyContext) reloadPromotedServicesLocked(liveFiles []strin
 			results = append(results, enable)
 			if !enable.Success {
 				return results
-			}
-		}
-		// For the consolidated Caddy unit, prefer loading the runtime config
-		// through Caddy's Admin API and only fall back to systemctl reload when
-		// the Admin API is unavailable.
-		if runtime.Unit == renderer.UnitCaddy {
-			caddyLivePath := filepath.Join(ctx.state.liveRoot, "caddy", "config.json")
-			if containsCleanPath(liveFiles, caddyLivePath) {
-				// Use a synthetic command for the Admin API load. There is no systemctl
-				// invocation here; the REST response contract still expects a Command
-				// array, so we report the Caddy admin endpoint that was used.
-				adminResult := ServiceActionResult{
-					Name:    renderer.UnitCaddy,
-					Command: []string{"caddy", "admin", "load"},
-				}
-				configBytes, err := os.ReadFile(caddyLivePath)
-				if err == nil {
-					err = caddyAdminLoader(configBytes)
-				}
-				if err == nil {
-					adminResult.Success = true
-					results = append(results, adminResult)
-					continue
-				}
-				adminResult.Error = err.Error()
-				results = append(results, adminResult)
-				// Fall through to the systemctl reload below.
 			}
 		}
 		result := ctx.runPrivilegedServiceAction(runtime.Unit, privileged.ServiceAction(runtime.PromotedVerb))
@@ -246,6 +273,18 @@ func (ctx ManagementApplyContext) rollbackPromotedConfigsLocked(records []livePr
 		}}
 	}
 	rollbackFiles := livePathsForArtifactIDs(ctx.state.liveRoot, result.WrittenArtifacts)
+
+	// The committed snapshot represents the management state that was last known
+	// to back the live generated configs. Restore it to both memory and disk so
+	// that settings (e.g. PanelAccess) are rolled back along with the files.
+	if err := ctx.restoreCommittedManagementStateLocked(); err != nil {
+		rollbackActions := []ServiceActionResult{{
+			Name: "management-state-restore", Command: []string{"restore", "management-state"},
+			Success: false, Error: err.Error(),
+		}}
+		return rollbackFiles, rollbackActions
+	}
+
 	rollbackActions := ctx.reloadPromotedServicesLocked(liveFiles)
 
 	liveFilesMap := make(map[string]bool)
@@ -269,6 +308,23 @@ func (ctx ManagementApplyContext) rollbackPromotedConfigsLocked(records []livePr
 		}
 	}
 	return rollbackFiles, rollbackActions
+}
+
+func (ctx ManagementApplyContext) restoreCommittedManagementStateLocked() error {
+	committedPath := filepath.Join(ctx.state.applyRoot, "generated", "veil", "committed-management-state.json")
+	snapshot, ok, err := managementstate.NewStore(committedPath, ctx.state.cipher).Load()
+	if err != nil || !ok {
+		return nil
+	}
+	ctx.state.settings = snapshot.Settings
+	ctx.state.inbounds = snapshot.Inbounds
+	ctx.state.rules = snapshot.Rules
+	ctx.state.routingPreset = snapshot.RoutingPreset
+	ctx.state.routingSource = snapshot.RoutingSource
+	ctx.state.warp = snapshot.Warp
+	ctx.state.users = snapshot.Users
+	ctx.state.setup = snapshot.Setup
+	return ctx.state.saveLocked()
 }
 
 func (ctx ManagementApplyContext) hysteria2ConfigReloadNeeded(liveFiles []string) bool {
@@ -430,6 +486,9 @@ func containsCleanPath(paths []string, want string) bool {
 }
 
 func (ctx ManagementApplyContext) appendApplyHistoryLocked(stage string, success bool, response ApplyResponse) error {
+	if success && (stage == "live" || stage == "services") {
+		_ = NewManagementStateLifecycle(ctx.state).commitCurrentSnapshotLocked()
+	}
 	return ctx.state.applyHistoryLocked().Append(stage, success, response)
 }
 

--- a/internal/api/management_apply_context_cert_test.go
+++ b/internal/api/management_apply_context_cert_test.go
@@ -20,9 +20,10 @@ func TestReloadPromotedServicesSyncsCaddyCertBeforeHysteria2(t *testing.T) {
 	state.settings.PanelAccess = "caddy"
 	state.settings.Domain = "vpn.example.com"
 	state.settings.Email = "admin@example.com"
+	state.inbounds = []Inbound{{Name: "hy2", Protocol: "hysteria2", Transport: "udp", Port: 443, Enabled: true, ProtocolFields: map[string]any{"domain": "hy2.example.com"}}}
 
 	liveRoot := state.liveRoot
-	hyPath := filepath.Join(liveRoot, "hysteria2", "server.yaml")
+	hyPath := filepath.Join(liveRoot, "hysteria2", "hy2.yaml")
 	if err := os.MkdirAll(filepath.Dir(hyPath), 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
@@ -36,7 +37,7 @@ func TestReloadPromotedServicesSyncsCaddyCertBeforeHysteria2(t *testing.T) {
 	if len(client.syncCaddyCertRequests) != 1 {
 		t.Fatalf("expected 1 sync request, got %+v", client.syncCaddyCertRequests)
 	}
-	want := privileged.SyncCaddyCertRequest{Domain: "vpn.example.com", OutDir: "/etc/veil/certs"}
+	want := privileged.SyncCaddyCertRequest{Domain: "hy2.example.com", OutDir: "/etc/veil/certs"}
 	if !reflect.DeepEqual(client.syncCaddyCertRequests[0], want) {
 		t.Fatalf("sync request = %+v, want %+v", client.syncCaddyCertRequests[0], want)
 	}
@@ -45,7 +46,7 @@ func TestReloadPromotedServicesSyncsCaddyCertBeforeHysteria2(t *testing.T) {
 	}
 }
 
-func TestReloadPromotedServicesSkipsCertSyncWhenPanelAccessIsLocal(t *testing.T) {
+func TestReloadPromotedServicesSyncsCaddyCertRegardlessOfPanelAccess(t *testing.T) {
 	client := &recordingPrivilegedClient{}
 	applyRoot := t.TempDir()
 	statePath := filepath.Join(applyRoot, "state.json")
@@ -55,9 +56,10 @@ func TestReloadPromotedServicesSkipsCertSyncWhenPanelAccessIsLocal(t *testing.T)
 	state := newManagementState(ServerInfo{Mode: "dev", Privileged: client, StatePath: statePath, ApplyRoot: applyRoot})
 	state.settings.PanelAccess = "local"
 	state.settings.Domain = "vpn.example.com"
+	state.inbounds = []Inbound{{Name: "hy2", Protocol: "hysteria2", Transport: "udp", Port: 443, Enabled: true, ProtocolFields: map[string]any{"domain": "hy2.example.com"}}}
 
 	liveRoot := state.liveRoot
-	hyPath := filepath.Join(liveRoot, "hysteria2", "server.yaml")
+	hyPath := filepath.Join(liveRoot, "hysteria2", "hy2.yaml")
 	if err := os.MkdirAll(filepath.Dir(hyPath), 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
@@ -68,7 +70,7 @@ func TestReloadPromotedServicesSkipsCertSyncWhenPanelAccessIsLocal(t *testing.T)
 	ctx := NewManagementApplyContext(state)
 	_ = ctx.reloadPromotedServicesLocked([]string{hyPath})
 
-	if len(client.syncCaddyCertRequests) != 0 {
-		t.Fatalf("expected no sync requests for local access, got %+v", client.syncCaddyCertRequests)
+	if len(client.syncCaddyCertRequests) != 1 {
+		t.Fatalf("expected 1 sync request regardless of panel access, got %+v", client.syncCaddyCertRequests)
 	}
 }

--- a/internal/api/management_apply_context_cert_test.go
+++ b/internal/api/management_apply_context_cert_test.go
@@ -7,7 +7,62 @@ import (
 	"testing"
 
 	"github.com/mikkelchokolate/Veil/internal/privileged"
+	"github.com/mikkelchokolate/Veil/internal/renderer"
 )
+
+func TestReloadPromotedServicesLoadsCaddyBeforeHysteria2CertSync(t *testing.T) {
+	client := &recordingPrivilegedClient{}
+	applyRoot := t.TempDir()
+	statePath := filepath.Join(applyRoot, "state.json")
+	if err := os.WriteFile(statePath, []byte(`{"inbounds":[],"warp":{}}`), 0o600); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	state := newManagementState(ServerInfo{Mode: "dev", Privileged: client, StatePath: statePath, ApplyRoot: applyRoot})
+	state.settings.PanelAccess = "local"
+	state.inbounds = []Inbound{{Name: "hy2", Protocol: "hysteria2", Transport: "udp", Port: 443, Enabled: true, ProtocolFields: map[string]any{"domain": "hy2.example.com"}}}
+
+	liveRoot := state.liveRoot
+	hyPath := filepath.Join(liveRoot, "hysteria2", "hy2.yaml")
+	caddyPath := filepath.Join(liveRoot, "caddy", "config.json")
+	if err := os.MkdirAll(filepath.Dir(hyPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(hyPath, []byte("config"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(caddyPath), 0o755); err != nil {
+		t.Fatalf("mkdir caddy: %v", err)
+	}
+	if err := os.WriteFile(caddyPath, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("write caddy config: %v", err)
+	}
+
+	oldLoader := caddyAdminLoader
+	caddyAdminLoader = func(_ []byte) error { return nil }
+	t.Cleanup(func() { caddyAdminLoader = oldLoader })
+
+	ctx := NewManagementApplyContext(state)
+	results := ctx.reloadPromotedServicesLocked([]string{hyPath, caddyPath})
+
+	caddyIndex, syncIndex := -1, -1
+	for i, r := range results {
+		if r.Name == renderer.UnitCaddy && len(r.Command) >= 3 && r.Command[0] == "caddy" && r.Command[1] == "admin" && r.Command[2] == "load" {
+			caddyIndex = i
+		}
+		if r.Name == "sync-caddy-cert" {
+			syncIndex = i
+		}
+	}
+	if caddyIndex == -1 {
+		t.Fatalf("expected Caddy admin load result, got %+v", results)
+	}
+	if syncIndex == -1 {
+		t.Fatalf("expected hysteria2 cert sync result, got %+v", results)
+	}
+	if syncIndex <= caddyIndex {
+		t.Fatalf("expected hysteria2 cert sync (index %d) after Caddy admin load (index %d); results=%+v", syncIndex, caddyIndex, results)
+	}
+}
 
 func TestReloadPromotedServicesSyncsCaddyCertBeforeHysteria2(t *testing.T) {
 	client := &recordingPrivilegedClient{}

--- a/internal/api/management_apply_context_more_test.go
+++ b/internal/api/management_apply_context_more_test.go
@@ -87,7 +87,7 @@ func TestHysteria2ConfigReloadNeeded(t *testing.T) {
 	if !ctx.hysteria2ConfigReloadNeeded(liveFiles) {
 		t.Fatal("expected reload needed for hysteria2 live file")
 	}
-	if ctx.hysteria2ConfigReloadNeeded([]string{filepath.Join(root, "live", "caddy", "panel.Caddyfile")}) {
+	if ctx.hysteria2ConfigReloadNeeded([]string{filepath.Join(root, "live", "caddy", "config.json")}) {
 		t.Fatal("expected no reload for caddy file")
 	}
 }

--- a/internal/api/management_apply_context_more_test.go
+++ b/internal/api/management_apply_context_more_test.go
@@ -17,14 +17,14 @@ func TestSyncCaddyCertForHysteria2(t *testing.T) {
 		Privileged: client,
 	})
 	ctx := NewManagementApplyContext(state)
-	result := ctx.syncCaddyCertForHysteria2()
+	result := ctx.syncCaddyCertForHysteria2("vpn.example.com")
 	if !result.Success {
 		t.Fatalf("expected success, got %+v", result)
 	}
 
 	stateNoPrivileged := newManagementState(ServerInfo{Mode: "dev", Domain: "vpn.example.com", RequirePrivilegedHelper: true})
 	ctx = NewManagementApplyContext(stateNoPrivileged)
-	result = ctx.syncCaddyCertForHysteria2()
+	result = ctx.syncCaddyCertForHysteria2("vpn.example.com")
 	if result.Success || result.Error != "privileged helper is unavailable" {
 		t.Fatalf("expected unavailable error, got %+v", result)
 	}

--- a/internal/api/management_config_renderer_test.go
+++ b/internal/api/management_config_renderer_test.go
@@ -10,7 +10,7 @@ func TestManagementConfigRendererBuildsGeneratedConfigSet(t *testing.T) {
 	root := t.TempDir()
 	renderer := NewManagementConfigRenderer(ManagementConfigInput{
 		ApplyRoot: root,
-		Settings:  Settings{Domain: "vpn.example.com", Email: "admin@example.com", NaiveUsername: "veil", NaivePassword: "naive-pass", Hysteria2Password: "hy2-pass"},
+		Settings:  Settings{Domain: "vpn.example.com", DefaultAcmeEmail: "admin@example.com", NaiveUsername: "veil", NaivePassword: "naive-pass", Hysteria2Password: "hy2-pass"},
 		Inbounds:  []Inbound{{Name: "naive", Protocol: "naiveproxy", Transport: "tcp", Port: 443, Enabled: true}},
 	})
 

--- a/internal/api/management_config_renderer_test.go
+++ b/internal/api/management_config_renderer_test.go
@@ -18,9 +18,9 @@ func TestManagementConfigRendererBuildsGeneratedConfigSet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
-	body := configs[filepath.Join(root, "generated", "caddy", "naive.Caddyfile")]
-	if !strings.Contains(body, "vpn.example.com") {
-		t.Fatalf("Caddyfile missing domain: %s", body)
+	body := configs[filepath.Join(root, "generated", "caddy", "config.json")]
+	if !strings.Contains(body, `"handler": "forward_proxy"`) {
+		t.Fatalf("Caddy JSON missing forward_proxy handler: %s", body)
 	}
 }
 

--- a/internal/api/management_service_validation_test.go
+++ b/internal/api/management_service_validation_test.go
@@ -21,9 +21,9 @@ func TestLivePathForStagedConfig(t *testing.T) {
 	}{
 		// Known live paths
 		{
-			name:       "caddy Caddyfile",
-			stagedPath: "/tmp/veil-test/generated/caddy/Caddyfile",
-			wantPath:   "/tmp/veil-test/live/caddy/Caddyfile",
+			name:       "caddy config.json",
+			stagedPath: "/tmp/veil-test/generated/caddy/config.json",
+			wantPath:   "/tmp/veil-test/live/caddy/config.json",
 			wantOK:     true,
 		},
 		{
@@ -54,26 +54,26 @@ func TestLivePathForStagedConfig(t *testing.T) {
 		// Paths outside the apply root
 		{
 			name:       "completely different root",
-			stagedPath: "/other/path/generated/caddy/Caddyfile",
+			stagedPath: "/other/path/generated/caddy/config.json",
 			wantPath:   "",
 			wantOK:     false,
 		},
 		{
 			name:       "apply root as substring but not prefix",
-			stagedPath: "/var/tmp/veil-test-extra/generated/caddy/Caddyfile",
+			stagedPath: "/var/tmp/veil-test-extra/generated/caddy/config.json",
 			wantPath:   "",
 			wantOK:     false,
 		},
 		// Paths without the generated prefix (under apply root but not in generated/)
 		{
 			name:       "staged directory instead of generated",
-			stagedPath: "/tmp/veil-test/staged/caddy/Caddyfile",
+			stagedPath: "/tmp/veil-test/staged/caddy/config.json",
 			wantPath:   "",
 			wantOK:     false,
 		},
 		{
 			name:       "live directory instead of generated",
-			stagedPath: "/tmp/veil-test/live/caddy/Caddyfile",
+			stagedPath: "/tmp/veil-test/live/caddy/config.json",
 			wantPath:   "",
 			wantOK:     false,
 		},
@@ -86,7 +86,7 @@ func TestLivePathForStagedConfig(t *testing.T) {
 		},
 		{
 			name:       "just generated prefix no root",
-			stagedPath: "generated/caddy/Caddyfile",
+			stagedPath: "generated/caddy/config.json",
 			wantPath:   "",
 			wantOK:     false,
 		},
@@ -112,9 +112,9 @@ func TestLivePathForStagedConfigTrailingSlashRoot(t *testing.T) {
 		applyRoot: "/tmp/veil-test/",
 	}
 
-	gotPath, gotOK := state.livePathForStagedConfig("/tmp/veil-test/generated/caddy/Caddyfile")
+	gotPath, gotOK := state.livePathForStagedConfig("/tmp/veil-test/generated/caddy/config.json")
 	gotPath = filepath.ToSlash(gotPath)
-	wantPath := "/tmp/veil-test/live/caddy/Caddyfile"
+	wantPath := "/tmp/veil-test/live/caddy/config.json"
 	if gotPath != wantPath {
 		t.Fatalf("path = %q, want %q", gotPath, wantPath)
 	}

--- a/internal/api/management_settings_test.go
+++ b/internal/api/management_settings_test.go
@@ -150,9 +150,12 @@ func TestHandleSettingsRejectsFallbackRootPathTraversal(t *testing.T) {
 	}{
 		{"PUT /var/lib/veil/www → 200", "/var/lib/veil/www", http.StatusOK, true},
 		{"PUT /var/lib/veil/custom/path → 200", "/var/lib/veil/custom/path", http.StatusOK, true},
-		{"PUT /etc/passwd → 200 (normalized into /var/lib/veil)", "/etc/passwd", http.StatusOK, true},
-		{"PUT /var/lib/veil/../../../etc → 200 (normalized)", "/var/lib/veil/../../../etc", http.StatusOK, true},
-		{"PUT traversal attempt → 200 (contained by prepend)", "/var/lib/veil/../../../../etc", http.StatusOK, true},
+		{"PUT /var/lib/veil → 200", "/var/lib/veil", http.StatusOK, true},
+		{"PUT /etc/passwd → 400", "/etc/passwd", http.StatusBadRequest, false},
+		{"PUT /var/lib/veil2 → 400 (boundary prefix)", "/var/lib/veil2", http.StatusBadRequest, false},
+		{"PUT /var/lib/veil-evil → 400 (boundary prefix)", "/var/lib/veil-evil", http.StatusBadRequest, false},
+		{"PUT /var/lib/veil/../../../etc → 400", "/var/lib/veil/../../../etc", http.StatusBadRequest, false},
+		{"PUT traversal attempt → 400", "/var/lib/veil/../../../../etc", http.StatusBadRequest, false},
 		{"PUT empty → 200", "", http.StatusOK, false},
 		{"PUT relative/path → 200", "relative/path", http.StatusOK, true},
 	}

--- a/internal/api/management_state_lifecycle.go
+++ b/internal/api/management_state_lifecycle.go
@@ -158,7 +158,16 @@ func (l ManagementStateLifecycle) Load() error {
 		return nil
 	}
 	ApplyManagementSnapshot(l.state, snapshot)
+	// Keep a committed snapshot that represents the state currently backing the
+	// live generated configs. It is updated after each successful apply and is
+	// used to restore settings/inbounds during rollback.
+	_ = l.commitCurrentSnapshotLocked()
 	return nil
+}
+
+func (l ManagementStateLifecycle) commitCurrentSnapshotLocked() error {
+	committedPath := filepath.Join(l.state.applyRoot, "generated", "veil", "committed-management-state.json")
+	return managementstate.NewStore(committedPath, l.state.cipher).Save(l.SnapshotLocked())
 }
 
 func (l ManagementStateLifecycle) ReloadLocked() error {

--- a/internal/api/management_state_validation_test.go
+++ b/internal/api/management_state_validation_test.go
@@ -24,7 +24,7 @@ func TestManagementStateValidationUsesStrictStateCodec(t *testing.T) {
 
 func TestManagementStateValidationReusesApplyPlanIntent(t *testing.T) {
 	body := []byte(`{
-		"settings":{"panelListen":"127.0.0.1:2096","panelAccess":"caddy","webBasePath":"/panel/","mode":"dev","domain":"panel.example.com","email":"admin@example.com"},
+		"settings":{"panelListen":"127.0.0.1:2096","panelAccess":"caddy","webBasePath":"/panel/","mode":"dev","panelDomain":"panel.example.com","panelEmail":"admin@example.com"},
 		"inbounds":[{"name":"mieru-tcp","protocol":"mieru","transport":"tcp","port":443,"enabled":true,"password":"secret"}],
 		"routingRules":[],
 		"warp":{"enabled":false,"endpoint":"engage.cloudflareclient.com:2408"}
@@ -34,7 +34,17 @@ func TestManagementStateValidationReusesApplyPlanIntent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ValidateBytes: %v", err)
 	}
-	if result.Valid || !containsString(result.Errors, "panel caddy access uses 443/tcp; choose another TCP port for inbound mieru-tcp") {
-		t.Fatalf("expected Apply plan intent error, got %+v", result)
+	if result.Valid {
+		t.Fatalf("expected invalid plan, got %+v", result)
+	}
+	found := false
+	for _, err := range result.Errors {
+		if strings.Contains(err, "is claimed by multiple owners") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected bind conflict error, got %+v", result.Errors)
 	}
 }

--- a/internal/api/panel_caddy_naive_apply_test.go
+++ b/internal/api/panel_caddy_naive_apply_test.go
@@ -22,14 +22,14 @@ func TestGeneratedConfigSetRendersPanelCaddyAccessWithoutNaiveInbound(t *testing
 	if err != nil {
 		t.Fatalf("BuildGeneratedConfigSet: %v", err)
 	}
-	caddyfile := configs[filepath.Join(root, "generated", "caddy", "panel.Caddyfile")]
-	for _, want := range []string{"panel.example.com", "issuer acme", "issuer internal", "handle /panel-secret/*", "reverse_proxy 127.0.0.1:2096"} {
-		if !strings.Contains(caddyfile, want) {
-			t.Fatalf("Panel Caddyfile missing %q:\n%s", want, caddyfile)
+	caddyJSON := configs[filepath.Join(root, "generated", "caddy", "config.json")]
+	for _, want := range []string{"panel.example.com", `"handler": "reverse_proxy"`, `"dial": "127.0.0.1:2096"`} {
+		if !strings.Contains(caddyJSON, want) {
+			t.Fatalf("Panel Caddy JSON missing %q:\n%s", want, caddyJSON)
 		}
 	}
-	if strings.Contains(caddyfile, "forward_proxy") {
-		t.Fatalf("Panel-only Caddyfile should not include NaiveProxy forward_proxy:\n%s", caddyfile)
+	if strings.Contains(caddyJSON, `"handler": "forward_proxy"`) {
+		t.Fatalf("Panel-only Caddy JSON should not include NaiveProxy forward_proxy:\n%s", caddyJSON)
 	}
 }
 
@@ -53,10 +53,10 @@ func TestNaiveGeneratedConfigPreservesPanelCaddyAccessRoute(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildGeneratedConfigSet: %v", err)
 	}
-	caddyfile := configs[filepath.Join(root, "generated", "caddy", "naive.Caddyfile")]
-	for _, want := range []string{"forward_proxy", "basic_auth veil naive-secret", "handle /panel-secret/*", "reverse_proxy 127.0.0.1:2096"} {
-		if !strings.Contains(caddyfile, want) {
-			t.Fatalf("Caddyfile missing %q:\n%s", want, caddyfile)
+	caddyJSON := configs[filepath.Join(root, "generated", "caddy", "config.json")]
+	for _, want := range []string{`"handler": "forward_proxy"`, `"handler": "reverse_proxy"`, `"dial": "127.0.0.1:2096"`} {
+		if !strings.Contains(caddyJSON, want) {
+			t.Fatalf("Caddy JSON missing %q:\n%s", want, caddyJSON)
 		}
 	}
 }
@@ -71,8 +71,8 @@ func TestNaiveGeneratedConfigWithoutPanelCaddyDoesNotExposePanelRoute(t *testing
 	if err != nil {
 		t.Fatalf("BuildGeneratedConfigSet: %v", err)
 	}
-	caddyfile := configs[filepath.Join(root, "generated", "caddy", "naive.Caddyfile")]
-	if strings.Contains(caddyfile, "reverse_proxy 127.0.0.1:2096") || strings.Contains(caddyfile, "handle /panel-secret/*") {
-		t.Fatalf("Caddyfile should not include Panel Caddy access route:\n%s", caddyfile)
+	caddyJSON := configs[filepath.Join(root, "generated", "caddy", "config.json")]
+	if strings.Contains(caddyJSON, `"dial": "127.0.0.1:2096"`) || strings.Contains(caddyJSON, `"path": ["/panel-secret/`) {
+		t.Fatalf("Caddy JSON should not include Panel Caddy access route:\n%s", caddyJSON)
 	}
 }

--- a/internal/api/panel_caddy_naive_apply_test.go
+++ b/internal/api/panel_caddy_naive_apply_test.go
@@ -11,12 +11,12 @@ func TestGeneratedConfigSetRendersPanelCaddyAccessWithoutNaiveInbound(t *testing
 	configs, err := BuildGeneratedConfigSet(GeneratedConfigInput{
 		ApplyRoot: root,
 		Settings: Settings{
-			PanelListen: "127.0.0.1:2096",
-			PanelAccess: "caddy",
-			WebBasePath: "/panel-secret/",
-			Mode:        "server",
-			Domain:      "panel.example.com",
-			Email:       "admin@example.com",
+			PanelListen:      "127.0.0.1:2096",
+			PanelAccess:      "caddy",
+			WebBasePath:      "/panel-secret/",
+			Mode:             "server",
+			Domain:           "panel.example.com",
+			DefaultAcmeEmail: "admin@example.com",
 		},
 	})
 	if err != nil {
@@ -38,15 +38,15 @@ func TestNaiveGeneratedConfigPreservesPanelCaddyAccessRoute(t *testing.T) {
 	configs, err := BuildGeneratedConfigSet(GeneratedConfigInput{
 		ApplyRoot: root,
 		Settings: Settings{
-			PanelListen:   "127.0.0.1:2096",
-			PanelAccess:   "caddy",
-			WebBasePath:   "/panel-secret/",
-			Mode:          "server",
-			Domain:        "vpn.example.com",
-			Email:         "admin@example.com",
-			NaiveUsername: "veil",
-			NaivePassword: "naive-secret",
-			FallbackRoot:  "/var/lib/veil/www",
+			PanelListen:      "127.0.0.1:2096",
+			PanelAccess:      "caddy",
+			WebBasePath:      "/panel-secret/",
+			Mode:             "server",
+			Domain:           "vpn.example.com",
+			DefaultAcmeEmail: "admin@example.com",
+			NaiveUsername:    "veil",
+			NaivePassword:    "naive-secret",
+			FallbackRoot:     "/var/lib/veil/www",
 		},
 		Inbounds: []Inbound{{Name: "naive", Protocol: "naiveproxy", Transport: "tcp", Port: 443, Enabled: true}},
 	})
@@ -65,7 +65,7 @@ func TestNaiveGeneratedConfigWithoutPanelCaddyDoesNotExposePanelRoute(t *testing
 	root := t.TempDir()
 	configs, err := BuildGeneratedConfigSet(GeneratedConfigInput{
 		ApplyRoot: root,
-		Settings:  Settings{PanelListen: "127.0.0.1:2096", Mode: "server", Domain: "vpn.example.com", Email: "admin@example.com", NaiveUsername: "veil", NaivePassword: "naive-secret", FallbackRoot: "/var/lib/veil/www"},
+		Settings:  Settings{PanelListen: "127.0.0.1:2096", Mode: "server", Domain: "vpn.example.com", DefaultAcmeEmail: "admin@example.com", NaiveUsername: "veil", NaivePassword: "naive-secret", FallbackRoot: "/var/lib/veil/www"},
 		Inbounds:  []Inbound{{Name: "naive", Protocol: "naiveproxy", Transport: "tcp", Port: 443, Enabled: true}},
 	})
 	if err != nil {

--- a/internal/api/privileged_local.go
+++ b/internal/api/privileged_local.go
@@ -33,7 +33,7 @@ func newLocalPrivilegedClient(state *managementState) privileged.Client {
 		BackupRoot:           state.backupDir,
 		UpdateRoot:           filepath.Join(stateRoot, "updates"),
 		ManagedUnits:         units,
-		ManagedUnitPrefixes:  []string{"veil-caddy@", "veil-hysteria2@", "veil-olcrtc@"},
+		ManagedUnitPrefixes:  []string{"veil-caddy.service", "veil-hysteria2@", "veil-olcrtc@"},
 		UpdateArtifacts:      map[string]string{"veil-update": "veil-update.tar.gz"},
 		Artifacts:            map[string]privileged.ArtifactPath{},
 		FirewallRules:        map[string]struct{}{},

--- a/internal/api/privileged_routes_test.go
+++ b/internal/api/privileged_routes_test.go
@@ -39,7 +39,7 @@ func (c *recordingPrivilegedClient) Promote(_ context.Context, request privilege
 
 func TestPrivilegedApplyUsesLogicalArtifactIDsAndOpaqueRollback(t *testing.T) {
 	root := t.TempDir()
-	staged := filepath.Join(root, "generated", "caddy", "edge.Caddyfile")
+	staged := filepath.Join(root, "generated", "caddy", "config.json")
 	if err := os.MkdirAll(filepath.Dir(staged), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -50,7 +50,7 @@ func TestPrivilegedApplyUsesLogicalArtifactIDsAndOpaqueRollback(t *testing.T) {
 		statusActiveState: "inactive", // WARP is not running in this caddy-only scenario
 		promoteResult: privileged.PromoteResult{
 			BackupID:         "20260605T120000.000000000Z",
-			WrittenArtifacts: []string{"caddy/edge.Caddyfile"},
+			WrittenArtifacts: []string{"caddy/config.json"},
 		},
 	}
 	state := newManagementState(ServerInfo{Mode: "dev", ApplyRoot: root, Privileged: client})
@@ -60,11 +60,11 @@ func TestPrivilegedApplyUsesLogicalArtifactIDsAndOpaqueRollback(t *testing.T) {
 		t.Fatalf("promote staged configs: %v", err)
 	}
 	if !reflect.DeepEqual(client.promotions, []privileged.PromoteRequest{{
-		ArtifactIDs: []string{"caddy/edge.Caddyfile"},
+		ArtifactIDs: []string{"caddy/config.json"},
 	}}) {
 		t.Fatalf("promotion requests=%+v", client.promotions)
 	}
-	if !reflect.DeepEqual(liveFiles, []string{filepath.Join(root, "live", "caddy", "edge.Caddyfile")}) {
+	if !reflect.DeepEqual(liveFiles, []string{filepath.Join(root, "live", "caddy", "config.json")}) {
 		t.Fatalf("live files=%+v", liveFiles)
 	}
 	if len(records) != 1 || records[0].BackupID != "20260605T120000.000000000Z" {
@@ -73,7 +73,7 @@ func TestPrivilegedApplyUsesLogicalArtifactIDsAndOpaqueRollback(t *testing.T) {
 
 	client.promoteResult = privileged.PromoteResult{
 		BackupID:         "20260605T120000.000000000Z",
-		WrittenArtifacts: []string{"caddy/edge.Caddyfile"},
+		WrittenArtifacts: []string{"caddy/config.json"},
 	}
 	rollbackFiles, _ := context.rollbackPromotedConfigsLocked(records, liveFiles)
 	if len(client.promotions) != 2 || client.promotions[1].RestoreBackupID != "20260605T120000.000000000Z" {

--- a/internal/api/privileged_routes_test.go
+++ b/internal/api/privileged_routes_test.go
@@ -88,10 +88,10 @@ func TestPrivilegedApplyHealthChecksUseHelperStatus(t *testing.T) {
 	client := &recordingPrivilegedClient{}
 	state := newManagementState(ServerInfo{Mode: "dev", Privileged: client})
 	results := NewManagementApplyContext(state).checkServiceHealthLocked([]ServiceActionResult{{
-		Name: "veil-caddy@panel.service", Success: true,
+		Name: "veil-mieru.service", Success: true,
 	}})
 	if !reflect.DeepEqual(client.statusRequests, []privileged.ServiceStatusRequest{{
-		Units: []string{"veil-caddy@panel.service"},
+		Units: []string{"veil-mieru.service"},
 	}}) {
 		t.Fatalf("status requests=%+v", client.statusRequests)
 	}
@@ -190,7 +190,7 @@ func TestPrivilegedServiceStatusAndLogsUseManagedUnits(t *testing.T) {
 	client := &recordingPrivilegedClient{}
 	router, _ := NewRouter(ServerInfo{Version: "test", Mode: "dev", Privileged: client})
 
-	restart := httptest.NewRequest(http.MethodPost, "/api/services/caddy-panel/restart", strings.NewReader(`{"confirm":true}`))
+	restart := httptest.NewRequest(http.MethodPost, "/api/services/mieru/restart", strings.NewReader(`{"confirm":true}`))
 	restart.Header.Set("Content-Type", "application/json")
 	restartResponse := httptest.NewRecorder()
 	router.ServeHTTP(restartResponse, restart)
@@ -198,7 +198,7 @@ func TestPrivilegedServiceStatusAndLogsUseManagedUnits(t *testing.T) {
 		t.Fatalf("restart status=%d body=%s", restartResponse.Code, restartResponse.Body.String())
 	}
 	wantAction := privileged.ServiceActionRequest{
-		Unit: "veil-caddy@panel.service", Action: privileged.ServiceActionRestart,
+		Unit: "veil-mieru.service", Action: privileged.ServiceActionRestart,
 	}
 	if !reflect.DeepEqual(client.serviceActions, []privileged.ServiceActionRequest{wantAction}) {
 		t.Fatalf("service actions=%+v", client.serviceActions)
@@ -216,12 +216,12 @@ func TestPrivilegedServiceStatusAndLogsUseManagedUnits(t *testing.T) {
 	}
 
 	logResponse := httptest.NewRecorder()
-	router.ServeHTTP(logResponse, httptest.NewRequest(http.MethodGet, "/api/logs?unit=caddy-panel&lines=500", nil))
+	router.ServeHTTP(logResponse, httptest.NewRequest(http.MethodGet, "/api/logs?unit=mieru&lines=500", nil))
 	if logResponse.Code != http.StatusOK {
 		t.Fatalf("logs status=%d body=%s", logResponse.Code, logResponse.Body.String())
 	}
 	if !reflect.DeepEqual(client.journals, []privileged.JournalRequest{{
-		Unit: "veil-caddy@panel.service", Lines: 500,
+		Unit: "veil-mieru.service", Lines: 500,
 	}}) {
 		t.Fatalf("journal requests=%+v", client.journals)
 	}

--- a/internal/api/profile_preview_routes.go
+++ b/internal/api/profile_preview_routes.go
@@ -18,7 +18,7 @@ type RURecommendedPreviewResponse struct {
 	Email       string `json:"email"`
 	PanelAccess string `json:"panelAccess"`
 	PanelURL    string `json:"panelUrl,omitempty"`
-	Caddyfile   string `json:"caddyfile,omitempty"`
+	CaddyJSON   string `json:"caddyJSON,omitempty"`
 }
 
 type ProfilePreviewRoutes struct{}
@@ -56,7 +56,7 @@ func (ProfilePreviewRoutes) handleRURecommendedPreview(w http.ResponseWriter, r 
 		Email:       profile.Email,
 		PanelAccess: req.PanelAccess,
 		PanelURL:    panelURL,
-		Caddyfile:   redactProfileSecrets(profile, profile.Caddyfile),
+		CaddyJSON:   redactProfileSecrets(profile, profile.CaddyJSON),
 	})
 }
 

--- a/internal/api/promoted_service_reload_test.go
+++ b/internal/api/promoted_service_reload_test.go
@@ -10,22 +10,26 @@ import (
 func TestPromotedServiceReloaderRunsExpectedReloads(t *testing.T) {
 	root := t.TempDir()
 	commands := [][]string{}
-	reloader := service.NewPromotedServiceReloader(root, NewManagedRuntimeCatalog(), func(command []string) ServiceActionResult {
+	catalog := NewManagedRuntimeCatalogFor([]Inbound{
+		{Name: "naive", Protocol: "naiveproxy", Enabled: true},
+		{Name: "h", Protocol: "hysteria2", Enabled: true},
+	}, WarpConfig{})
+	reloader := service.NewPromotedServiceReloader(root, catalog, func(command []string) ServiceActionResult {
 		commands = append(commands, append([]string(nil), command...))
 		return ServiceActionResult{Success: true}
 	})
 
 	results := reloader.Reload([]string{
-		filepath.Join(root, "live", "caddy", "panel.Caddyfile"),
-		filepath.Join(root, "live", "hysteria2", "server.yaml"),
+		filepath.Join(root, "live", "caddy", "config.json"),
+		filepath.Join(root, "live", "hysteria2", "h.yaml"),
 	})
 	if len(results) != 2 || len(commands) != 2 {
 		t.Fatalf("results=%+v commands=%+v", results, commands)
 	}
-	if commands[0][2] != "veil-caddy@panel.service" || commands[1][2] != "veil-hysteria2@.service" {
+	if commands[0][2] != "veil-hysteria2@h.service" || commands[1][2] != "veil-caddy.service" {
 		t.Fatalf("commands = %+v", commands)
 	}
-	if results[0].Name != "veil-caddy@panel.service" || results[1].Name != "veil-hysteria2@.service" {
+	if results[0].Name != "veil-hysteria2@h.service" || results[1].Name != "veil-caddy.service" {
 		t.Fatalf("result names = %+v", results)
 	}
 }

--- a/internal/api/router_core_test.go
+++ b/internal/api/router_core_test.go
@@ -210,7 +210,7 @@ func TestStatusEndpointIncludesRuntimeServiceStates(t *testing.T) {
 		switch unit {
 		case "veil.service":
 			return ServiceRuntimeStatus{Unit: unit, LoadState: "loaded", ActiveState: "active", SubState: "running"}
-		case "veil-caddy@panel.service":
+		case "veil-mieru.service":
 			return ServiceRuntimeStatus{Unit: unit, LoadState: "loaded", ActiveState: "inactive", SubState: "dead"}
 		default:
 			return ServiceRuntimeStatus{Unit: unit, LoadState: "not-found", ActiveState: "unknown", SubState: "unknown", Error: "unit not found"}
@@ -250,8 +250,8 @@ func TestStatusEndpointIncludesRuntimeServiceStates(t *testing.T) {
 	if services["veil"].Unit != "veil.service" || services["veil"].ActiveState != "active" || services["veil"].SubState != "running" {
 		t.Fatalf("veil runtime status not included: %+v", services["veil"])
 	}
-	if services["caddy-panel"].Unit != "veil-caddy@panel.service" || services["caddy-panel"].ActiveState != "inactive" || services["caddy-panel"].SubState != "dead" {
-		t.Fatalf("naive/caddy runtime status not included: %+v", services["caddy-panel"])
+	if services["mieru"].Unit != "veil-mieru.service" || services["mieru"].ActiveState != "inactive" || services["mieru"].SubState != "dead" {
+		t.Fatalf("mieru runtime status not included: %+v", services["mieru"])
 	}
 	if services["hysteria2"].Unit != "veil-hysteria2@.service" || services["hysteria2"].ActiveState != "unknown" || services["hysteria2"].Error == "" {
 		t.Fatalf("hysteria2 runtime status error not included: %+v", services["hysteria2"])
@@ -349,8 +349,8 @@ func TestRouterStatus(t *testing.T) {
 	if body.Name != "Veil" || body.Version != "test" || body.Mode != "dev" {
 		t.Fatalf("unexpected status: %+v", body)
 	}
-	if len(body.Services) != 6 {
-		t.Fatalf("expected 6 services, got %+v", body.Services)
+	if len(body.Services) != 5 {
+		t.Fatalf("expected 5 services, got %+v", body.Services)
 	}
 }
 

--- a/internal/api/router_management_apply_json_test.go
+++ b/internal/api/router_management_apply_json_test.go
@@ -120,7 +120,7 @@ func TestManagementApplyStagesRenderedConfigsFromManagementState(t *testing.T) {
 			"panelListen":"127.0.0.1:2096",
 			"mode":"dev",
 			"domain":"vpn.example.com",
-			"email":"admin@example.com",
+			"defaultAcmeEmail":"admin@example.com",
 			"naiveUsername":"veil",
 			"naivePassword":"naive-secret",
 			"hysteria2Password":"hy2-secret",
@@ -179,7 +179,7 @@ func TestManagementApplyStagesWarpOutboundWhenEnabled(t *testing.T) {
 			"panelListen":"127.0.0.1:2096",
 			"mode":"dev",
 			"domain":"vpn.example.com",
-			"email":"admin@example.com",
+			"defaultAcmeEmail":"admin@example.com",
 			"hysteria2Password":"hy2-secret"
 		},
 		"inbounds":[{"name":"hysteria2","protocol":"hysteria2","transport":"udp","port":443,"enabled":true}],
@@ -236,7 +236,7 @@ func TestManagementApplyRunsFixedValidatorsForStagedRenderedConfigs(t *testing.T
 			"panelListen":"127.0.0.1:2096",
 			"mode":"dev",
 			"domain":"vpn.example.com",
-			"email":"admin@example.com",
+			"defaultAcmeEmail":"admin@example.com",
 			"naiveUsername":"veil",
 			"naivePassword":"naive-secret",
 			"hysteria2Password":"hy2-secret"
@@ -286,7 +286,7 @@ func TestManagementApplyReportsValidatorFailureWithoutSystemdSideEffects(t *test
 			"panelListen":"127.0.0.1:2096",
 			"mode":"dev",
 			"domain":"vpn.example.com",
-			"email":"admin@example.com",
+			"defaultAcmeEmail":"admin@example.com",
 			"naiveUsername":"veil",
 			"naivePassword":"naive-secret"
 		},

--- a/internal/api/router_management_apply_json_test.go
+++ b/internal/api/router_management_apply_json_test.go
@@ -255,7 +255,7 @@ func TestManagementApplyRunsFixedValidatorsForStagedRenderedConfigs(t *testing.T
 	defer func() { stagedConfigValidator = old }()
 	stagedConfigValidator = func(paths []string) []ConfigValidationResult {
 		return []ConfigValidationResult{
-			{Name: "caddy", Config: filepath.Join(applyRoot, "generated", "caddy", "naive.Caddyfile"), Command: []string{"caddy", "validate", "--config", filepath.Join(applyRoot, "generated", "caddy", "naive.Caddyfile")}, Valid: true},
+			{Name: "caddy", Config: filepath.Join(applyRoot, "generated", "caddy", "config.json"), Command: []string{"caddy", "validate", "--config", filepath.Join(applyRoot, "generated", "caddy", "config.json")}, Valid: true},
 			{Name: "hysteria2", Config: filepath.Join(applyRoot, "generated", "hysteria2", "hysteria2.yaml"), Command: []string{"hysteria", "server", "--config", filepath.Join(applyRoot, "generated", "hysteria2", "hysteria2.yaml"), "--check"}, Valid: true},
 		}
 	}

--- a/internal/api/router_management_apply_json_test.go
+++ b/internal/api/router_management_apply_json_test.go
@@ -149,7 +149,7 @@ func TestManagementApplyStagesRenderedConfigsFromManagementState(t *testing.T) {
 	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	caddyPath := filepath.Join(applyRoot, "generated", "caddy", "naive.Caddyfile")
+	caddyPath := filepath.Join(applyRoot, "generated", "caddy", "config.json")
 	hy2Path := filepath.Join(applyRoot, "generated", "hysteria2", "hysteria2.yaml")
 	if !containsString(response.WrittenFiles, caddyPath) || !containsString(response.WrittenFiles, hy2Path) {
 		t.Fatalf("apply response missing rendered configs: %+v", response.WrittenFiles)
@@ -158,7 +158,7 @@ func TestManagementApplyStagesRenderedConfigsFromManagementState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read caddy config: %v", err)
 	}
-	if !strings.Contains(string(caddyBody), "vpn.example.com") || !strings.Contains(string(caddyBody), "basic_auth veil naive-secret") || !strings.Contains(string(caddyBody), "protocols h1 h2") {
+	if !strings.Contains(string(caddyBody), "vpn.example.com") || !strings.Contains(string(caddyBody), `"handler": "forward_proxy"`) {
 		t.Fatalf("unexpected caddy config: %s", string(caddyBody))
 	}
 	hy2Body, err := os.ReadFile(hy2Path)

--- a/internal/api/router_management_apply_live_services_test.go
+++ b/internal/api/router_management_apply_live_services_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -295,10 +296,12 @@ func TestManagementApplyServicesRunsAllowlistedReloadsAfterLivePromotion(t *test
 	oldValidator := stagedConfigValidator
 	oldRunner := serviceActionRunner
 	oldHealth := serviceHealthChecker
+	oldLoader := caddyAdminLoader
 	defer func() {
 		stagedConfigValidator = oldValidator
 		serviceActionRunner = oldRunner
 		serviceHealthChecker = oldHealth
+		caddyAdminLoader = oldLoader
 	}()
 	stagedConfigValidator = func(paths []string) []ConfigValidationResult {
 		results := make([]ConfigValidationResult, 0, len(paths))
@@ -311,6 +314,11 @@ func TestManagementApplyServicesRunsAllowlistedReloadsAfterLivePromotion(t *test
 	serviceActionRunner = func(command []string) ServiceActionResult {
 		serviceCalls = append(serviceCalls, append([]string(nil), command...))
 		return ServiceActionResult{Name: command[len(command)-1], Command: command, Success: true}
+	}
+	var adminLoads [][]byte
+	caddyAdminLoader = func(configJSON []byte) error {
+		adminLoads = append(adminLoads, append([]byte(nil), configJSON...))
+		return nil
 	}
 	serviceHealthChecker = func(service string) ServiceHealthResult {
 		return ServiceHealthResult{Name: service, Command: []string{"systemctl", "is-active", "--quiet", service}, Healthy: true}
@@ -327,44 +335,51 @@ func TestManagementApplyServicesRunsAllowlistedReloadsAfterLivePromotion(t *test
 	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	expectedCaddy := []string{"systemctl", "reload", "veil-caddy.service"}
-	expectedHy2 := []string{"systemctl", "restart", "veil-hysteria2@hysteria2.service"}
-	if !response.ServicesApplied || len(response.ServiceActions) != 2 || len(serviceCalls) != 2 {
-		t.Fatalf("expected two service actions: response=%+v calls=%+v", response, serviceCalls)
+	if len(adminLoads) != 1 {
+		t.Fatalf("expected one Caddy Admin API load, got %d", len(adminLoads))
 	}
-	if !stringSlicesEqual(serviceCalls[0], expectedHy2) || !stringSlicesEqual(serviceCalls[1], expectedCaddy) {
+	if !strings.Contains(string(adminLoads[0]), "vpn.example.com") {
+		t.Fatalf("expected admin load to use live caddy config, got %s", string(adminLoads[0]))
+	}
+	expectedHy2 := []string{"systemctl", "restart", "veil-hysteria2@hysteria2.service"}
+	if !response.ServicesApplied || len(response.ServiceActions) != 2 || len(serviceCalls) != 1 {
+		t.Fatalf("expected caddy via admin API plus one systemctl call: response=%+v calls=%+v", response, serviceCalls)
+	}
+	if !stringSlicesEqual(serviceCalls[0], expectedHy2) {
 		t.Fatalf("unexpected service calls: %+v", serviceCalls)
 	}
-	if !response.ServiceActions[0].Success || !response.ServiceActions[1].Success {
-		t.Fatalf("expected successful service action results: %+v", response.ServiceActions)
+	if response.ServiceActions[0].Name != "veil-hysteria2@hysteria2.service" || !response.ServiceActions[0].Success {
+		t.Fatalf("expected successful Hysteria2 result: %+v", response.ServiceActions)
+	}
+	if response.ServiceActions[1].Name != "veil-caddy.service" || !response.ServiceActions[1].Success {
+		t.Fatalf("expected successful Caddy Admin API result: %+v", response.ServiceActions)
 	}
 }
 
 func TestManagementApplyServicesStopsOnReloadFailure(t *testing.T) {
 	statePath := filepath.Join(t.TempDir(), "state.json")
-	if err := writeRenderableManagementState(statePath, "dual"); err != nil {
+	if err := writeRenderableManagementState(statePath, "naive-only"); err != nil {
 		t.Fatalf("write state: %v", err)
 	}
 	oldValidator := stagedConfigValidator
 	oldRunner := serviceActionRunner
 	oldHealth := serviceHealthChecker
+	oldLoader := caddyAdminLoader
 	defer func() {
 		stagedConfigValidator = oldValidator
 		serviceActionRunner = oldRunner
 		serviceHealthChecker = oldHealth
+		caddyAdminLoader = oldLoader
 	}()
 	stagedConfigValidator = func(paths []string) []ConfigValidationResult {
-		results := make([]ConfigValidationResult, 0, len(paths))
-		for _, path := range paths {
-			results = append(results, ConfigValidationResult{Name: filepath.Base(path), Config: path, Valid: true})
-		}
-		return results
+		return []ConfigValidationResult{{Name: "caddy", Config: paths[0], Valid: true}}
 	}
 	serviceCalls := [][]string{}
 	serviceActionRunner = func(command []string) ServiceActionResult {
 		serviceCalls = append(serviceCalls, append([]string(nil), command...))
 		return ServiceActionResult{Name: command[len(command)-1], Command: command, Success: false, Error: "reload failed"}
 	}
+	caddyAdminLoader = func(configJSON []byte) error { return fmt.Errorf("admin load failed") }
 	r, _ := NewRouter(ServerInfo{Version: "test", Mode: "dev", StatePath: statePath, ApplyRoot: t.TempDir()})
 	w := httptest.NewRecorder()
 
@@ -377,8 +392,8 @@ func TestManagementApplyServicesStopsOnReloadFailure(t *testing.T) {
 	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if response.ServicesApplied || !response.RolledBack || len(response.ServiceActions) != 1 || response.ServiceActions[0].Error != "reload failed" || len(serviceCalls) != 2 {
-		t.Fatalf("expected failed service action followed by rollback reload: response=%+v calls=%+v", response, serviceCalls)
+	if response.ServicesApplied || !response.RolledBack || len(response.ServiceActions) != 2 || response.ServiceActions[0].Error != "admin load failed" || response.ServiceActions[1].Error != "reload failed" || len(serviceCalls) != 2 {
+		t.Fatalf("expected failed admin load and fallback reload, followed by rollback reload: response=%+v calls=%+v", response, serviceCalls)
 	}
 }
 
@@ -390,10 +405,12 @@ func TestManagementApplyServicesChecksHealthAfterReload(t *testing.T) {
 	oldValidator := stagedConfigValidator
 	oldRunner := serviceActionRunner
 	oldHealth := serviceHealthChecker
+	oldLoader := caddyAdminLoader
 	defer func() {
 		stagedConfigValidator = oldValidator
 		serviceActionRunner = oldRunner
 		serviceHealthChecker = oldHealth
+		caddyAdminLoader = oldLoader
 	}()
 	stagedConfigValidator = func(paths []string) []ConfigValidationResult {
 		return []ConfigValidationResult{{Name: "caddy", Config: paths[0], Valid: true}}
@@ -401,6 +418,7 @@ func TestManagementApplyServicesChecksHealthAfterReload(t *testing.T) {
 	serviceActionRunner = func(command []string) ServiceActionResult {
 		return ServiceActionResult{Name: command[len(command)-1], Command: command, Success: true}
 	}
+	caddyAdminLoader = func(configJSON []byte) error { return nil }
 	healthCalls := [][]string{}
 	serviceHealthChecker = func(service string) ServiceHealthResult {
 		healthCalls = append(healthCalls, []string{"systemctl", "is-active", "--quiet", service})
@@ -417,6 +435,9 @@ func TestManagementApplyServicesChecksHealthAfterReload(t *testing.T) {
 	var response ApplyResponse
 	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
 		t.Fatalf("decode response: %v", err)
+	}
+	if len(response.ServiceActions) != 1 || response.ServiceActions[0].Name != "veil-caddy.service" || !response.ServiceActions[0].Success {
+		t.Fatalf("expected successful Caddy Admin API action: %+v", response.ServiceActions)
 	}
 	if len(response.HealthChecks) != 1 || !response.HealthChecks[0].Healthy || len(healthCalls) != 1 {
 		t.Fatalf("expected one successful health check: response=%+v calls=%+v", response.HealthChecks, healthCalls)
@@ -439,10 +460,12 @@ func TestManagementApplyServicesRollsBackLiveConfigOnHealthFailure(t *testing.T)
 	oldValidator := stagedConfigValidator
 	oldRunner := serviceActionRunner
 	oldHealth := serviceHealthChecker
+	oldLoader := caddyAdminLoader
 	defer func() {
 		stagedConfigValidator = oldValidator
 		serviceActionRunner = oldRunner
 		serviceHealthChecker = oldHealth
+		caddyAdminLoader = oldLoader
 	}()
 	stagedConfigValidator = func(paths []string) []ConfigValidationResult {
 		return []ConfigValidationResult{{Name: "caddy", Config: paths[0], Valid: true}}
@@ -451,6 +474,11 @@ func TestManagementApplyServicesRollsBackLiveConfigOnHealthFailure(t *testing.T)
 	serviceActionRunner = func(command []string) ServiceActionResult {
 		serviceCalls = append(serviceCalls, append([]string(nil), command...))
 		return ServiceActionResult{Name: command[len(command)-1], Command: command, Success: true}
+	}
+	var adminLoads [][]byte
+	caddyAdminLoader = func(configJSON []byte) error {
+		adminLoads = append(adminLoads, append([]byte(nil), configJSON...))
+		return nil
 	}
 	serviceHealthChecker = func(service string) ServiceHealthResult {
 		return ServiceHealthResult{Name: service, Command: []string{"systemctl", "is-active", "--quiet", service}, Healthy: false, Error: "service unhealthy"}
@@ -477,9 +505,11 @@ func TestManagementApplyServicesRollsBackLiveConfigOnHealthFailure(t *testing.T)
 	if string(body) != "old caddy\n" {
 		t.Fatalf("expected rollback to restore old live config, got %q", string(body))
 	}
-	expected := [][]string{{"systemctl", "reload", "veil-caddy.service"}, {"systemctl", "reload", "veil-caddy.service"}}
-	if len(serviceCalls) != len(expected) || !stringSlicesEqual(serviceCalls[0], expected[0]) || !stringSlicesEqual(serviceCalls[1], expected[1]) {
-		t.Fatalf("expected reload before and after rollback: %+v", serviceCalls)
+	if len(adminLoads) != 2 {
+		t.Fatalf("expected two Caddy Admin API loads (before and after rollback), got %d", len(adminLoads))
+	}
+	if len(serviceCalls) != 0 {
+		t.Fatalf("expected no systemctl calls when Admin API succeeds, got %+v", serviceCalls)
 	}
 }
 
@@ -492,10 +522,12 @@ func TestManagementApplyWritesAuditHistoryForSuccessfulServiceApply(t *testing.T
 	oldValidator := stagedConfigValidator
 	oldRunner := serviceActionRunner
 	oldHealth := serviceHealthChecker
+	oldLoader := caddyAdminLoader
 	defer func() {
 		stagedConfigValidator = oldValidator
 		serviceActionRunner = oldRunner
 		serviceHealthChecker = oldHealth
+		caddyAdminLoader = oldLoader
 	}()
 	stagedConfigValidator = func(paths []string) []ConfigValidationResult {
 		return []ConfigValidationResult{{Name: "caddy", Config: paths[0], Valid: true}}
@@ -503,6 +535,7 @@ func TestManagementApplyWritesAuditHistoryForSuccessfulServiceApply(t *testing.T
 	serviceActionRunner = func(command []string) ServiceActionResult {
 		return ServiceActionResult{Name: command[len(command)-1], Command: command, Success: true}
 	}
+	caddyAdminLoader = func(configJSON []byte) error { return nil }
 	serviceHealthChecker = func(service string) ServiceHealthResult {
 		return ServiceHealthResult{Name: service, Command: []string{"systemctl", "is-active", "--quiet", service}, Healthy: true}
 	}
@@ -551,10 +584,12 @@ func TestManagementApplyWritesAuditHistoryForRollback(t *testing.T) {
 	oldValidator := stagedConfigValidator
 	oldRunner := serviceActionRunner
 	oldHealth := serviceHealthChecker
+	oldLoader := caddyAdminLoader
 	defer func() {
 		stagedConfigValidator = oldValidator
 		serviceActionRunner = oldRunner
 		serviceHealthChecker = oldHealth
+		caddyAdminLoader = oldLoader
 	}()
 	stagedConfigValidator = func(paths []string) []ConfigValidationResult {
 		return []ConfigValidationResult{{Name: "caddy", Config: paths[0], Valid: true}}
@@ -562,6 +597,7 @@ func TestManagementApplyWritesAuditHistoryForRollback(t *testing.T) {
 	serviceActionRunner = func(command []string) ServiceActionResult {
 		return ServiceActionResult{Name: command[len(command)-1], Command: command, Success: true}
 	}
+	caddyAdminLoader = func(configJSON []byte) error { return nil }
 	serviceHealthChecker = func(service string) ServiceHealthResult {
 		return ServiceHealthResult{Name: service, Command: []string{"systemctl", "is-active", "--quiet", service}, Healthy: false, Error: "service unhealthy"}
 	}
@@ -593,12 +629,9 @@ func TestManagementApplyServicesCleansOrphanedInstances(t *testing.T) {
 	}
 	applyRoot := t.TempDir()
 
-	// Write the orphan config files to the live directories
-	orphanCaddy := filepath.Join(applyRoot, "live", "caddy", "orphan.Caddyfile")
+	// Write the orphan config files to the live directories. Caddy artifacts are
+	// now exclusively config.json and are not scanned as orphans.
 	orphanHysteria2 := filepath.Join(applyRoot, "live", "hysteria2", "orphan.yaml")
-	if err := atomicfile.Write(orphanCaddy, []byte("caddy config"), 0o600, 0o700); err != nil {
-		t.Fatalf("write orphan caddy: %v", err)
-	}
 	if err := atomicfile.Write(orphanHysteria2, []byte("hysteria2 config"), 0o600, 0o700); err != nil {
 		t.Fatalf("write orphan hysteria2: %v", err)
 	}
@@ -606,10 +639,12 @@ func TestManagementApplyServicesCleansOrphanedInstances(t *testing.T) {
 	oldValidator := stagedConfigValidator
 	oldRunner := serviceActionRunner
 	oldHealth := serviceHealthChecker
+	oldLoader := caddyAdminLoader
 	defer func() {
 		stagedConfigValidator = oldValidator
 		serviceActionRunner = oldRunner
 		serviceHealthChecker = oldHealth
+		caddyAdminLoader = oldLoader
 	}()
 
 	stagedConfigValidator = func(paths []string) []ConfigValidationResult {
@@ -626,6 +661,8 @@ func TestManagementApplyServicesCleansOrphanedInstances(t *testing.T) {
 		return ServiceActionResult{Name: command[len(command)-1], Command: command, Success: true}
 	}
 
+	caddyAdminLoader = func(configJSON []byte) error { return nil }
+
 	serviceHealthChecker = func(service string) ServiceHealthResult {
 		return ServiceHealthResult{Name: service, Command: []string{"systemctl", "is-active", "--quiet", service}, Healthy: true}
 	}
@@ -639,10 +676,7 @@ func TestManagementApplyServicesCleansOrphanedInstances(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	// Verify that orphans were removed
-	if _, err := os.Stat(orphanCaddy); !os.IsNotExist(err) {
-		t.Fatalf("orphan caddy config should be deleted, stat err: %v", err)
-	}
+	// Verify that the hysteria2 orphan was removed
 	if _, err := os.Stat(orphanHysteria2); !os.IsNotExist(err) {
 		t.Fatalf("orphan hysteria2 config should be deleted, stat err: %v", err)
 	}
@@ -675,12 +709,9 @@ func TestManagementApplyServicesRestoresOrphanedInstancesOnRollback(t *testing.T
 	}
 	applyRoot := t.TempDir()
 
-	// Write the orphan config files to the live directories
-	orphanCaddy := filepath.Join(applyRoot, "live", "caddy", "orphan.Caddyfile")
+	// Write the orphan config files to the live directories. Caddy artifacts are
+	// now exclusively config.json and are not scanned as orphans.
 	orphanHysteria2 := filepath.Join(applyRoot, "live", "hysteria2", "orphan.yaml")
-	if err := atomicfile.Write(orphanCaddy, []byte("caddy config"), 0o600, 0o700); err != nil {
-		t.Fatalf("write orphan caddy: %v", err)
-	}
 	if err := atomicfile.Write(orphanHysteria2, []byte("hysteria2 config"), 0o600, 0o700); err != nil {
 		t.Fatalf("write orphan hysteria2: %v", err)
 	}
@@ -688,10 +719,12 @@ func TestManagementApplyServicesRestoresOrphanedInstancesOnRollback(t *testing.T
 	oldValidator := stagedConfigValidator
 	oldRunner := serviceActionRunner
 	oldHealth := serviceHealthChecker
+	oldLoader := caddyAdminLoader
 	defer func() {
 		stagedConfigValidator = oldValidator
 		serviceActionRunner = oldRunner
 		serviceHealthChecker = oldHealth
+		caddyAdminLoader = oldLoader
 	}()
 
 	stagedConfigValidator = func(paths []string) []ConfigValidationResult {
@@ -708,6 +741,8 @@ func TestManagementApplyServicesRestoresOrphanedInstancesOnRollback(t *testing.T
 		return ServiceActionResult{Name: command[len(command)-1], Command: command, Success: true}
 	}
 
+	caddyAdminLoader = func(configJSON []byte) error { return nil }
+
 	// Make the health checker fail to trigger a rollback
 	serviceHealthChecker = func(service string) ServiceHealthResult {
 		return ServiceHealthResult{Name: service, Command: []string{"systemctl", "is-active", "--quiet", service}, Healthy: false, Error: "forced reload failure"}
@@ -722,8 +757,7 @@ func TestManagementApplyServicesRestoresOrphanedInstancesOnRollback(t *testing.T
 		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
 	}
 
-	// Verify that orphans were restored
-	assertFileBody(t, orphanCaddy, "caddy config")
+	// Verify that the hysteria2 orphan was restored
 	assertFileBody(t, orphanHysteria2, "hysteria2 config")
 
 	// Verify the service actions on rollback (enable/start for orphans). Caddy
@@ -745,5 +779,130 @@ func TestManagementApplyServicesRestoresOrphanedInstancesOnRollback(t *testing.T
 		if !found {
 			t.Fatalf("expected rollback call %v not found in service calls: %+v", expectedCall, serviceCalls)
 		}
+	}
+}
+
+
+func TestManagementApplyServicesFallsBackToSystemctlWhenCaddyAdminLoadFails(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	if err := writeRenderableManagementState(statePath, "naive-only"); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	applyRoot := t.TempDir()
+	oldValidator := stagedConfigValidator
+	oldRunner := serviceActionRunner
+	oldHealth := serviceHealthChecker
+	oldLoader := caddyAdminLoader
+	defer func() {
+		stagedConfigValidator = oldValidator
+		serviceActionRunner = oldRunner
+		serviceHealthChecker = oldHealth
+		caddyAdminLoader = oldLoader
+	}()
+	stagedConfigValidator = func(paths []string) []ConfigValidationResult {
+		return []ConfigValidationResult{{Name: "caddy", Config: paths[0], Valid: true}}
+	}
+	serviceCalls := [][]string{}
+	serviceActionRunner = func(command []string) ServiceActionResult {
+		serviceCalls = append(serviceCalls, append([]string(nil), command...))
+		return ServiceActionResult{Name: command[len(command)-1], Command: command, Success: false, Error: "reload failed"}
+	}
+	caddyAdminLoader = func(configJSON []byte) error {
+		return fmt.Errorf("admin load failed")
+	}
+	serviceHealthChecker = func(service string) ServiceHealthResult {
+		return ServiceHealthResult{Name: service, Command: []string{"systemctl", "is-active", "--quiet", service}, Healthy: true}
+	}
+	r, _ := NewRouter(ServerInfo{Version: "test", Mode: "dev", StatePath: statePath, ApplyRoot: applyRoot})
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/api/apply", strings.NewReader(`{"confirm":true,"applyLive":true,"applyServices":true}`)))
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	var response ApplyResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.ServicesApplied || !response.RolledBack || len(response.ServiceActions) != 2 {
+		t.Fatalf("expected failed admin load with fallback and rollback: response=%+v", response)
+	}
+	if response.ServiceActions[0].Name != "veil-caddy.service" || response.ServiceActions[0].Success {
+		t.Fatalf("expected failed Caddy Admin API result: %+v", response.ServiceActions)
+	}
+	if response.ServiceActions[1].Name != "veil-caddy.service" || response.ServiceActions[1].Error != "reload failed" {
+		t.Fatalf("expected fallback systemctl reload failure: %+v", response.ServiceActions)
+	}
+	if len(serviceCalls) != 2 || !stringSlicesEqual(serviceCalls[0], []string{"systemctl", "reload", "veil-caddy.service"}) {
+		t.Fatalf("expected fallback reload before rollback: %+v", serviceCalls)
+	}
+}
+
+func TestManagementApplyServicesRollsBackUsesCaddyAdminLoaderWithRestoredConfig(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	if err := writeRenderableManagementState(statePath, "naive-only"); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	applyRoot := t.TempDir()
+	liveCaddy := filepath.Join(applyRoot, "live", "caddy", "config.json")
+	if err := atomicfile.Write(liveCaddy, []byte("old caddy\n"), 0o600, 0o700); err != nil {
+		t.Fatalf("write existing live caddy: %v", err)
+	}
+	oldValidator := stagedConfigValidator
+	oldRunner := serviceActionRunner
+	oldHealth := serviceHealthChecker
+	oldLoader := caddyAdminLoader
+	defer func() {
+		stagedConfigValidator = oldValidator
+		serviceActionRunner = oldRunner
+		serviceHealthChecker = oldHealth
+		caddyAdminLoader = oldLoader
+	}()
+	stagedConfigValidator = func(paths []string) []ConfigValidationResult {
+		return []ConfigValidationResult{{Name: "caddy", Config: paths[0], Valid: true}}
+	}
+	serviceCalls := [][]string{}
+	serviceActionRunner = func(command []string) ServiceActionResult {
+		serviceCalls = append(serviceCalls, append([]string(nil), command...))
+		return ServiceActionResult{Name: command[len(command)-1], Command: command, Success: true}
+	}
+	var adminLoads [][]byte
+	caddyAdminLoader = func(configJSON []byte) error {
+		adminLoads = append(adminLoads, append([]byte(nil), configJSON...))
+		return nil
+	}
+	serviceHealthChecker = func(service string) ServiceHealthResult {
+		return ServiceHealthResult{Name: service, Command: []string{"systemctl", "is-active", "--quiet", service}, Healthy: false, Error: "service unhealthy"}
+	}
+	r, _ := NewRouter(ServerInfo{Version: "test", Mode: "dev", StatePath: statePath, ApplyRoot: applyRoot})
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/api/apply", strings.NewReader(`{"confirm":true,"applyLive":true,"applyServices":true}`)))
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	var response ApplyResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.ServicesApplied || !response.RolledBack || len(response.RollbackActions) != 1 {
+		t.Fatalf("expected rollback via Admin API: %+v", response)
+	}
+	if len(adminLoads) != 2 {
+		t.Fatalf("expected two Admin API loads, got %d", len(adminLoads))
+	}
+	if string(adminLoads[0]) == string(adminLoads[1]) {
+		t.Fatalf("expected rollback to load restored config bytes, but both loads were identical")
+	}
+	if !strings.Contains(string(adminLoads[0]), "vpn.example.com") {
+		t.Fatalf("expected first admin load to use promoted config: %s", string(adminLoads[0]))
+	}
+	if string(adminLoads[1]) != "old caddy\n" {
+		t.Fatalf("expected rollback admin load to use restored config, got %q", string(adminLoads[1]))
+	}
+	if len(serviceCalls) != 0 {
+		t.Fatalf("expected no systemctl calls when Admin API succeeds, got %+v", serviceCalls)
 	}
 }

--- a/internal/api/router_management_apply_live_services_test.go
+++ b/internal/api/router_management_apply_live_services_test.go
@@ -45,7 +45,7 @@ func TestManagementApplyLiveRequiresExplicitFlagAndKeepsStagedOnlyByDefault(t *t
 	if len(response.LiveFiles) != 0 || len(response.BackupFiles) != 0 {
 		t.Fatalf("staged-only apply should not report live files/backups: %+v", response)
 	}
-	if _, err := os.Stat(filepath.Join(applyRoot, "live", "caddy", "naive.Caddyfile")); !os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(applyRoot, "live", "caddy", "config.json")); !os.IsNotExist(err) {
 		t.Fatalf("staged-only apply should not write live caddy config, stat err: %v", err)
 	}
 }
@@ -56,7 +56,7 @@ func TestManagementApplyLivePromotesValidatedConfigsAndBacksUpExistingFiles(t *t
 		t.Fatalf("write state: %v", err)
 	}
 	applyRoot := t.TempDir()
-	existingCaddy := filepath.Join(applyRoot, "live", "caddy", "naive.Caddyfile")
+	existingCaddy := filepath.Join(applyRoot, "live", "caddy", "config.json")
 	if err := atomicfile.Write(existingCaddy, []byte("old caddy\n"), 0o600, 0o700); err != nil {
 		t.Fatalf("write existing live caddy: %v", err)
 	}
@@ -81,7 +81,7 @@ func TestManagementApplyLivePromotesValidatedConfigsAndBacksUpExistingFiles(t *t
 	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	liveCaddy := filepath.Join(applyRoot, "live", "caddy", "naive.Caddyfile")
+	liveCaddy := filepath.Join(applyRoot, "live", "caddy", "config.json")
 	liveHysteria := filepath.Join(applyRoot, "live", "hysteria2", "hysteria2.yaml")
 	if !response.LiveApplied || !containsString(response.LiveFiles, liveCaddy) || !containsString(response.LiveFiles, liveHysteria) {
 		t.Fatalf("expected live files in response: %+v", response)
@@ -100,7 +100,7 @@ func TestManagementApplyLivePromotesValidatedConfigsAndBacksUpExistingFiles(t *t
 	if err != nil {
 		t.Fatalf("read live caddy: %v", err)
 	}
-	if !strings.Contains(string(caddyBody), "vpn.example.com") || !strings.Contains(string(caddyBody), "basic_auth veil naive-secret") {
+	if !strings.Contains(string(caddyBody), "vpn.example.com") {
 		t.Fatalf("unexpected live caddy config: %s", string(caddyBody))
 	}
 	if _, err := os.Stat(liveHysteria); err != nil {
@@ -114,7 +114,7 @@ func TestManagementApplyLiveRejectsFailedValidationBeforeReplacingLiveFiles(t *t
 		t.Fatalf("write state: %v", err)
 	}
 	applyRoot := t.TempDir()
-	liveCaddy := filepath.Join(applyRoot, "live", "caddy", "naive.Caddyfile")
+	liveCaddy := filepath.Join(applyRoot, "live", "caddy", "config.json")
 	if err := atomicfile.Write(liveCaddy, []byte("old caddy\n"), 0o600, 0o700); err != nil {
 		t.Fatalf("write existing live caddy: %v", err)
 	}
@@ -327,12 +327,12 @@ func TestManagementApplyServicesRunsAllowlistedReloadsAfterLivePromotion(t *test
 	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	expectedNaive := []string{"systemctl", "restart", "veil-caddy@naive.service"}
+	expectedCaddy := []string{"systemctl", "reload", "veil-caddy.service"}
 	expectedHy2 := []string{"systemctl", "restart", "veil-hysteria2@hysteria2.service"}
 	if !response.ServicesApplied || len(response.ServiceActions) != 2 || len(serviceCalls) != 2 {
 		t.Fatalf("expected two service actions: response=%+v calls=%+v", response, serviceCalls)
 	}
-	if !stringSlicesEqual(serviceCalls[0], expectedNaive) || !stringSlicesEqual(serviceCalls[1], expectedHy2) {
+	if !stringSlicesEqual(serviceCalls[0], expectedHy2) || !stringSlicesEqual(serviceCalls[1], expectedCaddy) {
 		t.Fatalf("unexpected service calls: %+v", serviceCalls)
 	}
 	if !response.ServiceActions[0].Success || !response.ServiceActions[1].Success {
@@ -421,7 +421,7 @@ func TestManagementApplyServicesChecksHealthAfterReload(t *testing.T) {
 	if len(response.HealthChecks) != 1 || !response.HealthChecks[0].Healthy || len(healthCalls) != 1 {
 		t.Fatalf("expected one successful health check: response=%+v calls=%+v", response.HealthChecks, healthCalls)
 	}
-	if !stringSlicesEqual(healthCalls[0], []string{"systemctl", "is-active", "--quiet", "veil-caddy@naive.service"}) {
+	if !stringSlicesEqual(healthCalls[0], []string{"systemctl", "is-active", "--quiet", "veil-caddy.service"}) {
 		t.Fatalf("unexpected health command: %+v", healthCalls)
 	}
 }
@@ -432,7 +432,7 @@ func TestManagementApplyServicesRollsBackLiveConfigOnHealthFailure(t *testing.T)
 		t.Fatalf("write state: %v", err)
 	}
 	applyRoot := t.TempDir()
-	liveCaddy := filepath.Join(applyRoot, "live", "caddy", "naive.Caddyfile")
+	liveCaddy := filepath.Join(applyRoot, "live", "caddy", "config.json")
 	if err := atomicfile.Write(liveCaddy, []byte("old caddy\n"), 0o600, 0o700); err != nil {
 		t.Fatalf("write existing live caddy: %v", err)
 	}
@@ -477,7 +477,7 @@ func TestManagementApplyServicesRollsBackLiveConfigOnHealthFailure(t *testing.T)
 	if string(body) != "old caddy\n" {
 		t.Fatalf("expected rollback to restore old live config, got %q", string(body))
 	}
-	expected := [][]string{{"systemctl", "restart", "veil-caddy@naive.service"}, {"systemctl", "restart", "veil-caddy@naive.service"}}
+	expected := [][]string{{"systemctl", "reload", "veil-caddy.service"}, {"systemctl", "reload", "veil-caddy.service"}}
 	if len(serviceCalls) != len(expected) || !stringSlicesEqual(serviceCalls[0], expected[0]) || !stringSlicesEqual(serviceCalls[1], expected[1]) {
 		t.Fatalf("expected reload before and after rollback: %+v", serviceCalls)
 	}
@@ -544,7 +544,7 @@ func TestManagementApplyWritesAuditHistoryForRollback(t *testing.T) {
 		t.Fatalf("write state: %v", err)
 	}
 	applyRoot := t.TempDir()
-	liveCaddy := filepath.Join(applyRoot, "live", "caddy", "naive.Caddyfile")
+	liveCaddy := filepath.Join(applyRoot, "live", "caddy", "config.json")
 	if err := atomicfile.Write(liveCaddy, []byte("old caddy\n"), 0o600, 0o700); err != nil {
 		t.Fatalf("write live caddy: %v", err)
 	}
@@ -647,10 +647,9 @@ func TestManagementApplyServicesCleansOrphanedInstances(t *testing.T) {
 		t.Fatalf("orphan hysteria2 config should be deleted, stat err: %v", err)
 	}
 
-	// Verify the service actions (stop/disable for orphans)
+	// Verify the service actions (stop/disable for orphans). Caddy is now a
+	// single veil-caddy.service, so per-inbound caddy orphan services are gone.
 	expectedStopDisableCalls := [][]string{
-		{"systemctl", "stop", "veil-caddy@orphan.service"},
-		{"systemctl", "disable", "veil-caddy@orphan.service"},
 		{"systemctl", "stop", "veil-hysteria2@orphan.service"},
 		{"systemctl", "disable", "veil-hysteria2@orphan.service"},
 	}
@@ -727,10 +726,10 @@ func TestManagementApplyServicesRestoresOrphanedInstancesOnRollback(t *testing.T
 	assertFileBody(t, orphanCaddy, "caddy config")
 	assertFileBody(t, orphanHysteria2, "hysteria2 config")
 
-	// Verify the service actions on rollback (enable/start for orphans)
+	// Verify the service actions on rollback (enable/start for orphans). Caddy
+	// is now a single veil-caddy.service, so per-inbound caddy orphan services
+	// are gone.
 	expectedEnableStartCalls := [][]string{
-		{"systemctl", "enable", "veil-caddy@orphan.service"},
-		{"systemctl", "start", "veil-caddy@orphan.service"},
 		{"systemctl", "enable", "veil-hysteria2@orphan.service"},
 		{"systemctl", "start", "veil-hysteria2@orphan.service"},
 	}

--- a/internal/api/router_management_apply_live_services_test.go
+++ b/internal/api/router_management_apply_live_services_test.go
@@ -348,11 +348,21 @@ func TestManagementApplyServicesRunsAllowlistedReloadsAfterLivePromotion(t *test
 	if !stringSlicesEqual(serviceCalls[0], expectedHy2) {
 		t.Fatalf("unexpected service calls: %+v", serviceCalls)
 	}
-	if response.ServiceActions[0].Name != "veil-hysteria2@hysteria2.service" || !response.ServiceActions[0].Success {
-		t.Fatalf("expected successful Hysteria2 result: %+v", response.ServiceActions)
+	caddyOK := false
+	hy2OK := false
+	for _, action := range response.ServiceActions {
+		switch action.Name {
+		case "veil-caddy.service":
+			caddyOK = action.Success
+		case "veil-hysteria2@hysteria2.service":
+			hy2OK = action.Success
+		}
 	}
-	if response.ServiceActions[1].Name != "veil-caddy.service" || !response.ServiceActions[1].Success {
+	if !caddyOK {
 		t.Fatalf("expected successful Caddy Admin API result: %+v", response.ServiceActions)
+	}
+	if !hy2OK {
+		t.Fatalf("expected successful Hysteria2 result: %+v", response.ServiceActions)
 	}
 }
 
@@ -904,5 +914,130 @@ func TestManagementApplyServicesRollsBackUsesCaddyAdminLoaderWithRestoredConfig(
 	}
 	if len(serviceCalls) != 0 {
 		t.Fatalf("expected no systemctl calls when Admin API succeeds, got %+v", serviceCalls)
+	}
+}
+
+// TestManagementApplyRollbackRestoresSettingsState verifies that a rollback
+// after a failed Panel mode switch restores both the live Caddy config and the
+// in-memory/on-disk management state. Before the fix the live files were
+// rolled back but settings.PanelAccess stayed on "caddy", so the next apply
+// would still use the broken mode.
+func TestManagementApplyRollbackRestoresSettingsState(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	if err := os.WriteFile(statePath, []byte(`{
+		"settings":{
+			"panelListen":"127.0.0.1:2096",
+			"mode":"dev",
+			"panelAccess":"direct",
+			"webBasePath":"/panel/",
+			"domain":"vpn.example.com",
+			"email":"admin@example.com",
+			"defaultAcmeEmail":"admin@example.com",
+			"naiveUsername":"veil",
+			"naivePassword":"naive-secret",
+			"fallbackRoot":"/var/lib/veil/www",
+			"firewallManagement":false
+		},
+		"inbounds":[
+			{"name":"naive","protocol":"naiveproxy","transport":"tcp","port":443,"enabled":true,"protocolFields":{"domain":"vpn.example.com"}}
+		],
+		"routingRules":[],
+		"warp":{"enabled":false,"endpoint":"engage.cloudflareclient.com:2408"}
+	}`), 0o600); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	applyRoot := t.TempDir()
+	keyPath := filepath.Join(t.TempDir(), "state.key")
+	liveCaddy := filepath.Join(applyRoot, "live", "caddy", "config.json")
+	if err := atomicfile.Write(liveCaddy, []byte("old caddy\n"), 0o600, 0o700); err != nil {
+		t.Fatalf("write existing live caddy: %v", err)
+	}
+
+	oldValidator := stagedConfigValidator
+	oldRunner := serviceActionRunner
+	oldHealth := serviceHealthChecker
+	oldLoader := caddyAdminLoader
+	defer func() {
+		stagedConfigValidator = oldValidator
+		serviceActionRunner = oldRunner
+		serviceHealthChecker = oldHealth
+		caddyAdminLoader = oldLoader
+	}()
+	stagedConfigValidator = func(paths []string) []ConfigValidationResult {
+		results := make([]ConfigValidationResult, 0, len(paths))
+		for _, path := range paths {
+			results = append(results, ConfigValidationResult{Name: filepath.Base(path), Config: path, Valid: true})
+		}
+		return results
+	}
+	serviceActionRunner = func(command []string) ServiceActionResult {
+		return ServiceActionResult{Name: command[len(command)-1], Command: command, Success: true}
+	}
+	caddyAdminLoader = func(configJSON []byte) error { return nil }
+	serviceHealthChecker = func(service string) ServiceHealthResult {
+		return ServiceHealthResult{Name: service, Command: []string{"systemctl", "is-active", "--quiet", service}, Healthy: false, Error: "panel unreachable"}
+	}
+
+	r, _ := NewRouter(ServerInfo{Version: "test", Mode: "dev", StatePath: statePath, ApplyRoot: applyRoot, KeyPath: keyPath})
+
+	// Simulate the user switching Panel mode from direct to caddy.
+	// panelPublicPort is chosen so it does not collide with the naive inbound.
+	settingsBody := `{
+		"panelListen":"127.0.0.1:2096",
+		"mode":"dev",
+		"panelAccess":"caddy",
+		"panelDomain":"panel.example.com",
+		"panelEmail":"admin@example.com",
+		"panelPublicPort":8443,
+		"webBasePath":"/panel/",
+		"domain":"vpn.example.com",
+		"email":"admin@example.com",
+		"defaultAcmeEmail":"admin@example.com",
+		"naiveUsername":"veil",
+		"naivePassword":"naive-secret",
+		"fallbackRoot":"/var/lib/veil/www",
+		"firewallManagement":false
+	}`
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPut, "/api/settings", strings.NewReader(settingsBody)))
+	if w.Code != http.StatusOK {
+		t.Fatalf("settings update failed: %d %s", w.Code, w.Body.String())
+	}
+
+	// Apply the mode switch; the health check fails and triggers rollback.
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/api/apply", strings.NewReader(`{"confirm":true,"applyLive":true,"applyServices":true}`)))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 after rollback, got %d: %s", w.Code, w.Body.String())
+	}
+	var response ApplyResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !response.RolledBack || len(response.RollbackFiles) == 0 {
+		t.Fatalf("expected rollback response: %+v", response)
+	}
+
+	// The live Caddy config must be restored to the previous version.
+	caddyBody, err := os.ReadFile(liveCaddy)
+	if err != nil {
+		t.Fatalf("read live caddy: %v", err)
+	}
+	if string(caddyBody) != "old caddy\n" {
+		t.Fatalf("live caddy config was not restored: %q", string(caddyBody))
+	}
+
+	// The management state must also be restored to the previous mode.
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/settings", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("get settings failed: %d %s", w.Code, w.Body.String())
+	}
+	var settings Settings
+	if err := json.NewDecoder(w.Body).Decode(&settings); err != nil {
+		t.Fatalf("decode settings: %v", err)
+	}
+	if settings.PanelAccess != "direct" {
+		t.Fatalf("settings.PanelAccess was not rolled back: got %q want direct; settings=%+v", settings.PanelAccess, settings)
 	}
 }

--- a/internal/api/router_management_apply_plan_test.go
+++ b/internal/api/router_management_apply_plan_test.go
@@ -72,7 +72,7 @@ func TestManagementApplyPlanRejectsInvalidEnabledInbound(t *testing.T) {
 func TestManagementApplyPlanUsesEnabledInboundsToSelectProtocols(t *testing.T) {
 	statePath := filepath.Join(t.TempDir(), "state.json")
 	if err := os.WriteFile(statePath, []byte(`{
-		"settings":{"panelListen":"127.0.0.1:2096","mode":"dev","domain":"vpn.example.com","email":"admin@example.com","naiveUsername":"veil","naivePassword":"secret","hysteria2Password":"hy2-secret"},
+		"settings":{"panelListen":"127.0.0.1:2096","mode":"dev","domain":"vpn.example.com","defaultAcmeEmail":"admin@example.com","naiveUsername":"veil","naivePassword":"secret","hysteria2Password":"hy2-secret"},
 		"inbounds":[
 			{"name":"naive","protocol":"naiveproxy","transport":"tcp","port":443,"enabled":true},
 			{"name":"hysteria2","protocol":"hysteria2","transport":"udp","port":443,"enabled":true}
@@ -105,7 +105,7 @@ func TestManagementApplyPlanUsesEnabledInboundsToSelectProtocols(t *testing.T) {
 func TestManagementApplyPlanRejectsMissingRenderSettingsForEnabledInbound(t *testing.T) {
 	statePath := filepath.Join(t.TempDir(), "state.json")
 	if err := os.WriteFile(statePath, []byte(`{
-		"settings":{"panelListen":"127.0.0.1:2096","mode":"dev","domain":"vpn.example.com","email":"admin@example.com"},
+		"settings":{"panelListen":"127.0.0.1:2096","mode":"dev","domain":"vpn.example.com","defaultAcmeEmail":"admin@example.com"},
 		"inbounds":[{"name":"naive","protocol":"naiveproxy","transport":"tcp","port":443,"enabled":true}],
 		"routingRules":[],
 		"warp":{"enabled":false,"endpoint":"engage.cloudflareclient.com:2408"}

--- a/internal/api/router_management_apply_plan_test.go
+++ b/internal/api/router_management_apply_plan_test.go
@@ -124,7 +124,7 @@ func TestManagementApplyPlanRejectsMissingRenderSettingsForEnabledInbound(t *tes
 	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if response.Valid || len(response.Errors) == 0 || !strings.Contains(strings.Join(response.Errors, ";"), "naive username, and naive password are required") {
+	if response.Valid || len(response.Errors) == 0 || !strings.Contains(strings.Join(response.Errors, ";"), "missing valid credentials") {
 		t.Fatalf("expected missing naive credentials validation error: %+v", response)
 	}
 }

--- a/internal/api/router_management_apply_plan_test.go
+++ b/internal/api/router_management_apply_plan_test.go
@@ -94,10 +94,10 @@ func TestManagementApplyPlanUsesEnabledInboundsToSelectProtocols(t *testing.T) {
 	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if !containsString(response.Configs, "/etc/veil/generated/caddy/panel.Caddyfile") || !containsString(response.Configs, "/etc/veil/generated/hysteria2/server.yaml") {
+	if !containsString(response.Configs, "/etc/veil/generated/caddy/config.json") || !containsString(response.Configs, "/etc/veil/generated/hysteria2/server.yaml") {
 		t.Fatalf("expected all enabled Inbounds in apply plan: %+v", response.Configs)
 	}
-	if !containsString(response.Actions, "restart veil-caddy@.service") || !containsString(response.Actions, "restart veil-hysteria2@.service") {
+	if !containsString(response.Actions, "reload veil-caddy.service") || !containsString(response.Actions, "restart veil-hysteria2@.service") {
 		t.Fatalf("expected all enabled Inbound actions: %+v", response.Actions)
 	}
 }
@@ -105,7 +105,7 @@ func TestManagementApplyPlanUsesEnabledInboundsToSelectProtocols(t *testing.T) {
 func TestManagementApplyPlanRejectsMissingRenderSettingsForEnabledInbound(t *testing.T) {
 	statePath := filepath.Join(t.TempDir(), "state.json")
 	if err := os.WriteFile(statePath, []byte(`{
-		"settings":{"panelListen":"127.0.0.1:2096","mode":"dev","domain":"vpn.example.com"},
+		"settings":{"panelListen":"127.0.0.1:2096","mode":"dev","domain":"vpn.example.com","email":"admin@example.com"},
 		"inbounds":[{"name":"naive","protocol":"naiveproxy","transport":"tcp","port":443,"enabled":true}],
 		"routingRules":[],
 		"warp":{"enabled":false,"endpoint":"engage.cloudflareclient.com:2408"}
@@ -124,7 +124,7 @@ func TestManagementApplyPlanRejectsMissingRenderSettingsForEnabledInbound(t *tes
 	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if response.Valid || len(response.Errors) == 0 || !strings.Contains(strings.Join(response.Errors, ";"), "naive username and password are required") {
+	if response.Valid || len(response.Errors) == 0 || !strings.Contains(strings.Join(response.Errors, ";"), "naive username, and naive password are required") {
 		t.Fatalf("expected missing naive credentials validation error: %+v", response)
 	}
 }

--- a/internal/api/router_panel_preview_tools_preview_test.go
+++ b/internal/api/router_panel_preview_tools_preview_test.go
@@ -53,7 +53,7 @@ func TestRURecommendedPreviewEndpointDefaultsToPanelOnly(t *testing.T) {
 	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if response.Domain != "example.com" || response.Email != "admin@example.com" || response.Caddyfile != "" {
+	if response.Domain != "example.com" || response.Email != "admin@example.com" || response.CaddyJSON != "" {
 		t.Fatalf("preview should default to Panel-only: %+v", response)
 	}
 }
@@ -73,11 +73,11 @@ func TestRURecommendedPreviewEndpointRendersPanelCaddyAccess(t *testing.T) {
 	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if response.PanelAccess != "caddy" || response.PanelURL == "" || response.Caddyfile == "" {
+	if response.PanelAccess != "caddy" || response.PanelURL == "" || response.CaddyJSON == "" {
 		t.Fatalf("expected Panel Caddy preview: %+v", response)
 	}
-	if strings.Contains(response.Caddyfile, "forward_proxy") || !strings.Contains(response.Caddyfile, "reverse_proxy 127.0.0.1:") {
-		t.Fatalf("unexpected Panel Caddyfile:\n%s", response.Caddyfile)
+	if strings.Contains(response.CaddyJSON, "forward_proxy") || !strings.Contains(response.CaddyJSON, `"dial": "127.0.0.1:`) {
+		t.Fatalf("unexpected Panel Caddy JSON:\n%s", response.CaddyJSON)
 	}
 }
 

--- a/internal/api/router_panel_preview_tools_tools_test.go
+++ b/internal/api/router_panel_preview_tools_tools_test.go
@@ -221,18 +221,24 @@ func TestFirewallEndpoint(t *testing.T) {
 		if !result.Active {
 			t.Error("expected UFW active")
 		}
-		if len(result.Rules) != 1 {
-			t.Fatalf("expected 1 Panel rule, got %d: %+v", len(result.Rules), result.Rules)
+		if len(result.Rules) != 2 {
+			t.Fatalf("expected panel + TLS-ALPN-01 rules, got %d: %+v", len(result.Rules), result.Rules)
 		}
 		hasPanel := false
+		hasTLSALPN := false
 		for _, rule := range result.Rules {
 			switch {
 			case rule.Port == 2096 && rule.Protocol == "tcp":
 				hasPanel = true
+			case rule.Port == 443 && rule.Protocol == "tcp":
+				hasTLSALPN = true
 			}
 		}
 		if !hasPanel {
 			t.Error("missing panel TCP/2096 rule")
+		}
+		if !hasTLSALPN {
+			t.Error("missing TLS-ALPN-01 TCP/443 rule")
 		}
 	})
 

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -62,11 +62,11 @@ func stringSlicesEqual(left []string, right []string) bool {
 
 func writeRenderableManagementState(path string, inboundSet string) error {
 	inbounds := `[
-			{"name":"naive","protocol":"naiveproxy","transport":"tcp","port":443,"enabled":true},
+			{"name":"naive","protocol":"naiveproxy","transport":"tcp","port":443,"enabled":true,"protocolFields":{"domain":"vpn.example.com"}},
 			{"name":"hysteria2","protocol":"hysteria2","transport":"udp","port":443,"enabled":true}
 		]`
 	if inboundSet == "naive-only" {
-		inbounds = `[{"name":"naive","protocol":"naiveproxy","transport":"tcp","port":443,"enabled":true}]`
+		inbounds = `[{"name":"naive","protocol":"naiveproxy","transport":"tcp","port":443,"enabled":true,"protocolFields":{"domain":"vpn.example.com"}}]`
 	}
 	return os.WriteFile(path, []byte(`{
 		"settings":{
@@ -74,6 +74,7 @@ func writeRenderableManagementState(path string, inboundSet string) error {
 			"mode":"dev",
 			"domain":"vpn.example.com",
 			"email":"admin@example.com",
+			"defaultAcmeEmail":"admin@example.com",
 			"naiveUsername":"veil",
 			"naivePassword":"naive-secret",
 			"hysteria2Password":"hy2-secret",

--- a/internal/api/router_utility_security_logs_test.go
+++ b/internal/api/router_utility_security_logs_test.go
@@ -78,7 +78,7 @@ func TestIsAllowedHealthService(t *testing.T) {
 		service string
 		want    bool
 	}{
-		{"veil-caddy@panel.service", true},
+		{"veil-mieru.service", true},
 		{"veil-hysteria2@default.service", true},
 		{"veil-hysteria2@.service", true},
 		{"veil-warp.service", true},
@@ -86,8 +86,8 @@ func TestIsAllowedHealthService(t *testing.T) {
 		{"caddy.service", false},
 		{"hysteria2.service", false},
 		{"", false},
-		{"veil-caddy@panel", false},
-		{"veil-caddy@panel.service.evil", false},
+		{"veil-mieru", false},
+		{"veil-mieru.service.evil", false},
 	}
 	for _, tt := range tests {
 		got := service.NewCommandPolicy(NewManagedRuntimeCatalog()).AllowsHealth(tt.service)
@@ -104,8 +104,8 @@ func TestIsAllowedServiceCommand(t *testing.T) {
 		want    bool
 	}{
 		{
-			name:    "restart naive",
-			command: []string{"systemctl", "restart", "veil-caddy@panel.service"},
+			name:    "restart mieru",
+			command: []string{"systemctl", "restart", "veil-mieru.service"},
 			want:    true,
 		},
 		{
@@ -125,12 +125,12 @@ func TestIsAllowedServiceCommand(t *testing.T) {
 		},
 		{
 			name:    "non-systemctl",
-			command: []string{"bash", "reload", "veil-caddy@panel.service"},
+			command: []string{"bash", "reload", "veil-mieru.service"},
 			want:    false,
 		},
 		{
 			name:    "non-allowed verb",
-			command: []string{"systemctl", "status", "veil-caddy@panel.service"},
+			command: []string{"systemctl", "status", "veil-mieru.service"},
 			want:    false,
 		},
 		{
@@ -140,7 +140,7 @@ func TestIsAllowedServiceCommand(t *testing.T) {
 		},
 		{
 			name:    "too many args",
-			command: []string{"systemctl", "reload", "veil-caddy@panel.service", "extra"},
+			command: []string{"systemctl", "reload", "veil-mieru.service", "extra"},
 			want:    false,
 		},
 		{

--- a/internal/api/service_command_policy_test.go
+++ b/internal/api/service_command_policy_test.go
@@ -7,15 +7,18 @@ import (
 )
 
 func TestServiceCommandPolicyAllowsOnlyManagedPromotedActionsAndHealthServices(t *testing.T) {
-	policy := service.NewCommandPolicy(NewManagedRuntimeCatalog())
-	if !policy.AllowsAction([]string{"systemctl", "restart", "veil-caddy@panel.service"}) {
-		t.Fatalf("expected veil-caddy@panel restart to be allowed")
+	policy := service.NewCommandPolicy(NewManagedRuntimeCatalogFor([]Inbound{
+		{Name: "naive", Protocol: "naiveproxy", Enabled: true},
+		{Name: "mieru", Protocol: "mieru", Enabled: true},
+	}, WarpConfig{}))
+	if !policy.AllowsAction([]string{"systemctl", "reload", "veil-caddy.service"}) {
+		t.Fatalf("expected veil-caddy reload to be allowed")
 	}
 	if !policy.AllowsAction([]string{"systemctl", "restart", "veil-mieru.service"}) {
 		t.Fatalf("expected veil-mieru restart to be allowed")
 	}
-	if policy.AllowsAction([]string{"systemctl", "reload", "veil-caddy@panel.service"}) {
-		t.Fatalf("reload must not be allowed for Caddy panel")
+	if policy.AllowsAction([]string{"systemctl", "restart", "veil-caddy.service"}) {
+		t.Fatalf("restart must not be allowed for single Caddy service")
 	}
 	if policy.AllowsAction([]string{"systemctl", "reload", "veil-mieru.service"}) {
 		t.Fatalf("reload must not be allowed for Mieru")

--- a/internal/api/services_test.go
+++ b/internal/api/services_test.go
@@ -47,7 +47,7 @@ func TestServicesRestartSuccess(t *testing.T) {
 	defer func() { serviceActionRunner = orig }()
 
 	r, _ := NewRouter(ServerInfo{Version: "test"})
-	req := httptest.NewRequest(http.MethodPost, "/api/services/caddy-panel/restart", strings.NewReader(`{"confirm":true}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/services/mieru/restart", strings.NewReader(`{"confirm":true}`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)

--- a/internal/applyplan/planner_more_test.go
+++ b/internal/applyplan/planner_more_test.go
@@ -248,9 +248,9 @@ func TestServiceActionVerbsIgnoresInvalidActions(t *testing.T) {
 
 func TestServiceVerbForUnit(t *testing.T) {
 	verbs := map[string]string{
-		"veil-mieru.service":  "restart",
-		"veil-caddy@.service": "reload",
-		"veil-other@.service": "not-a-verb",
+		"veil-mieru.service":      "restart",
+		"veil-hysteria2@.service": "reload",
+		"veil-other@.service":     "not-a-verb",
 	}
 
 	tests := []struct {
@@ -258,8 +258,8 @@ func TestServiceVerbForUnit(t *testing.T) {
 		want string
 	}{
 		{"veil-mieru.service", "restart"},
-		{"veil-caddy@edge.service", "reload"},
-		{"veil-caddy@panel.service", "reload"},
+		{"veil-hysteria2@edge.service", "reload"},
+		{"veil-hysteria2@panel.service", "reload"},
 		{"veil-unknown.service", ""},
 		{"veil-other@foo.service", "not-a-verb"},
 	}

--- a/internal/applyplan/planner_test.go
+++ b/internal/applyplan/planner_test.go
@@ -15,8 +15,8 @@ func TestPlannerBuildsStructuredOperationsDeterministically(t *testing.T) {
 		GeneratedRoot: "/var/lib/veil/staging",
 		LiveRoot:      "/etc/veil/generated",
 		PanelAccess: Material{
-			Configs: []string{"/etc/veil/generated/caddy/edge.Caddyfile"},
-			Actions: []string{"reload veil-caddy@edge.service"},
+			Configs: []string{"/etc/veil/generated/caddy/config.json"},
+			Actions: []string{"reload veil-caddy.service"},
 		},
 		Inbounds: []model.Inbound{{
 			Name: "edge", Protocol: "mieru", Transport: "tcp", Port: 443, Enabled: true,
@@ -32,8 +32,8 @@ func TestPlannerBuildsStructuredOperationsDeterministically(t *testing.T) {
 	want := []model.ApplyOperation{
 		{
 			Type:              "promote_file",
-			Source:            "/var/lib/veil/staging/caddy/edge.Caddyfile",
-			Destination:       "/etc/veil/generated/caddy/edge.Caddyfile",
+			Source:            "/var/lib/veil/staging/caddy/config.json",
+			Destination:       "/etc/veil/generated/caddy/config.json",
 			InterruptionRisk:  "reload",
 			RollbackAvailable: true,
 			ValidationSource:  "render-and-live-host",
@@ -48,7 +48,7 @@ func TestPlannerBuildsStructuredOperationsDeterministically(t *testing.T) {
 		},
 		{
 			Type:              "reload_service",
-			Unit:              "veil-caddy@edge.service",
+			Unit:              "veil-caddy.service",
 			InterruptionRisk:  "reload",
 			RollbackAvailable: true,
 			ValidationSource:  "managed-unit-catalog",
@@ -96,7 +96,7 @@ func TestPlannerStructuredPreviewDoesNotContainSecrets(t *testing.T) {
 
 func TestPlannerBuildsManagementApplyIntentFromPanelProtocolsWarpAndRouting(t *testing.T) {
 	plan := Build(Input{
-		PanelAccess: Material{Configs: []string{"/etc/veil/generated/caddy/panel.Caddyfile"}, Actions: []string{"reload veil-caddy@panel.service"}, Runtimes: []string{"veil-caddy@panel.service"}},
+		PanelAccess: Material{Configs: []string{"/etc/veil/generated/caddy/config.json"}, Actions: []string{"reload veil-caddy.service"}, Runtimes: []string{"veil-caddy.service"}},
 		Settings:    model.Settings{Domain: "vpn.example.com"},
 		Inbounds: []model.Inbound{
 			{Name: "mieru", Protocol: "mieru", Transport: "tcp", Port: 443, Enabled: true},
@@ -116,17 +116,17 @@ func TestPlannerBuildsManagementApplyIntentFromPanelProtocolsWarpAndRouting(t *t
 	if !plan.Valid {
 		t.Fatalf("plan errors = %+v", plan.Errors)
 	}
-	for _, want := range []string{"/etc/veil/generated/caddy/panel.Caddyfile", "/etc/veil/generated/mieru/server_config.json", "/etc/veil/generated/sing-box/warp.json", "/etc/veil/generated/rules/geoip.dat"} {
+	for _, want := range []string{"/etc/veil/generated/caddy/config.json", "/etc/veil/generated/mieru/server_config.json", "/etc/veil/generated/sing-box/warp.json", "/etc/veil/generated/rules/geoip.dat"} {
 		if !contains(plan.Configs, want) {
 			t.Fatalf("configs missing %q: %+v", want, plan.Configs)
 		}
 	}
-	for _, want := range []string{"validate management state", "stage generated configs", "reload veil-caddy@panel.service", "restart veil-mieru.service", "restart veil-warp.service"} {
+	for _, want := range []string{"validate management state", "stage generated configs", "reload veil-caddy.service", "restart veil-mieru.service", "restart veil-warp.service"} {
 		if !contains(plan.Actions, want) {
 			t.Fatalf("actions missing %q: %+v", want, plan.Actions)
 		}
 	}
-	for _, want := range []string{"veil-caddy@panel.service", "veil-mieru.service", "veil-warp.service"} {
+	for _, want := range []string{"veil-caddy.service", "veil-mieru.service", "veil-warp.service"} {
 		if !contains(plan.Runtimes, want) {
 			t.Fatalf("runtimes missing %q: %+v", want, plan.Runtimes)
 		}

--- a/internal/bindregistry/bindkey.go
+++ b/internal/bindregistry/bindkey.go
@@ -1,0 +1,64 @@
+package bindregistry
+
+import "strings"
+
+type ListenNetwork string
+
+const (
+	ListenTCP ListenNetwork = "tcp"
+	ListenUDP ListenNetwork = "udp"
+)
+
+type BindKey struct {
+	Address string
+	Port    int
+	Network ListenNetwork
+}
+
+type BindOwnerKind string
+
+const (
+	BindOwnerPanelDirect   BindOwnerKind = "panel_direct"
+	BindOwnerPanelCaddy    BindOwnerKind = "panel_caddy"
+	BindOwnerNaive         BindOwnerKind = "naive"
+	BindOwnerHysteria2     BindOwnerKind = "hysteria2"
+	BindOwnerLegacyCaddy   BindOwnerKind = "legacy_caddy"
+	BindOwnerAcmeChallenge BindOwnerKind = "acme_challenge"
+)
+
+type BindOwner struct {
+	Kind        BindOwnerKind
+	ServiceName string
+	InboundName string
+}
+
+func NormalizeAddress(addr string) string {
+	addr = strings.TrimSpace(addr)
+	if addr == "" {
+		return "0.0.0.0"
+	}
+	return addr
+}
+
+func IsWildcard(addr string) bool {
+	return addr == "0.0.0.0" || addr == "::" || addr == ""
+}
+
+func (k BindKey) Canonical() BindKey {
+	return BindKey{Address: NormalizeAddress(k.Address), Port: k.Port, Network: k.Network}
+}
+
+func (k BindKey) Overlaps(other BindKey) bool {
+	a := k.Canonical()
+	b := other.Canonical()
+	if a.Port != b.Port || a.Network != b.Network {
+		return false
+	}
+	if a.Address == b.Address {
+		return true
+	}
+	if IsWildcard(a.Address) || IsWildcard(b.Address) {
+		return true
+	}
+	return false
+}

--- a/internal/bindregistry/bindkey.go
+++ b/internal/bindregistry/bindkey.go
@@ -1,0 +1,137 @@
+package bindregistry
+
+import (
+	"fmt"
+	"net/netip"
+	"strings"
+)
+
+// ListenNetwork is the network protocol used by a public listener.
+type ListenNetwork string
+
+const (
+	ListenTCP ListenNetwork = "tcp"
+	ListenUDP ListenNetwork = "udp"
+)
+
+// BindKey uniquely identifies a network listener after canonicalization.
+type BindKey struct {
+	Address string
+	Port    int
+	Network ListenNetwork
+}
+
+// BindOwnerKind identifies the subsystem that owns a listener.
+type BindOwnerKind string
+
+const (
+	BindOwnerPanelDirect   BindOwnerKind = "panel_direct"
+	BindOwnerPanelCaddy    BindOwnerKind = "panel_caddy"
+	BindOwnerNaive         BindOwnerKind = "naive"
+	BindOwnerHysteria2     BindOwnerKind = "hysteria2"
+	BindOwnerInbound       BindOwnerKind = "inbound"
+	BindOwnerLegacyCaddy   BindOwnerKind = "legacy_caddy"
+	BindOwnerAcmeChallenge BindOwnerKind = "acme_challenge"
+)
+
+// BindOwner describes the service or inbound responsible for a listener.
+type BindOwner struct {
+	Kind        BindOwnerKind
+	ServiceName string
+	InboundName string
+}
+
+// NormalizeAddress returns a stable textual representation for a bind address.
+// Empty addresses and * are treated as the public IPv4 wildcard.
+func NormalizeAddress(addr string) string {
+	addr = strings.TrimSpace(addr)
+	switch addr {
+	case "", "*", "0.0.0.0":
+		return "0.0.0.0"
+	case "::", "[::]":
+		return "::"
+	}
+
+	if strings.HasPrefix(addr, "[") && strings.HasSuffix(addr, "]") {
+		addr = strings.TrimSuffix(strings.TrimPrefix(addr, "["), "]")
+	}
+	if parsed, err := netip.ParseAddr(addr); err == nil {
+		return parsed.Unmap().String()
+	}
+	return strings.ToLower(addr)
+}
+
+// IsWildcard reports whether addr represents an IPv4 or IPv6 wildcard.
+func IsWildcard(addr string) bool {
+	switch NormalizeAddress(addr) {
+	case "0.0.0.0", "::":
+		return true
+	default:
+		return false
+	}
+}
+
+// Canonical returns the normalized form of k. Use Validate before persisting a
+// user-supplied key.
+func (k BindKey) Canonical() BindKey {
+	return BindKey{
+		Address: NormalizeAddress(k.Address),
+		Port:    k.Port,
+		Network: ListenNetwork(strings.ToLower(strings.TrimSpace(string(k.Network)))),
+	}
+}
+
+// Validate checks that the key can represent a real TCP or UDP listener.
+func (k BindKey) Validate() error {
+	canonical := k.Canonical()
+	if canonical.Port < 1 || canonical.Port > 65535 {
+		return fmt.Errorf("invalid bind port %d: must be between 1 and 65535", canonical.Port)
+	}
+	if canonical.Network != ListenTCP && canonical.Network != ListenUDP {
+		return fmt.Errorf("invalid listen network %q: must be tcp or udp", canonical.Network)
+	}
+	if _, err := netip.ParseAddr(canonical.Address); err != nil {
+		return fmt.Errorf("invalid bind address %q: %w", canonical.Address, err)
+	}
+	return nil
+}
+
+// Overlaps reports whether two keys may claim the same operating-system
+// listener. IPv6 wildcard is treated conservatively as dual-stack because the
+// runtime may use IPV6_V6ONLY=0.
+func (k BindKey) Overlaps(other BindKey) bool {
+	a := k.Canonical()
+	b := other.Canonical()
+	if a.Port != b.Port || a.Network != b.Network {
+		return false
+	}
+	if a.Address == b.Address {
+		return true
+	}
+
+	aAddr, aErr := netip.ParseAddr(a.Address)
+	bAddr, bErr := netip.ParseAddr(b.Address)
+	if aErr != nil || bErr != nil {
+		// Invalid keys are rejected by Validate. Keep overlap checking
+		// conservative if an unchecked key reaches this method.
+		return IsWildcard(a.Address) || IsWildcard(b.Address)
+	}
+	aAddr = aAddr.Unmap()
+	bAddr = bAddr.Unmap()
+
+	if IsWildcard(a.Address) || IsWildcard(b.Address) {
+		if aAddr.Is6() && IsWildcard(a.Address) {
+			return true
+		}
+		if bAddr.Is6() && IsWildcard(b.Address) {
+			return true
+		}
+		return aAddr.Is4() == bAddr.Is4()
+	}
+	return false
+}
+
+func (k BindKey) String() string {
+	canonical := k.Canonical()
+	return fmt.Sprintf("%s %s:%d", canonical.Network, canonical.Address, canonical.Port)
+}

--- a/internal/bindregistry/bindkey.go
+++ b/internal/bindregistry/bindkey.go
@@ -22,6 +22,7 @@ const (
 	BindOwnerPanelCaddy    BindOwnerKind = "panel_caddy"
 	BindOwnerNaive         BindOwnerKind = "naive"
 	BindOwnerHysteria2     BindOwnerKind = "hysteria2"
+	BindOwnerInbound       BindOwnerKind = "inbound"
 	BindOwnerLegacyCaddy   BindOwnerKind = "legacy_caddy"
 	BindOwnerAcmeChallenge BindOwnerKind = "acme_challenge"
 )

--- a/internal/bindregistry/bindkey_test.go
+++ b/internal/bindregistry/bindkey_test.go
@@ -1,0 +1,89 @@
+package bindregistry
+
+import "testing"
+
+func TestNormalizeAddress(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty", in: "", want: "0.0.0.0"},
+		{name: "star", in: "*", want: "0.0.0.0"},
+		{name: "trimmed ipv4", in: " 192.0.2.10 ", want: "192.0.2.10"},
+		{name: "bracketed ipv6", in: "[2001:db8::1]", want: "2001:db8::1"},
+		{name: "ipv4 mapped ipv6", in: "::ffff:192.0.2.10", want: "192.0.2.10"},
+		{name: "ipv6 wildcard", in: "[::]", want: "::"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := NormalizeAddress(tc.in); got != tc.want {
+				t.Fatalf("NormalizeAddress(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBindKeyValidate(t *testing.T) {
+	t.Parallel()
+
+	valid := BindKey{Address: " 0.0.0.0 ", Port: 443, Network: "TCP"}
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("valid key rejected: %v", err)
+	}
+
+	cases := []BindKey{
+		{Address: "not-an-ip", Port: 443, Network: ListenTCP},
+		{Address: "0.0.0.0", Port: 0, Network: ListenTCP},
+		{Address: "0.0.0.0", Port: 65536, Network: ListenTCP},
+		{Address: "0.0.0.0", Port: 443, Network: "sctp"},
+	}
+	for _, key := range cases {
+		if err := key.Validate(); err == nil {
+			t.Errorf("expected %v to be rejected", key)
+		}
+	}
+}
+
+func TestBindKeyOverlap(t *testing.T) {
+	t.Parallel()
+
+	tcp443 := BindKey{Address: "0.0.0.0", Port: 443, Network: ListenTCP}
+	if !tcp443.Overlaps(BindKey{Address: "192.0.2.10", Port: 443, Network: ListenTCP}) {
+		t.Error("IPv4 wildcard must overlap a specific IPv4 address")
+	}
+	if tcp443.Overlaps(BindKey{Address: "0.0.0.0", Port: 443, Network: ListenUDP}) {
+		t.Error("TCP and UDP listeners must not overlap")
+	}
+	if tcp443.Overlaps(BindKey{Address: "0.0.0.0", Port: 8443, Network: ListenTCP}) {
+		t.Error("different ports must not overlap")
+	}
+	if tcp443.Overlaps(BindKey{Address: "2001:db8::1", Port: 443, Network: ListenTCP}) {
+		t.Error("IPv4 wildcard must not overlap a specific IPv6 address")
+	}
+
+	ipv6Wildcard := BindKey{Address: "::", Port: 443, Network: ListenTCP}
+	if !ipv6Wildcard.Overlaps(tcp443) {
+		t.Error("IPv6 wildcard is conservatively treated as dual-stack")
+	}
+
+	firstSpecific := BindKey{Address: "192.0.2.10", Port: 443, Network: ListenTCP}
+	secondSpecific := BindKey{Address: "192.0.2.11", Port: 443, Network: ListenTCP}
+	if firstSpecific.Overlaps(secondSpecific) {
+		t.Error("different specific addresses must not overlap")
+	}
+}
+
+func TestBindKeyCanonical(t *testing.T) {
+	t.Parallel()
+
+	got := (BindKey{Address: " [2001:db8::1] ", Port: 443, Network: " TCP "}).Canonical()
+	want := BindKey{Address: "2001:db8::1", Port: 443, Network: ListenTCP}
+	if got != want {
+		t.Fatalf("Canonical() = %#v, want %#v", got, want)
+	}
+}

--- a/internal/bindregistry/bindkey_test.go
+++ b/internal/bindregistry/bindkey_test.go
@@ -1,0 +1,36 @@
+package bindregistry
+
+import "testing"
+
+func TestNormalizeAddress(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"0.0.0.0", "0.0.0.0"},
+		{"", "0.0.0.0"},
+		{"::", "::"},
+		{" 0.0.0.0 ", "0.0.0.0"},
+	}
+	for _, c := range cases {
+		got := NormalizeAddress(c.in)
+		if got != c.want {
+			t.Errorf("NormalizeAddress(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestBindKeyOverlap(t *testing.T) {
+	wildcardTCP443 := BindKey{Address: "0.0.0.0", Port: 443, Network: ListenTCP}
+	specificTCP443 := BindKey{Address: "192.168.1.10", Port: 443, Network: ListenTCP}
+	if !wildcardTCP443.Overlaps(specificTCP443) {
+		t.Error("wildcard IPv4 must overlap specific IPv4 on same port/protocol")
+	}
+	udp443 := BindKey{Address: "0.0.0.0", Port: 443, Network: ListenUDP}
+	if wildcardTCP443.Overlaps(udp443) {
+		t.Error("TCP and UDP on same port must not conflict")
+	}
+	otherPort := BindKey{Address: "192.168.1.10", Port: 8443, Network: ListenTCP}
+	if specificTCP443.Overlaps(otherPort) {
+		t.Error("different ports must not conflict")
+	}
+}

--- a/internal/bindregistry/conflicts.go
+++ b/internal/bindregistry/conflicts.go
@@ -1,6 +1,9 @@
 package bindregistry
 
-import "fmt"
+import (
+	"fmt"
+	"sort"
+)
 
 type Conflict struct {
 	Key     BindKey
@@ -13,21 +16,33 @@ func ValidateNoConflicts(owners map[BindKey]BindOwner) []Conflict {
 	for k, o := range owners {
 		canonical[k.Canonical()] = o
 	}
+
+	keys := make([]BindKey, 0, len(canonical))
+	for k := range canonical {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].Network != keys[j].Network {
+			return keys[i].Network < keys[j].Network
+		}
+		if keys[i].Address != keys[j].Address {
+			return keys[i].Address < keys[j].Address
+		}
+		return keys[i].Port < keys[j].Port
+	})
+
 	var conflicts []Conflict
-	for k, owner := range canonical {
+	for i, k := range keys {
 		var overlapping []BindOwner
-		for otherK, otherOwner := range canonical {
-			if otherK == k {
-				continue
-			}
+		for _, otherK := range keys[i+1:] {
 			if k.Overlaps(otherK) {
-				overlapping = append(overlapping, otherOwner)
+				overlapping = append(overlapping, canonical[otherK])
 			}
 		}
 		if len(overlapping) > 0 {
 			conflicts = append(conflicts, Conflict{
 				Key:     k,
-				Owners:  append([]BindOwner{owner}, overlapping...),
+				Owners:  append([]BindOwner{canonical[k]}, overlapping...),
 				Message: fmt.Sprintf("%s %s:%d is claimed by multiple owners", k.Network, k.Address, k.Port),
 			})
 		}

--- a/internal/bindregistry/conflicts.go
+++ b/internal/bindregistry/conflicts.go
@@ -1,0 +1,36 @@
+package bindregistry
+
+import "fmt"
+
+type Conflict struct {
+	Key     BindKey
+	Owners  []BindOwner
+	Message string
+}
+
+func ValidateNoConflicts(owners map[BindKey]BindOwner) []Conflict {
+	canonical := make(map[BindKey]BindOwner, len(owners))
+	for k, o := range owners {
+		canonical[k.Canonical()] = o
+	}
+	var conflicts []Conflict
+	for k, owner := range canonical {
+		var overlapping []BindOwner
+		for otherK, otherOwner := range canonical {
+			if otherK == k {
+				continue
+			}
+			if k.Overlaps(otherK) {
+				overlapping = append(overlapping, otherOwner)
+			}
+		}
+		if len(overlapping) > 0 {
+			conflicts = append(conflicts, Conflict{
+				Key:     k,
+				Owners:  append([]BindOwner{owner}, overlapping...),
+				Message: fmt.Sprintf("%s %s:%d is claimed by multiple owners", k.Network, k.Address, k.Port),
+			})
+		}
+	}
+	return conflicts
+}

--- a/internal/bindregistry/conflicts.go
+++ b/internal/bindregistry/conflicts.go
@@ -1,0 +1,65 @@
+package bindregistry
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Conflict describes two owners whose listener keys overlap.
+type Conflict struct {
+	Key     BindKey
+	Owners  []BindOwner
+	Message string
+}
+
+type ownedBind struct {
+	key   BindKey
+	owner BindOwner
+}
+
+// ValidateNoConflicts reports every pair of overlapping listener owners. The
+// result order is stable so API errors and tests do not depend on map ordering.
+func ValidateNoConflicts(owners map[BindKey]BindOwner) []Conflict {
+	entries := make([]ownedBind, 0, len(owners))
+	for key, owner := range owners {
+		entries = append(entries, ownedBind{key: key.Canonical(), owner: owner})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		left := entries[i].key.String() + "\x00" + ownerDescription(entries[i].owner)
+		right := entries[j].key.String() + "\x00" + ownerDescription(entries[j].owner)
+		return left < right
+	})
+
+	conflicts := make([]Conflict, 0)
+	for i := 0; i < len(entries); i++ {
+		for j := i + 1; j < len(entries); j++ {
+			if !entries[i].key.Overlaps(entries[j].key) {
+				continue
+			}
+			first := entries[i]
+			second := entries[j]
+			conflicts = append(conflicts, Conflict{
+				Key:    first.key,
+				Owners: []BindOwner{first.owner, second.owner},
+				Message: fmt.Sprintf(
+					"%s owned by %s conflicts with %s owned by %s",
+					first.key.String(), ownerDescription(first.owner),
+					second.key.String(), ownerDescription(second.owner),
+				),
+			})
+		}
+	}
+	return conflicts
+}
+
+func ownerDescription(owner BindOwner) string {
+	parts := []string{string(owner.Kind)}
+	if owner.InboundName != "" {
+		parts = append(parts, fmt.Sprintf("inbound %q", owner.InboundName))
+	}
+	if owner.ServiceName != "" {
+		parts = append(parts, fmt.Sprintf("service %q", owner.ServiceName))
+	}
+	return strings.Join(parts, " ")
+}

--- a/internal/bindregistry/conflicts_test.go
+++ b/internal/bindregistry/conflicts_test.go
@@ -1,0 +1,27 @@
+package bindregistry
+
+import "testing"
+
+func TestValidateNoConflicts(t *testing.T) {
+	owners := map[BindKey]BindOwner{
+		{Address: "0.0.0.0", Port: 443, Network: ListenTCP}: {Kind: BindOwnerPanelCaddy},
+		{Address: "192.168.1.10", Port: 443, Network: ListenTCP}: {Kind: BindOwnerNaive, InboundName: "naive-1"},
+	}
+	conflicts := ValidateNoConflicts(owners)
+	if len(conflicts) == 0 {
+		t.Fatal("expected conflict between wildcard Panel and specific naive on TCP 443")
+	}
+	if conflicts[0].Owners[0].Kind != BindOwnerPanelCaddy {
+		t.Error("first owner should be Panel Caddy")
+	}
+}
+
+func TestValidateNoConflictsNoCollision(t *testing.T) {
+	owners := map[BindKey]BindOwner{
+		{Address: "0.0.0.0", Port: 443, Network: ListenTCP}: {Kind: BindOwnerPanelCaddy},
+		{Address: "0.0.0.0", Port: 443, Network: ListenUDP}: {Kind: BindOwnerHysteria2},
+	}
+	if conflicts := ValidateNoConflicts(owners); len(conflicts) != 0 {
+		t.Fatalf("expected no TCP/UDP conflict, got %v", conflicts)
+	}
+}

--- a/internal/bindregistry/conflicts_test.go
+++ b/internal/bindregistry/conflicts_test.go
@@ -1,0 +1,88 @@
+package bindregistry
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateNoConflictsReportsWildcardCollision(t *testing.T) {
+	t.Parallel()
+
+	owners := map[BindKey]BindOwner{
+		{Address: "0.0.0.0", Port: 443, Network: ListenTCP}: {
+			Kind:        BindOwnerPanelCaddy,
+			ServiceName: "veil-caddy.service",
+		},
+		{Address: "192.0.2.10", Port: 443, Network: ListenTCP}: {
+			Kind:        BindOwnerNaive,
+			InboundName: "naive-main",
+		},
+	}
+
+	conflicts := ValidateNoConflicts(owners)
+	if len(conflicts) != 1 {
+		t.Fatalf("expected one conflict, got %#v", conflicts)
+	}
+	if len(conflicts[0].Owners) != 2 {
+		t.Fatalf("expected two owners, got %#v", conflicts[0].Owners)
+	}
+	for _, fragment := range []string{"tcp", "443", "panel_caddy", "naive-main"} {
+		if !strings.Contains(conflicts[0].Message, fragment) {
+			t.Errorf("conflict message %q does not contain %q", conflicts[0].Message, fragment)
+		}
+	}
+}
+
+func TestValidateNoConflictsAllowsTCPAndUDPReuse(t *testing.T) {
+	t.Parallel()
+
+	owners := map[BindKey]BindOwner{
+		{Address: "0.0.0.0", Port: 443, Network: ListenTCP}: {Kind: BindOwnerPanelCaddy},
+		{Address: "0.0.0.0", Port: 443, Network: ListenUDP}: {
+			Kind:        BindOwnerHysteria2,
+			InboundName: "hy-main",
+		},
+	}
+	if conflicts := ValidateNoConflicts(owners); len(conflicts) != 0 {
+		t.Fatalf("expected no TCP/UDP conflict, got %#v", conflicts)
+	}
+}
+
+func TestValidateNoConflictsCanonicalizesEquivalentKeys(t *testing.T) {
+	t.Parallel()
+
+	owners := map[BindKey]BindOwner{
+		{Address: "", Port: 8443, Network: "TCP"}: {
+			Kind:        BindOwnerNaive,
+			InboundName: "first",
+		},
+		{Address: "0.0.0.0", Port: 8443, Network: ListenTCP}: {
+			Kind:        BindOwnerNaive,
+			InboundName: "second",
+		},
+	}
+	if conflicts := ValidateNoConflicts(owners); len(conflicts) != 1 {
+		t.Fatalf("expected equivalent keys to conflict, got %#v", conflicts)
+	}
+}
+
+func TestValidateNoConflictsStableOrder(t *testing.T) {
+	t.Parallel()
+
+	owners := map[BindKey]BindOwner{
+		{Address: "0.0.0.0", Port: 443, Network: ListenTCP}: {Kind: BindOwnerPanelCaddy},
+		{Address: "192.0.2.10", Port: 443, Network: ListenTCP}: {Kind: BindOwnerNaive, InboundName: "a"},
+		{Address: "192.0.2.11", Port: 443, Network: ListenTCP}: {Kind: BindOwnerNaive, InboundName: "b"},
+	}
+
+	first := ValidateNoConflicts(owners)
+	second := ValidateNoConflicts(owners)
+	if len(first) != len(second) {
+		t.Fatalf("unstable result length: %d != %d", len(first), len(second))
+	}
+	for i := range first {
+		if first[i].Message != second[i].Message {
+			t.Fatalf("unstable result at %d: %q != %q", i, first[i].Message, second[i].Message)
+		}
+	}
+}

--- a/internal/caddyadmin/client.go
+++ b/internal/caddyadmin/client.go
@@ -1,0 +1,32 @@
+package caddyadmin
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+)
+
+type Client struct {
+	AdminEndpoint string
+	HTTPClient    *http.Client
+}
+
+func NewClient(endpoint string) Client {
+	if endpoint == "" {
+		endpoint = "http://127.0.0.1:2019"
+	}
+	return Client{AdminEndpoint: endpoint, HTTPClient: http.DefaultClient}
+}
+
+func (c Client) LoadConfig(json []byte) error {
+	url := c.AdminEndpoint + "/load"
+	resp, err := c.HTTPClient.Post(url, "application/json", bytes.NewReader(json))
+	if err != nil {
+		return fmt.Errorf("caddy admin POST failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("caddy admin returned %s", resp.Status)
+	}
+	return nil
+}

--- a/internal/caddyadmin/client.go
+++ b/internal/caddyadmin/client.go
@@ -4,7 +4,10 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
+	"time"
 )
+
+const defaultAdminTimeout = 30 * time.Second
 
 type Client struct {
 	AdminEndpoint string
@@ -15,7 +18,7 @@ func NewClient(endpoint string) Client {
 	if endpoint == "" {
 		endpoint = "http://127.0.0.1:2019"
 	}
-	return Client{AdminEndpoint: endpoint, HTTPClient: http.DefaultClient}
+	return Client{AdminEndpoint: endpoint, HTTPClient: &http.Client{Timeout: defaultAdminTimeout}}
 }
 
 func (c Client) LoadConfig(json []byte) error {

--- a/internal/caddyadmin/client_test.go
+++ b/internal/caddyadmin/client_test.go
@@ -1,0 +1,32 @@
+package caddyadmin
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestLoadConfigPostsJSON(t *testing.T) {
+	var received string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s", r.Method)
+		}
+		if r.URL.Path != "/load" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		buf := make([]byte, r.ContentLength)
+		r.Body.Read(buf)
+		received = string(buf)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	if err := c.LoadConfig([]byte(`{"apps":{}}`)); err != nil {
+		t.Fatal(err)
+	}
+	if received == "" {
+		t.Error("server received empty body")
+	}
+}

--- a/internal/caddyassembly/challenge.go
+++ b/internal/caddyassembly/challenge.go
@@ -52,6 +52,9 @@ func PlanAcmeChallengeBinds(
 					})
 					continue
 				}
+				// A compatible Caddy owner already answers TLS-ALPN-01 on :443; do not
+				// add a challenge-only bind that would replace it.
+				continue
 			}
 			add(key, spec.Domain)
 		case "dns-01":

--- a/internal/caddyassembly/challenge.go
+++ b/internal/caddyassembly/challenge.go
@@ -1,0 +1,62 @@
+package caddyassembly
+
+import (
+	"github.com/mikkelchokolate/Veil/internal/bindregistry"
+	"github.com/mikkelchokolate/Veil/internal/model"
+)
+
+type AcmeChallengeOwner struct {
+	ChallengeMode string
+	Domains       []string
+}
+
+func PlanAcmeChallengeBinds(
+	challengeMode string,
+	domains map[string]CaddyDomainCertSpec,
+	owners map[bindregistry.BindKey]bindregistry.BindOwner,
+) (map[bindregistry.BindKey]AcmeChallengeOwner, []model.ValidationIssue) {
+	result := make(map[bindregistry.BindKey]AcmeChallengeOwner)
+	var issues []model.ValidationIssue
+
+	add := func(key bindregistry.BindKey, domain string) {
+		owner := result[key]
+		owner.ChallengeMode = challengeMode
+		owner.Domains = append(owner.Domains, domain)
+		result[key] = owner
+	}
+
+	for _, spec := range domains {
+		switch challengeMode {
+		case "http-01":
+			key := bindregistry.BindKey{Address: "0.0.0.0", Port: 80, Network: bindregistry.ListenTCP}
+			if existing, ok := owners[key]; ok && existing.Kind != bindregistry.BindOwnerAcmeChallenge {
+				issues = append(issues, model.ValidationIssue{
+					Code:     "acme_http01_port_in_use",
+					Severity: "error",
+					Message:  "TCP :80 is required for http-01 but is owned by another service",
+					Source:   "caddyassembly",
+				})
+				continue
+			}
+			add(key, spec.Domain)
+		case "tls-alpn-01":
+			key := bindregistry.BindKey{Address: "0.0.0.0", Port: 443, Network: bindregistry.ListenTCP}
+			if existing, ok := owners[key]; ok && existing.Kind != bindregistry.BindOwnerAcmeChallenge {
+				// TLS-ALPN-01 can reuse a compatible Caddy TCP :443 listener; if owner is not Caddy, reject.
+				if existing.Kind != bindregistry.BindOwnerPanelCaddy && existing.Kind != bindregistry.BindOwnerNaive {
+					issues = append(issues, model.ValidationIssue{
+						Code:     "acme_tlsalpn_port_in_use",
+						Severity: "error",
+						Message:  "TCP :443 is required for tls-alpn-01 but is owned by a non-Caddy service",
+						Source:   "caddyassembly",
+					})
+					continue
+				}
+			}
+			add(key, spec.Domain)
+		case "dns-01":
+			// no bind
+		}
+	}
+	return result, issues
+}

--- a/internal/caddyassembly/challenge.go
+++ b/internal/caddyassembly/challenge.go
@@ -30,10 +30,14 @@ func PlanAcmeChallengeBinds(
 		case "http-01":
 			key := bindregistry.BindKey{Address: "0.0.0.0", Port: 80, Network: bindregistry.ListenTCP}
 			if existing, ok := owners[key]; ok && existing.Kind != bindregistry.BindOwnerAcmeChallenge {
+				// A compatible Caddy listener (Panel or Naive) can answer HTTP-01 on :80.
+				if existing.Kind == bindregistry.BindOwnerPanelCaddy || existing.Kind == bindregistry.BindOwnerNaive {
+					continue
+				}
 				issues = append(issues, model.ValidationIssue{
 					Code:     "acme_http01_port_in_use",
 					Severity: "error",
-					Message:  "TCP :80 is required for http-01 but is owned by another service",
+					Message:  "TCP :80 is required for http-01 but is owned by a non-Caddy service",
 					Source:   "caddyassembly",
 				})
 				continue

--- a/internal/caddyassembly/challenge_test.go
+++ b/internal/caddyassembly/challenge_test.go
@@ -90,6 +90,40 @@ func TestPlanAcmeChallengeBindsTLSALPN01Conflict(t *testing.T) {
 	}
 }
 
+func TestPlanAcmeChallengeBindsHTTP01ReusesPanelCaddyListener(t *testing.T) {
+	domains := map[string]CaddyDomainCertSpec{
+		"x.com": {Domain: "x.com", Email: "a@x.com"},
+	}
+	key := bindregistry.BindKey{Address: "0.0.0.0", Port: 80, Network: bindregistry.ListenTCP}
+	owners := map[bindregistry.BindKey]bindregistry.BindOwner{
+		key: {Kind: bindregistry.BindOwnerPanelCaddy},
+	}
+	planned, issues := PlanAcmeChallengeBinds("http-01", domains, owners)
+	if len(issues) > 0 {
+		t.Fatalf("unexpected issues: %v", issues)
+	}
+	if _, ok := planned[key]; ok {
+		t.Fatal("expected no TCP :80 challenge bind when Panel Caddy already owns the port")
+	}
+}
+
+func TestPlanAcmeChallengeBindsHTTP01ReusesNaiveListener(t *testing.T) {
+	domains := map[string]CaddyDomainCertSpec{
+		"x.com": {Domain: "x.com", Email: "a@x.com"},
+	}
+	key := bindregistry.BindKey{Address: "0.0.0.0", Port: 80, Network: bindregistry.ListenTCP}
+	owners := map[bindregistry.BindKey]bindregistry.BindOwner{
+		key: {Kind: bindregistry.BindOwnerNaive},
+	}
+	planned, issues := PlanAcmeChallengeBinds("http-01", domains, owners)
+	if len(issues) > 0 {
+		t.Fatalf("unexpected issues: %v", issues)
+	}
+	if _, ok := planned[key]; ok {
+		t.Fatal("expected no TCP :80 challenge bind when a naive inbound already owns the port")
+	}
+}
+
 func TestPlanAcmeChallengeBindsTLSALPN01ReusesCaddyListener(t *testing.T) {
 	domains := map[string]CaddyDomainCertSpec{
 		"x.com": {Domain: "x.com", Email: "a@x.com"},

--- a/internal/caddyassembly/challenge_test.go
+++ b/internal/caddyassembly/challenge_test.go
@@ -1,0 +1,108 @@
+package caddyassembly
+
+import (
+	"testing"
+
+	"github.com/mikkelchokolate/Veil/internal/bindregistry"
+)
+
+func TestPlanAcmeChallengeBindsHTTP01(t *testing.T) {
+	domains := map[string]CaddyDomainCertSpec{
+		"x.com": {Domain: "x.com", Email: "a@x.com"},
+	}
+	owners := map[bindregistry.BindKey]bindregistry.BindOwner{}
+	planned, issues := PlanAcmeChallengeBinds("http-01", domains, owners)
+	if len(issues) > 0 {
+		t.Fatalf("unexpected issues: %v", issues)
+	}
+	key := bindregistry.BindKey{Address: "0.0.0.0", Port: 80, Network: bindregistry.ListenTCP}
+	if _, ok := planned[key]; !ok {
+		t.Fatal("expected TCP :80 challenge bind")
+	}
+}
+
+func TestPlanAcmeChallengeBindsDNS01NoBind(t *testing.T) {
+	domains := map[string]CaddyDomainCertSpec{
+		"x.com": {Domain: "x.com", Email: "a@x.com"},
+	}
+	owners := map[bindregistry.BindKey]bindregistry.BindOwner{}
+	planned, issues := PlanAcmeChallengeBinds("dns-01", domains, owners)
+	if len(issues) > 0 {
+		t.Fatalf("unexpected issues: %v", issues)
+	}
+	if len(planned) != 0 {
+		t.Fatalf("dns-01 should add no binds, got %v", planned)
+	}
+}
+
+func TestPlanAcmeChallengeBindsTLSALPN01(t *testing.T) {
+	domains := map[string]CaddyDomainCertSpec{
+		"x.com": {Domain: "x.com", Email: "a@x.com"},
+	}
+	owners := map[bindregistry.BindKey]bindregistry.BindOwner{}
+	planned, issues := PlanAcmeChallengeBinds("tls-alpn-01", domains, owners)
+	if len(issues) > 0 {
+		t.Fatalf("unexpected issues: %v", issues)
+	}
+	key := bindregistry.BindKey{Address: "0.0.0.0", Port: 443, Network: bindregistry.ListenTCP}
+	if _, ok := planned[key]; !ok {
+		t.Fatal("expected TCP :443 challenge bind")
+	}
+}
+
+func TestPlanAcmeChallengeBindsHTTP01Conflict(t *testing.T) {
+	domains := map[string]CaddyDomainCertSpec{
+		"x.com": {Domain: "x.com", Email: "a@x.com"},
+	}
+	key := bindregistry.BindKey{Address: "0.0.0.0", Port: 80, Network: bindregistry.ListenTCP}
+	owners := map[bindregistry.BindKey]bindregistry.BindOwner{
+		key: {Kind: bindregistry.BindOwnerPanelDirect},
+	}
+	planned, issues := PlanAcmeChallengeBinds("http-01", domains, owners)
+	if len(planned) != 0 {
+		t.Fatalf("expected no planned binds on conflict, got %v", planned)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("expected one issue, got %v", issues)
+	}
+	if issues[0].Code != "acme_http01_port_in_use" {
+		t.Fatalf("expected acme_http01_port_in_use issue, got %v", issues[0])
+	}
+}
+
+func TestPlanAcmeChallengeBindsTLSALPN01Conflict(t *testing.T) {
+	domains := map[string]CaddyDomainCertSpec{
+		"x.com": {Domain: "x.com", Email: "a@x.com"},
+	}
+	key := bindregistry.BindKey{Address: "0.0.0.0", Port: 443, Network: bindregistry.ListenTCP}
+	owners := map[bindregistry.BindKey]bindregistry.BindOwner{
+		key: {Kind: bindregistry.BindOwnerPanelDirect},
+	}
+	planned, issues := PlanAcmeChallengeBinds("tls-alpn-01", domains, owners)
+	if len(planned) != 0 {
+		t.Fatalf("expected no planned binds on conflict, got %v", planned)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("expected one issue, got %v", issues)
+	}
+	if issues[0].Code != "acme_tlsalpn_port_in_use" {
+		t.Fatalf("expected acme_tlsalpn_port_in_use issue, got %v", issues[0])
+	}
+}
+
+func TestPlanAcmeChallengeBindsTLSALPN01ReusesCaddyListener(t *testing.T) {
+	domains := map[string]CaddyDomainCertSpec{
+		"x.com": {Domain: "x.com", Email: "a@x.com"},
+	}
+	key := bindregistry.BindKey{Address: "0.0.0.0", Port: 443, Network: bindregistry.ListenTCP}
+	owners := map[bindregistry.BindKey]bindregistry.BindOwner{
+		key: {Kind: bindregistry.BindOwnerPanelCaddy},
+	}
+	planned, issues := PlanAcmeChallengeBinds("tls-alpn-01", domains, owners)
+	if len(issues) > 0 {
+		t.Fatalf("unexpected issues: %v", issues)
+	}
+	if _, ok := planned[key]; !ok {
+		t.Fatal("expected TCP :443 challenge bind")
+	}
+}

--- a/internal/caddyassembly/challenge_test.go
+++ b/internal/caddyassembly/challenge_test.go
@@ -102,7 +102,7 @@ func TestPlanAcmeChallengeBindsTLSALPN01ReusesCaddyListener(t *testing.T) {
 	if len(issues) > 0 {
 		t.Fatalf("unexpected issues: %v", issues)
 	}
-	if _, ok := planned[key]; !ok {
-		t.Fatal("expected TCP :443 challenge bind")
+	if _, ok := planned[key]; ok {
+		t.Fatal("expected no TCP :443 challenge bind when a compatible Caddy listener already owns the port")
 	}
 }

--- a/internal/caddyassembly/domain.go
+++ b/internal/caddyassembly/domain.go
@@ -24,10 +24,10 @@ func ResolveDomainCertSpecs(settings model.Settings, inbounds []model.Inbound) (
 	owners := make(map[string]*CaddyDomainOwners)
 	emails := make(map[string]map[string]struct{})
 
-	if settings.PanelAccess == "caddy" && settings.Domain != "" {
-		domain := strings.ToLower(settings.Domain)
+	if settings.PanelAccess == "caddy" && settings.PanelDomain != "" {
+		domain := strings.ToLower(settings.PanelDomain)
 		ensureOwner(owners, domain).Panel = true
-		addEmail(emails, domain, settings.Email)
+		addEmail(emails, domain, settings.PanelEmail)
 	}
 
 	for _, inb := range inbounds {

--- a/internal/caddyassembly/domain.go
+++ b/internal/caddyassembly/domain.go
@@ -113,8 +113,5 @@ func naiveDomainWithFallback(inb model.Inbound, settings model.Settings) string 
 }
 
 func naiveEmailWithFallback(inb model.Inbound, settings model.Settings) string {
-	if e := stringField(inb.ProtocolFields, "email"); e != "" {
-		return e
-	}
-	return settings.Email
+	return stringField(inb.ProtocolFields, "email")
 }

--- a/internal/caddyassembly/domain.go
+++ b/internal/caddyassembly/domain.go
@@ -32,12 +32,12 @@ func ResolveDomainCertSpecs(settings model.Settings, inbounds []model.Inbound) (
 
 	for _, inb := range inbounds {
 		if inb.Protocol == "naiveproxy" {
-			domain := strings.ToLower(stringField(inb.ProtocolFields, "domain"))
+			domain := strings.ToLower(naiveDomainWithFallback(inb, settings))
 			if domain == "" {
 				continue
 			}
 			ensureOwner(owners, domain).NaiveInboundNames = append(ensureOwner(owners, domain).NaiveInboundNames, inb.Name)
-			addEmail(emails, domain, stringField(inb.ProtocolFields, "email"))
+			addEmail(emails, domain, naiveEmailWithFallback(inb, settings))
 		}
 		if inb.Protocol == "hysteria2" {
 			domain := strings.ToLower(stringField(inb.ProtocolFields, "domain"))
@@ -103,4 +103,18 @@ func stringField(m map[string]any, key string) string {
 		return ""
 	}
 	return v
+}
+
+func naiveDomainWithFallback(inb model.Inbound, settings model.Settings) string {
+	if d := stringField(inb.ProtocolFields, "domain"); d != "" {
+		return d
+	}
+	return settings.Domain
+}
+
+func naiveEmailWithFallback(inb model.Inbound, settings model.Settings) string {
+	if e := stringField(inb.ProtocolFields, "email"); e != "" {
+		return e
+	}
+	return settings.Email
 }

--- a/internal/caddyassembly/domain.go
+++ b/internal/caddyassembly/domain.go
@@ -1,0 +1,106 @@
+package caddyassembly
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/mikkelchokolate/Veil/internal/model"
+)
+
+type CaddyDomainOwners struct {
+	Panel                bool
+	NaiveInboundNames    []string
+	HysteriaInboundNames []string
+}
+
+type CaddyDomainCertSpec struct {
+	Domain string
+	Email  string
+	Owners CaddyDomainOwners
+}
+
+func ResolveDomainCertSpecs(settings model.Settings, inbounds []model.Inbound) (map[string]CaddyDomainCertSpec, error) {
+	owners := make(map[string]*CaddyDomainOwners)
+	emails := make(map[string]map[string]struct{})
+
+	if settings.PanelAccess == "caddy" && settings.Domain != "" {
+		domain := strings.ToLower(settings.Domain)
+		ensureOwner(owners, domain).Panel = true
+		addEmail(emails, domain, settings.Email)
+	}
+
+	for _, inb := range inbounds {
+		if inb.Protocol == "naiveproxy" {
+			domain := strings.ToLower(stringField(inb.ProtocolFields, "domain"))
+			if domain == "" {
+				continue
+			}
+			ensureOwner(owners, domain).NaiveInboundNames = append(ensureOwner(owners, domain).NaiveInboundNames, inb.Name)
+			addEmail(emails, domain, stringField(inb.ProtocolFields, "email"))
+		}
+		if inb.Protocol == "hysteria2" {
+			domain := strings.ToLower(stringField(inb.ProtocolFields, "domain"))
+			if domain == "" {
+				continue
+			}
+			ensureOwner(owners, domain).HysteriaInboundNames = append(ensureOwner(owners, domain).HysteriaInboundNames, inb.Name)
+			addEmail(emails, domain, stringField(inb.ProtocolFields, "email"))
+		}
+	}
+
+	specs := make(map[string]CaddyDomainCertSpec, len(owners))
+	for domain, o := range owners {
+		resolved, err := resolveEmail(domain, emails[domain], settings)
+		if err != nil {
+			return nil, err
+		}
+		specs[domain] = CaddyDomainCertSpec{Domain: domain, Email: resolved, Owners: *o}
+	}
+	return specs, nil
+}
+
+func ensureOwner(m map[string]*CaddyDomainOwners, domain string) *CaddyDomainOwners {
+	if m[domain] == nil {
+		m[domain] = &CaddyDomainOwners{}
+	}
+	return m[domain]
+}
+
+func addEmail(m map[string]map[string]struct{}, domain, email string) {
+	email = strings.TrimSpace(email)
+	if email == "" {
+		return
+	}
+	if m[domain] == nil {
+		m[domain] = make(map[string]struct{})
+	}
+	m[domain][email] = struct{}{}
+}
+
+func resolveEmail(domain string, explicit map[string]struct{}, settings model.Settings) (string, error) {
+	if len(explicit) > 1 {
+		return "", fmt.Errorf("domain %s has conflicting ACME emails", domain)
+	}
+	for e := range explicit {
+		return e, nil
+	}
+	if settings.DefaultAcmeEmail != "" {
+		return settings.DefaultAcmeEmail, nil
+	}
+	if settings.PanelEmail != "" {
+		return settings.PanelEmail, nil
+	}
+	return "", errors.New("no ACME email resolved for domain " + domain)
+}
+
+func stringField(m map[string]any, key string) string {
+	if m == nil {
+		return ""
+	}
+	v, ok := m[key].(string)
+	if !ok {
+		return ""
+	}
+	return v
+}

--- a/internal/caddyassembly/domain_test.go
+++ b/internal/caddyassembly/domain_test.go
@@ -31,3 +31,14 @@ func TestResolveDomainCertSpecsFallback(t *testing.T) {
 		t.Errorf("expected fallback email, got %q", specs["x.com"].Email)
 	}
 }
+
+func TestResolveDomainCertSpecsIgnoresLegacyGlobalEmailForNaive(t *testing.T) {
+	settings := model.Settings{PanelAccess: "direct", Email: "legacy@x.com"}
+	inbounds := []model.Inbound{
+		{Name: "n1", Protocol: "naiveproxy", ProtocolFields: map[string]any{"domain": "x.com"}},
+	}
+	_, err := ResolveDomainCertSpecs(settings, inbounds)
+	if err == nil {
+		t.Fatal("expected error when no explicit/default/panel email is available")
+	}
+}

--- a/internal/caddyassembly/domain_test.go
+++ b/internal/caddyassembly/domain_test.go
@@ -1,0 +1,33 @@
+package caddyassembly
+
+import (
+	"testing"
+
+	"github.com/mikkelchokolate/Veil/internal/model"
+)
+
+func TestResolveDomainCertSpecsConflictingEmail(t *testing.T) {
+	settings := model.Settings{PanelAccess: "direct"}
+	inbounds := []model.Inbound{
+		{Name: "n1", Protocol: "naiveproxy", ProtocolFields: map[string]any{"domain": "x.com", "email": "a@x.com"}},
+		{Name: "n2", Protocol: "naiveproxy", ProtocolFields: map[string]any{"domain": "x.com", "email": "b@x.com"}},
+	}
+	_, err := ResolveDomainCertSpecs(settings, inbounds)
+	if err == nil {
+		t.Fatal("expected conflicting email error")
+	}
+}
+
+func TestResolveDomainCertSpecsFallback(t *testing.T) {
+	settings := model.Settings{PanelAccess: "direct", DefaultAcmeEmail: "admin@x.com"}
+	inbounds := []model.Inbound{
+		{Name: "n1", Protocol: "naiveproxy", ProtocolFields: map[string]any{"domain": "x.com"}},
+	}
+	specs, err := ResolveDomainCertSpecs(settings, inbounds)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if specs["x.com"].Email != "admin@x.com" {
+		t.Errorf("expected fallback email, got %q", specs["x.com"].Email)
+	}
+}

--- a/internal/caddyassembly/domain_test.go
+++ b/internal/caddyassembly/domain_test.go
@@ -32,6 +32,27 @@ func TestResolveDomainCertSpecsFallback(t *testing.T) {
 	}
 }
 
+func TestResolveDomainCertSpecsIncludesHysteria2OnlyDomain(t *testing.T) {
+	settings := model.Settings{PanelAccess: "direct", DefaultAcmeEmail: "admin@x.com"}
+	inbounds := []model.Inbound{
+		{Name: "hy2", Protocol: "hysteria2", ProtocolFields: map[string]any{"domain": "hy.example.com"}},
+	}
+	specs, err := ResolveDomainCertSpecs(settings, inbounds)
+	if err != nil {
+		t.Fatal(err)
+	}
+	spec, ok := specs["hy.example.com"]
+	if !ok {
+		t.Fatalf("expected hysteria2-only domain in specs, got %+v", specs)
+	}
+	if spec.Email != "admin@x.com" {
+		t.Errorf("expected email admin@x.com, got %q", spec.Email)
+	}
+	if len(spec.Owners.HysteriaInboundNames) != 1 || spec.Owners.HysteriaInboundNames[0] != "hy2" {
+		t.Errorf("expected hysteria2 owner hy2, got %+v", spec.Owners.HysteriaInboundNames)
+	}
+}
+
 func TestResolveDomainCertSpecsIgnoresLegacyGlobalEmailForNaive(t *testing.T) {
 	settings := model.Settings{PanelAccess: "direct", Email: "legacy@x.com"}
 	inbounds := []model.Inbound{

--- a/internal/caddyassembly/hdd_happy_path_test.go
+++ b/internal/caddyassembly/hdd_happy_path_test.go
@@ -92,6 +92,8 @@ func TestBuildFinalRenderPlan_NaiveTCP443ConflictsWithPanelCaddy(t *testing.T) {
 		PanelDomain:       "panel.hy.flow2go.ru",
 		PanelPublicPort:   443,
 		PanelEmail:        "admin@hy.flow2go.ru",
+		PanelListen:       "127.0.0.1:2096",
+		WebBasePath:       "/panel/",
 		DefaultAcmeEmail:  "admin@hy.flow2go.ru",
 		AcmeChallengeMode: "tls-alpn-01",
 	}

--- a/internal/caddyassembly/hdd_happy_path_test.go
+++ b/internal/caddyassembly/hdd_happy_path_test.go
@@ -1,0 +1,199 @@
+package caddyassembly_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mikkelchokolate/Veil/internal/bindregistry"
+	"github.com/mikkelchokolate/Veil/internal/caddyassembly"
+	"github.com/mikkelchokolate/Veil/internal/model"
+)
+
+func naiveInbound(name, domain string, publicPort int, transport string, profiles ...model.ClientProfile) model.Inbound {
+	return model.Inbound{
+		Name:     name,
+		Protocol: "naiveproxy",
+		Enabled:  true,
+		Profiles: profiles,
+		ProtocolFields: map[string]any{
+			"domain":     domain,
+			"transport":  transport,
+			"publicPort": publicPort,
+		},
+	}
+}
+
+// TestBuildFinalRenderPlan_NaiveTCP443HappyPath verifies the happy path for a
+// single naiveproxy inbound on the default public port.
+func TestBuildFinalRenderPlan_NaiveTCP443HappyPath(t *testing.T) {
+	settings := model.Settings{
+		PanelAccess:              "direct",
+		DefaultInboundPublicPort: 443,
+		DefaultAcmeEmail:         "admin@hy.flow2go.ru",
+		AcmeChallengeMode:        "tls-alpn-01",
+	}
+	inbounds := []model.Inbound{
+		naiveInbound("test", "hy.flow2go.ru", 443, "tcp",
+			model.ClientProfile{Name: "default", Username: "user", Password: "pass", Enabled: true}),
+	}
+
+	plan, owners, issues, err := caddyassembly.BuildFinalRenderPlan(settings, inbounds)
+	if err != nil {
+		t.Fatalf("BuildFinalRenderPlan error: %v", err)
+	}
+	if len(issues) > 0 {
+		t.Fatalf("unexpected validation issues: %+v", issues)
+	}
+
+	naiveKey := bindregistry.BindKey{Address: "0.0.0.0", Port: 443, Network: bindregistry.ListenTCP}
+	owner := owners[naiveKey]
+	if owner.Kind != bindregistry.BindOwnerNaive {
+		t.Fatalf("expected naive owner on TCP :443, got %+v", owner)
+	}
+	if owner.InboundName != "test" {
+		t.Errorf("owner.InboundName = %q, want test", owner.InboundName)
+	}
+
+	server := plan.Servers[naiveKey]
+	if server.Kind != caddyassembly.CaddyOwnerNaive {
+		t.Fatalf("expected naive server, got %+v", server)
+	}
+	if server.Domain != "hy.flow2go.ru" {
+		t.Errorf("server.Domain = %q, want hy.flow2go.ru", server.Domain)
+	}
+	if server.Transport != "tcp" {
+		t.Errorf("server.Transport = %q, want tcp", server.Transport)
+	}
+	if len(server.NaiveUsers) != 1 {
+		t.Fatalf("expected 1 naive user, got %d", len(server.NaiveUsers))
+	}
+	if server.NaiveUsers[0].Username != "user" || server.NaiveUsers[0].Password != "pass" {
+		t.Errorf("unexpected credentials: %+v", server.NaiveUsers[0])
+	}
+
+	spec, ok := plan.Domains["hy.flow2go.ru"]
+	if !ok {
+		t.Fatal("expected domain cert spec for hy.flow2go.ru")
+	}
+	if spec.Email != "admin@hy.flow2go.ru" {
+		t.Errorf("spec.Email = %q, want admin@hy.flow2go.ru", spec.Email)
+	}
+	if len(spec.Owners.NaiveInboundNames) != 1 || spec.Owners.NaiveInboundNames[0] != "test" {
+		t.Errorf("unexpected domain owners: %+v", spec.Owners)
+	}
+}
+
+// TestBuildFinalRenderPlan_NaiveTCP443ConflictsWithPanelCaddy verifies that a
+// naive inbound on TCP :443 conflicts with the Panel caddy endpoint on the same
+// bind key.
+func TestBuildFinalRenderPlan_NaiveTCP443ConflictsWithPanelCaddy(t *testing.T) {
+	settings := model.Settings{
+		PanelAccess:       "caddy",
+		PanelDomain:       "panel.hy.flow2go.ru",
+		PanelPublicPort:   443,
+		PanelEmail:        "admin@hy.flow2go.ru",
+		DefaultAcmeEmail:  "admin@hy.flow2go.ru",
+		AcmeChallengeMode: "tls-alpn-01",
+	}
+	inbounds := []model.Inbound{
+		naiveInbound("test", "hy.flow2go.ru", 443, "tcp",
+			model.ClientProfile{Name: "default", Username: "user", Password: "pass", Enabled: true}),
+	}
+
+	_, _, _, err := caddyassembly.BuildFinalRenderPlan(settings, inbounds)
+	if err == nil {
+		t.Fatal("expected bind conflict between Panel caddy and naive inbound on TCP :443")
+	}
+	if !strings.Contains(err.Error(), "already owned") {
+		t.Fatalf("expected ownership conflict error, got %v", err)
+	}
+}
+
+// TestBuildFinalRenderPlan_NaiveFlatCredentialFallback verifies that
+// inbound.NaiveUsername / inbound.NaivePassword are used as credentials when no
+// profiles are present, matching the validation logic in apply_plan_builder.go
+// and the naiveproxy plugin fallback chain.
+func TestBuildFinalRenderPlan_NaiveFlatCredentialFallback(t *testing.T) {
+	settings := model.Settings{
+		PanelAccess:              "direct",
+		DefaultInboundPublicPort: 443,
+		DefaultAcmeEmail:         "admin@hy.flow2go.ru",
+		AcmeChallengeMode:        "tls-alpn-01",
+	}
+	inbounds := []model.Inbound{{
+		Name:         "test",
+		Protocol:     "naiveproxy",
+		Enabled:      true,
+		NaiveUsername: "flat-user",
+		NaivePassword: "flat-pass",
+		ProtocolFields: map[string]any{
+			"domain":    "hy.flow2go.ru",
+			"transport": "tcp",
+			"publicPort": 443,
+		},
+	}}
+
+	plan, _, _, err := caddyassembly.BuildFinalRenderPlan(settings, inbounds)
+	if err != nil {
+		t.Fatalf("BuildFinalRenderPlan error: %v", err)
+	}
+	server := plan.Servers[bindregistry.BindKey{Address: "0.0.0.0", Port: 443, Network: bindregistry.ListenTCP}]
+	if len(server.NaiveUsers) != 1 {
+		t.Fatalf("expected 1 naive user, got %d", len(server.NaiveUsers))
+	}
+	if server.NaiveUsers[0].Username != "flat-user" || server.NaiveUsers[0].Password != "flat-pass" {
+		t.Errorf("unexpected credentials: %+v", server.NaiveUsers[0])
+	}
+}
+
+// TestBuildFinalRenderPlan_SameDomainDifferentPortsSharedCert verifies that two
+// naive inbounds using the same domain on different public ports share domain
+// certificate ownership while owning distinct bind keys.
+func TestBuildFinalRenderPlan_SameDomainDifferentPortsSharedCert(t *testing.T) {
+	settings := model.Settings{
+		PanelAccess:              "direct",
+		DefaultInboundPublicPort: 443,
+		DefaultAcmeEmail:         "admin@hy.flow2go.ru",
+		AcmeChallengeMode:        "tls-alpn-01",
+	}
+	inbounds := []model.Inbound{
+		naiveInbound("test-a", "hy.flow2go.ru", 443, "tcp",
+			model.ClientProfile{Name: "default", Username: "user-a", Password: "pass-a", Enabled: true}),
+		naiveInbound("test-b", "hy.flow2go.ru", 8443, "tcp",
+			model.ClientProfile{Name: "default", Username: "user-b", Password: "pass-b", Enabled: true}),
+	}
+
+	plan, owners, _, err := caddyassembly.BuildFinalRenderPlan(settings, inbounds)
+	if err != nil {
+		t.Fatalf("BuildFinalRenderPlan error: %v", err)
+	}
+
+	conflicts := bindregistry.ValidateNoConflicts(owners)
+	if len(conflicts) != 0 {
+		t.Fatalf("unexpected bind conflicts: %+v", conflicts)
+	}
+
+	tcp443 := bindregistry.BindKey{Address: "0.0.0.0", Port: 443, Network: bindregistry.ListenTCP}
+	tcp8443 := bindregistry.BindKey{Address: "0.0.0.0", Port: 8443, Network: bindregistry.ListenTCP}
+	if owners[tcp443].InboundName != "test-a" {
+		t.Errorf("TCP :443 owner = %+v, want test-a", owners[tcp443])
+	}
+	if owners[tcp8443].InboundName != "test-b" {
+		t.Errorf("TCP :8443 owner = %+v, want test-b", owners[tcp8443])
+	}
+
+	spec, ok := plan.Domains["hy.flow2go.ru"]
+	if !ok {
+		t.Fatal("expected shared domain cert spec for hy.flow2go.ru")
+	}
+	if len(spec.Owners.NaiveInboundNames) != 2 {
+		t.Fatalf("expected 2 naive owners, got %d: %+v", len(spec.Owners.NaiveInboundNames), spec.Owners.NaiveInboundNames)
+	}
+	if spec.Email != "admin@hy.flow2go.ru" {
+		t.Errorf("spec.Email = %q, want admin@hy.flow2go.ru", spec.Email)
+	}
+
+	if len(plan.Servers) != 2 {
+		t.Fatalf("expected 2 servers, got %d", len(plan.Servers))
+	}
+}

--- a/internal/caddyassembly/plan.go
+++ b/internal/caddyassembly/plan.go
@@ -60,7 +60,13 @@ func BuildRenderPlan(
 			return CaddyRenderPlan{}, nil, fmt.Errorf("panel domain is required for caddy Panel access")
 		}
 		backendPort := panelBackendPort(settings.PanelListen)
+		if backendPort == 0 {
+			return CaddyRenderPlan{}, nil, fmt.Errorf("panelListen must be host:port")
+		}
 		webBasePath := veilsettings.NormalizeWebBasePath(settings.WebBasePath)
+		if webBasePath == "" || webBasePath == "/" {
+			return CaddyRenderPlan{}, nil, fmt.Errorf("webBasePath is required for caddy Panel access")
+		}
 		publicPort := settings.PanelPublicPort
 		if publicPort == 0 {
 			publicPort = 443

--- a/internal/caddyassembly/plan.go
+++ b/internal/caddyassembly/plan.go
@@ -3,6 +3,7 @@ package caddyassembly
 import (
 	"net"
 	"strconv"
+	"strings"
 
 	"github.com/mikkelchokolate/Veil/internal/bindregistry"
 	"github.com/mikkelchokolate/Veil/internal/model"
@@ -20,14 +21,22 @@ type CaddyBindOwner struct {
 	Kind        CaddyBindOwnerKind
 	Domain      string
 	InboundName string
-	BackendPort int    // Panel backend port parsed from PanelListen; used only for Panel owner
-	WebBasePath string // Normalized panel web base path; used only for Panel owner
+	BackendPort int              // Panel backend port parsed from PanelListen; used only for Panel owner
+	WebBasePath string           // Normalized panel web base path; used only for Panel owner
+	NaiveUsers  []CaddyNaiveUser // Only for naive owner
+}
+
+// CaddyNaiveUser is a minimal credential pair for the forward_proxy handler.
+type CaddyNaiveUser struct {
+	Username string
+	Password string
 }
 
 type CaddyRenderPlan struct {
-	Servers        map[bindregistry.BindKey]CaddyBindOwner
-	ACMEChallenges map[bindregistry.BindKey]AcmeChallengeOwner
-	Domains        map[string]CaddyDomainCertSpec
+	Servers              map[bindregistry.BindKey]CaddyBindOwner
+	ACMEChallenges       map[bindregistry.BindKey]AcmeChallengeOwner
+	Domains              map[string]CaddyDomainCertSpec
+	DefaultChallengeMode string
 }
 
 func BuildRenderPlan(
@@ -62,7 +71,8 @@ func BuildRenderPlan(
 		transport := naiveTransport(inb)
 		port := naivePublicPort(settings, inb)
 		domain := naiveDomain(inb, settings)
-		addNaiveBinds(transport, port, domain, inb.Name, owners, servers)
+		users := naiveUsers(inb, settings)
+		addNaiveBinds(transport, port, domain, inb.Name, users, owners, servers)
 	}
 
 	domains, err := ResolveDomainCertSpecs(settings, inbounds)
@@ -71,22 +81,23 @@ func BuildRenderPlan(
 	}
 
 	return CaddyRenderPlan{
-		Servers:        servers,
-		ACMEChallenges: challengeBinds,
-		Domains:        domains,
+		Servers:              servers,
+		ACMEChallenges:       challengeBinds,
+		Domains:              domains,
+		DefaultChallengeMode: settings.AcmeChallengeMode,
 	}, owners, nil
 }
 
-func addNaiveBinds(transport string, port int, domain, name string, owners map[bindregistry.BindKey]bindregistry.BindOwner, servers map[bindregistry.BindKey]CaddyBindOwner) {
+func addNaiveBinds(transport string, port int, domain, name string, users []CaddyNaiveUser, owners map[bindregistry.BindKey]bindregistry.BindOwner, servers map[bindregistry.BindKey]CaddyBindOwner) {
 	if transport == "tcp" || transport == "dual" {
 		key := bindregistry.BindKey{Address: "0.0.0.0", Port: port, Network: bindregistry.ListenTCP}
 		owners[key] = bindregistry.BindOwner{Kind: bindregistry.BindOwnerNaive, ServiceName: "veil-caddy.service", InboundName: name}
-		servers[key] = CaddyBindOwner{Kind: CaddyOwnerNaive, Domain: domain, InboundName: name}
+		servers[key] = CaddyBindOwner{Kind: CaddyOwnerNaive, Domain: domain, InboundName: name, NaiveUsers: users}
 	}
 	if transport == "quic" || transport == "dual" {
 		key := bindregistry.BindKey{Address: "0.0.0.0", Port: port, Network: bindregistry.ListenUDP}
 		owners[key] = bindregistry.BindOwner{Kind: bindregistry.BindOwnerNaive, ServiceName: "veil-caddy.service", InboundName: name}
-		servers[key] = CaddyBindOwner{Kind: CaddyOwnerNaive, Domain: domain, InboundName: name}
+		servers[key] = CaddyBindOwner{Kind: CaddyOwnerNaive, Domain: domain, InboundName: name, NaiveUsers: users}
 	}
 }
 
@@ -128,6 +139,31 @@ func naiveDomain(inbound model.Inbound, settings model.Settings) string {
 		return d
 	}
 	return settings.Domain
+}
+
+func naiveUsers(inbound model.Inbound, settings model.Settings) []CaddyNaiveUser {
+	var users []CaddyNaiveUser
+	for _, p := range inbound.Profiles {
+		if !p.Enabled || strings.TrimSpace(p.Username) == "" || strings.TrimSpace(p.Password) == "" {
+			continue
+		}
+		users = append(users, CaddyNaiveUser{Username: p.Username, Password: p.Password})
+	}
+	if len(users) > 0 {
+		return users
+	}
+	username := stringField(inbound.ProtocolFields, "naiveUsername")
+	if username == "" {
+		username = settings.NaiveUsername
+	}
+	password := stringField(inbound.ProtocolFields, "naivePassword")
+	if password == "" {
+		password = settings.NaivePassword
+	}
+	if username != "" && password != "" {
+		return []CaddyNaiveUser{{Username: username, Password: password}}
+	}
+	return nil
 }
 
 func panelBackendPort(panelListen string) int {

--- a/internal/caddyassembly/plan.go
+++ b/internal/caddyassembly/plan.go
@@ -216,8 +216,15 @@ func naiveFallbackRoot(inbound model.Inbound, settings model.Settings) string {
 
 func naiveUsers(inbound model.Inbound, settings model.Settings) []CaddyNaiveUser {
 	var users []CaddyNaiveUser
+	hasExplicitlyEnabledProfile := false
+	for _, profile := range inbound.Profiles {
+		if profile.Enabled {
+			hasExplicitlyEnabledProfile = true
+			break
+		}
+	}
 	for _, p := range inbound.Profiles {
-		if !p.Enabled || strings.TrimSpace(p.Password) == "" {
+		if (hasExplicitlyEnabledProfile && !p.Enabled) || strings.TrimSpace(p.Password) == "" {
 			continue
 		}
 		username := strings.TrimSpace(p.Username)

--- a/internal/caddyassembly/plan.go
+++ b/internal/caddyassembly/plan.go
@@ -21,6 +21,7 @@ type CaddyBindOwner struct {
 	Kind        CaddyBindOwnerKind
 	Domain      string
 	InboundName string
+	Transport   string           // Inbound transport; used only for Naive owner
 	BackendPort int              // Panel backend port parsed from PanelListen; used only for Panel owner
 	WebBasePath string           // Normalized panel web base path; used only for Panel owner
 	NaiveUsers  []CaddyNaiveUser // Only for naive owner
@@ -92,12 +93,12 @@ func addNaiveBinds(transport string, port int, domain, name string, users []Cadd
 	if transport == "tcp" || transport == "dual" {
 		key := bindregistry.BindKey{Address: "0.0.0.0", Port: port, Network: bindregistry.ListenTCP}
 		owners[key] = bindregistry.BindOwner{Kind: bindregistry.BindOwnerNaive, ServiceName: "veil-caddy.service", InboundName: name}
-		servers[key] = CaddyBindOwner{Kind: CaddyOwnerNaive, Domain: domain, InboundName: name, NaiveUsers: users}
+		servers[key] = CaddyBindOwner{Kind: CaddyOwnerNaive, Domain: domain, InboundName: name, Transport: transport, NaiveUsers: users}
 	}
 	if transport == "quic" || transport == "dual" {
 		key := bindregistry.BindKey{Address: "0.0.0.0", Port: port, Network: bindregistry.ListenUDP}
 		owners[key] = bindregistry.BindOwner{Kind: bindregistry.BindOwnerNaive, ServiceName: "veil-caddy.service", InboundName: name}
-		servers[key] = CaddyBindOwner{Kind: CaddyOwnerNaive, Domain: domain, InboundName: name, NaiveUsers: users}
+		servers[key] = CaddyBindOwner{Kind: CaddyOwnerNaive, Domain: domain, InboundName: name, Transport: transport, NaiveUsers: users}
 	}
 }
 

--- a/internal/caddyassembly/plan.go
+++ b/internal/caddyassembly/plan.go
@@ -1,0 +1,75 @@
+package caddyassembly
+
+import (
+	"github.com/mikkelchokolate/Veil/internal/bindregistry"
+	"github.com/mikkelchokolate/Veil/internal/model"
+	"github.com/mikkelchokolate/Veil/internal/protocols/naiveproxy"
+)
+
+type CaddyBindOwnerKind string
+
+const (
+	CaddyOwnerPanel CaddyBindOwnerKind = "panel"
+	CaddyOwnerNaive CaddyBindOwnerKind = "naive"
+)
+
+type CaddyBindOwner struct {
+	Kind        CaddyBindOwnerKind
+	Domain      string
+	InboundName string
+}
+
+type CaddyRenderPlan struct {
+	Servers        map[bindregistry.BindKey]CaddyBindOwner
+	ACMEChallenges map[bindregistry.BindKey]AcmeChallengeOwner
+	Domains        map[string]CaddyDomainCertSpec
+}
+
+func BuildRenderPlan(
+	settings model.Settings,
+	inbounds []model.Inbound,
+	challengeBinds map[bindregistry.BindKey]AcmeChallengeOwner,
+) (CaddyRenderPlan, map[bindregistry.BindKey]bindregistry.BindOwner, error) {
+	owners := make(map[bindregistry.BindKey]bindregistry.BindOwner)
+	servers := make(map[bindregistry.BindKey]CaddyBindOwner)
+
+	if settings.PanelAccess == "caddy" && settings.PanelDomain != "" {
+		key := bindregistry.BindKey{Address: "0.0.0.0", Port: settings.PanelPublicPort, Network: bindregistry.ListenTCP}
+		owners[key] = bindregistry.BindOwner{Kind: bindregistry.BindOwnerPanelCaddy, ServiceName: "veil-caddy.service"}
+		servers[key] = CaddyBindOwner{Kind: CaddyOwnerPanel, Domain: settings.PanelDomain}
+	}
+
+	for _, inb := range inbounds {
+		if inb.Protocol != "naiveproxy" || !inb.Enabled {
+			continue
+		}
+		transport := naiveproxy.NaiveTransport(inb)
+		port := naiveproxy.NaivePublicPort(settings, inb)
+		domain := naiveproxy.NaiveDomain(inb)
+		addNaiveBinds(transport, port, domain, inb.Name, owners, servers)
+	}
+
+	domains, err := ResolveDomainCertSpecs(settings, inbounds)
+	if err != nil {
+		return CaddyRenderPlan{}, nil, err
+	}
+
+	return CaddyRenderPlan{
+		Servers:        servers,
+		ACMEChallenges: challengeBinds,
+		Domains:        domains,
+	}, owners, nil
+}
+
+func addNaiveBinds(transport string, port int, domain, name string, owners map[bindregistry.BindKey]bindregistry.BindOwner, servers map[bindregistry.BindKey]CaddyBindOwner) {
+	if transport == "tcp" || transport == "dual" {
+		key := bindregistry.BindKey{Address: "0.0.0.0", Port: port, Network: bindregistry.ListenTCP}
+		owners[key] = bindregistry.BindOwner{Kind: bindregistry.BindOwnerNaive, ServiceName: "veil-caddy.service", InboundName: name}
+		servers[key] = CaddyBindOwner{Kind: CaddyOwnerNaive, Domain: domain, InboundName: name}
+	}
+	if transport == "quic" || transport == "dual" {
+		key := bindregistry.BindKey{Address: "0.0.0.0", Port: port, Network: bindregistry.ListenUDP}
+		owners[key] = bindregistry.BindOwner{Kind: bindregistry.BindOwnerNaive, ServiceName: "veil-caddy.service", InboundName: name}
+		servers[key] = CaddyBindOwner{Kind: CaddyOwnerNaive, Domain: domain, InboundName: name}
+	}
+}

--- a/internal/caddyassembly/plan.go
+++ b/internal/caddyassembly/plan.go
@@ -1,8 +1,12 @@
 package caddyassembly
 
 import (
+	"net"
+	"strconv"
+
 	"github.com/mikkelchokolate/Veil/internal/bindregistry"
 	"github.com/mikkelchokolate/Veil/internal/model"
+	veilsettings "github.com/mikkelchokolate/Veil/internal/settings"
 )
 
 type CaddyBindOwnerKind string
@@ -16,6 +20,8 @@ type CaddyBindOwner struct {
 	Kind        CaddyBindOwnerKind
 	Domain      string
 	InboundName string
+	BackendPort int    // Panel backend port parsed from PanelListen; used only for Panel owner
+	WebBasePath string // Normalized panel web base path; used only for Panel owner
 }
 
 type CaddyRenderPlan struct {
@@ -32,10 +38,21 @@ func BuildRenderPlan(
 	owners := make(map[bindregistry.BindKey]bindregistry.BindOwner)
 	servers := make(map[bindregistry.BindKey]CaddyBindOwner)
 
-	if settings.PanelAccess == "caddy" && settings.PanelDomain != "" {
-		key := bindregistry.BindKey{Address: "0.0.0.0", Port: settings.PanelPublicPort, Network: bindregistry.ListenTCP}
-		owners[key] = bindregistry.BindOwner{Kind: bindregistry.BindOwnerPanelCaddy, ServiceName: "veil-caddy.service"}
-		servers[key] = CaddyBindOwner{Kind: CaddyOwnerPanel, Domain: settings.PanelDomain}
+	if settings.PanelAccess == "caddy" {
+		panelDomain := settings.PanelDomain
+		if panelDomain == "" {
+			panelDomain = settings.Domain
+		}
+		if panelDomain != "" {
+			key := bindregistry.BindKey{Address: "0.0.0.0", Port: settings.PanelPublicPort, Network: bindregistry.ListenTCP}
+			owners[key] = bindregistry.BindOwner{Kind: bindregistry.BindOwnerPanelCaddy, ServiceName: "veil-caddy.service"}
+			servers[key] = CaddyBindOwner{
+				Kind:        CaddyOwnerPanel,
+				Domain:      panelDomain,
+				BackendPort: panelBackendPort(settings.PanelListen),
+				WebBasePath: veilsettings.NormalizeWebBasePath(settings.WebBasePath),
+			}
+		}
 	}
 
 	for _, inb := range inbounds {
@@ -44,7 +61,7 @@ func BuildRenderPlan(
 		}
 		transport := naiveTransport(inb)
 		port := naivePublicPort(settings, inb)
-		domain := naiveDomain(inb)
+		domain := naiveDomain(inb, settings)
 		addNaiveBinds(transport, port, domain, inb.Name, owners, servers)
 	}
 
@@ -103,7 +120,24 @@ func naivePublicPort(settings model.Settings, inbound model.Inbound) int {
 	return 443
 }
 
-// naiveDomain mirrors the naiveproxy plugin helper.
-func naiveDomain(inbound model.Inbound) string {
-	return stringField(inbound.ProtocolFields, "domain")
+// naiveDomain mirrors the naiveproxy plugin helper, falling back to the global
+// settings domain so existing state that stores the domain at the top level
+// continues to render.
+func naiveDomain(inbound model.Inbound, settings model.Settings) string {
+	if d := stringField(inbound.ProtocolFields, "domain"); d != "" {
+		return d
+	}
+	return settings.Domain
+}
+
+func panelBackendPort(panelListen string) int {
+	_, portText, err := net.SplitHostPort(panelListen)
+	if err != nil {
+		return 0
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil || port <= 0 || port > 65535 {
+		return 0
+	}
+	return port
 }

--- a/internal/caddyassembly/plan.go
+++ b/internal/caddyassembly/plan.go
@@ -3,7 +3,6 @@ package caddyassembly
 import (
 	"github.com/mikkelchokolate/Veil/internal/bindregistry"
 	"github.com/mikkelchokolate/Veil/internal/model"
-	"github.com/mikkelchokolate/Veil/internal/protocols/naiveproxy"
 )
 
 type CaddyBindOwnerKind string
@@ -43,9 +42,9 @@ func BuildRenderPlan(
 		if inb.Protocol != "naiveproxy" || !inb.Enabled {
 			continue
 		}
-		transport := naiveproxy.NaiveTransport(inb)
-		port := naiveproxy.NaivePublicPort(settings, inb)
-		domain := naiveproxy.NaiveDomain(inb)
+		transport := naiveTransport(inb)
+		port := naivePublicPort(settings, inb)
+		domain := naiveDomain(inb)
 		addNaiveBinds(transport, port, domain, inb.Name, owners, servers)
 	}
 
@@ -72,4 +71,39 @@ func addNaiveBinds(transport string, port int, domain, name string, owners map[b
 		owners[key] = bindregistry.BindOwner{Kind: bindregistry.BindOwnerNaive, ServiceName: "veil-caddy.service", InboundName: name}
 		servers[key] = CaddyBindOwner{Kind: CaddyOwnerNaive, Domain: domain, InboundName: name}
 	}
+}
+
+// naiveTransport mirrors the behavior of the naiveproxy plugin helper so that
+// caddyassembly can remain independent of the protocol package and avoid an
+// import cycle with the renderer.
+func naiveTransport(inbound model.Inbound) string {
+	t := stringField(inbound.ProtocolFields, "transport")
+	if t == "" {
+		return "tcp"
+	}
+	return t
+}
+
+// naivePublicPort mirrors the naiveproxy plugin helper.
+func naivePublicPort(settings model.Settings, inbound model.Inbound) int {
+	if v, ok := inbound.ProtocolFields["publicPort"]; ok {
+		if n, ok := v.(float64); ok {
+			return int(n)
+		}
+		if n, ok := v.(int); ok {
+			return n
+		}
+	}
+	if inbound.Port != 0 {
+		return inbound.Port
+	}
+	if settings.DefaultInboundPublicPort != 0 {
+		return settings.DefaultInboundPublicPort
+	}
+	return 443
+}
+
+// naiveDomain mirrors the naiveproxy plugin helper.
+func naiveDomain(inbound model.Inbound) string {
+	return stringField(inbound.ProtocolFields, "domain")
 }

--- a/internal/caddyassembly/plan.go
+++ b/internal/caddyassembly/plan.go
@@ -25,6 +25,7 @@ type CaddyBindOwner struct {
 	BackendPort int              // Panel backend port parsed from PanelListen; used only for Panel owner
 	WebBasePath string           // Normalized panel web base path; used only for Panel owner
 	NaiveUsers  []CaddyNaiveUser // Only for naive owner
+	FallbackRoot string          // Only for naive owner
 }
 
 // CaddyNaiveUser is a minimal credential pair for the forward_proxy handler.
@@ -73,7 +74,8 @@ func BuildRenderPlan(
 		port := naivePublicPort(settings, inb)
 		domain := naiveDomain(inb, settings)
 		users := naiveUsers(inb, settings)
-		addNaiveBinds(transport, port, domain, inb.Name, users, owners, servers)
+		fallbackRoot := naiveFallbackRoot(inb, settings)
+		addNaiveBinds(transport, port, domain, inb.Name, users, fallbackRoot, owners, servers)
 	}
 
 	domains, err := ResolveDomainCertSpecs(settings, inbounds)
@@ -89,16 +91,16 @@ func BuildRenderPlan(
 	}, owners, nil
 }
 
-func addNaiveBinds(transport string, port int, domain, name string, users []CaddyNaiveUser, owners map[bindregistry.BindKey]bindregistry.BindOwner, servers map[bindregistry.BindKey]CaddyBindOwner) {
+func addNaiveBinds(transport string, port int, domain, name string, users []CaddyNaiveUser, fallbackRoot string, owners map[bindregistry.BindKey]bindregistry.BindOwner, servers map[bindregistry.BindKey]CaddyBindOwner) {
 	if transport == "tcp" || transport == "dual" {
 		key := bindregistry.BindKey{Address: "0.0.0.0", Port: port, Network: bindregistry.ListenTCP}
 		owners[key] = bindregistry.BindOwner{Kind: bindregistry.BindOwnerNaive, ServiceName: "veil-caddy.service", InboundName: name}
-		servers[key] = CaddyBindOwner{Kind: CaddyOwnerNaive, Domain: domain, InboundName: name, Transport: transport, NaiveUsers: users}
+		servers[key] = CaddyBindOwner{Kind: CaddyOwnerNaive, Domain: domain, InboundName: name, Transport: transport, NaiveUsers: users, FallbackRoot: fallbackRoot}
 	}
 	if transport == "quic" || transport == "dual" {
 		key := bindregistry.BindKey{Address: "0.0.0.0", Port: port, Network: bindregistry.ListenUDP}
 		owners[key] = bindregistry.BindOwner{Kind: bindregistry.BindOwnerNaive, ServiceName: "veil-caddy.service", InboundName: name}
-		servers[key] = CaddyBindOwner{Kind: CaddyOwnerNaive, Domain: domain, InboundName: name, Transport: transport, NaiveUsers: users}
+		servers[key] = CaddyBindOwner{Kind: CaddyOwnerNaive, Domain: domain, InboundName: name, Transport: transport, NaiveUsers: users, FallbackRoot: fallbackRoot}
 	}
 }
 
@@ -140,6 +142,21 @@ func naiveDomain(inbound model.Inbound, settings model.Settings) string {
 		return d
 	}
 	return settings.Domain
+}
+
+// naiveFallbackRoot mirrors the naiveproxy plugin helper to avoid an import
+// cycle with the renderer. It falls back to the built-in default web root.
+func naiveFallbackRoot(inbound model.Inbound, settings model.Settings) string {
+	if root := stringField(inbound.ProtocolFields, "fallbackRoot"); root != "" {
+		return root
+	}
+	if inbound.FallbackRoot != "" {
+		return inbound.FallbackRoot
+	}
+	if settings.FallbackRoot != "" {
+		return settings.FallbackRoot
+	}
+	return "/var/lib/veil/www"
 }
 
 func naiveUsers(inbound model.Inbound, settings model.Settings) []CaddyNaiveUser {

--- a/internal/caddyassembly/plan.go
+++ b/internal/caddyassembly/plan.go
@@ -1,6 +1,7 @@
 package caddyassembly
 
 import (
+	"fmt"
 	"net"
 	"strconv"
 	"strings"
@@ -71,6 +72,9 @@ func BuildRenderPlan(
 			continue
 		}
 		transport := naiveTransport(inb)
+		if transport != "tcp" {
+			return CaddyRenderPlan{}, nil, fmt.Errorf("naive inbound %q uses unsupported transport %q (only tcp is supported)", inb.Name, transport)
+		}
 		port := naivePublicPort(settings, inb)
 		domain := naiveDomain(inb, settings)
 		users := naiveUsers(inb, settings)
@@ -172,9 +176,15 @@ func naiveUsers(inbound model.Inbound, settings model.Settings) []CaddyNaiveUser
 	}
 	username := stringField(inbound.ProtocolFields, "naiveUsername")
 	if username == "" {
+		username = stringField(settings.ProtocolFields, "naiveUsername")
+	}
+	if username == "" {
 		username = settings.NaiveUsername
 	}
 	password := stringField(inbound.ProtocolFields, "naivePassword")
+	if password == "" {
+		password = stringField(settings.ProtocolFields, "naivePassword")
+	}
 	if password == "" {
 		password = settings.NaivePassword
 	}

--- a/internal/caddyassembly/plan.go
+++ b/internal/caddyassembly/plan.go
@@ -19,14 +19,14 @@ const (
 )
 
 type CaddyBindOwner struct {
-	Kind        CaddyBindOwnerKind
-	Domain      string
-	InboundName string
-	Transport   string           // Inbound transport; used only for Naive owner
-	BackendPort int              // Panel backend port parsed from PanelListen; used only for Panel owner
-	WebBasePath string           // Normalized panel web base path; used only for Panel owner
-	NaiveUsers  []CaddyNaiveUser // Only for naive owner
-	FallbackRoot string          // Only for naive owner
+	Kind         CaddyBindOwnerKind
+	Domain       string
+	InboundName  string
+	Transport    string           // Inbound transport; used only for Naive owner
+	BackendPort  int              // Panel backend port parsed from PanelListen; used only for Panel owner
+	WebBasePath  string           // Normalized panel web base path; used only for Panel owner
+	NaiveUsers   []CaddyNaiveUser // Only for naive owner
+	FallbackRoot string           // Only for naive owner
 }
 
 // CaddyNaiveUser is a minimal credential pair for the forward_proxy handler.
@@ -57,12 +57,16 @@ func BuildRenderPlan(
 		}
 		if panelDomain != "" {
 			key := bindregistry.BindKey{Address: "0.0.0.0", Port: settings.PanelPublicPort, Network: bindregistry.ListenTCP}
-			owners[key] = bindregistry.BindOwner{Kind: bindregistry.BindOwnerPanelCaddy, ServiceName: "veil-caddy.service"}
-			servers[key] = CaddyBindOwner{
+			if err := setOwner(owners, key, bindregistry.BindOwner{Kind: bindregistry.BindOwnerPanelCaddy, ServiceName: "veil-caddy.service"}); err != nil {
+				return CaddyRenderPlan{}, nil, err
+			}
+			if err := setServer(servers, key, CaddyBindOwner{
 				Kind:        CaddyOwnerPanel,
 				Domain:      panelDomain,
 				BackendPort: panelBackendPort(settings.PanelListen),
 				WebBasePath: veilsettings.NormalizeWebBasePath(settings.WebBasePath),
+			}); err != nil {
+				return CaddyRenderPlan{}, nil, err
 			}
 		}
 	}
@@ -79,7 +83,9 @@ func BuildRenderPlan(
 		domain := naiveDomain(inb, settings)
 		users := naiveUsers(inb, settings)
 		fallbackRoot := naiveFallbackRoot(inb, settings)
-		addNaiveBinds(transport, port, domain, inb.Name, users, fallbackRoot, owners, servers)
+		if err := addNaiveBinds(transport, port, domain, inb.Name, users, fallbackRoot, owners, servers); err != nil {
+			return CaddyRenderPlan{}, nil, err
+		}
 	}
 
 	domains, err := ResolveDomainCertSpecs(settings, inbounds)
@@ -117,17 +123,26 @@ func BuildFinalRenderPlan(
 	return plan, owners, issues, nil
 }
 
-func addNaiveBinds(transport string, port int, domain, name string, users []CaddyNaiveUser, fallbackRoot string, owners map[bindregistry.BindKey]bindregistry.BindOwner, servers map[bindregistry.BindKey]CaddyBindOwner) {
+func addNaiveBinds(transport string, port int, domain, name string, users []CaddyNaiveUser, fallbackRoot string, owners map[bindregistry.BindKey]bindregistry.BindOwner, servers map[bindregistry.BindKey]CaddyBindOwner) error {
 	if transport == "tcp" || transport == "dual" {
 		key := bindregistry.BindKey{Address: "0.0.0.0", Port: port, Network: bindregistry.ListenTCP}
-		owners[key] = bindregistry.BindOwner{Kind: bindregistry.BindOwnerNaive, ServiceName: "veil-caddy.service", InboundName: name}
-		servers[key] = CaddyBindOwner{Kind: CaddyOwnerNaive, Domain: domain, InboundName: name, Transport: transport, NaiveUsers: users, FallbackRoot: fallbackRoot}
+		if err := setOwner(owners, key, bindregistry.BindOwner{Kind: bindregistry.BindOwnerNaive, ServiceName: "veil-caddy.service", InboundName: name}); err != nil {
+			return err
+		}
+		if err := setServer(servers, key, CaddyBindOwner{Kind: CaddyOwnerNaive, Domain: domain, InboundName: name, Transport: transport, NaiveUsers: users, FallbackRoot: fallbackRoot}); err != nil {
+			return err
+		}
 	}
 	if transport == "quic" || transport == "dual" {
 		key := bindregistry.BindKey{Address: "0.0.0.0", Port: port, Network: bindregistry.ListenUDP}
-		owners[key] = bindregistry.BindOwner{Kind: bindregistry.BindOwnerNaive, ServiceName: "veil-caddy.service", InboundName: name}
-		servers[key] = CaddyBindOwner{Kind: CaddyOwnerNaive, Domain: domain, InboundName: name, Transport: transport, NaiveUsers: users, FallbackRoot: fallbackRoot}
+		if err := setOwner(owners, key, bindregistry.BindOwner{Kind: bindregistry.BindOwnerNaive, ServiceName: "veil-caddy.service", InboundName: name}); err != nil {
+			return err
+		}
+		if err := setServer(servers, key, CaddyBindOwner{Kind: CaddyOwnerNaive, Domain: domain, InboundName: name, Transport: transport, NaiveUsers: users, FallbackRoot: fallbackRoot}); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 // naiveTransport mirrors the behavior of the naiveproxy plugin helper so that
@@ -198,12 +213,21 @@ func naiveUsers(inbound model.Inbound, settings model.Settings) []CaddyNaiveUser
 	}
 	username := stringField(inbound.ProtocolFields, "naiveUsername")
 	if username == "" {
+		username = strings.TrimSpace(inbound.NaiveUsername)
+	}
+	if username == "" {
 		username = stringField(settings.ProtocolFields, "naiveUsername")
 	}
 	if username == "" {
 		username = settings.NaiveUsername
 	}
-	password := stringField(inbound.ProtocolFields, "naivePassword")
+	password := strings.TrimSpace(inbound.Password)
+	if password == "" {
+		password = stringField(inbound.ProtocolFields, "naivePassword")
+	}
+	if password == "" {
+		password = strings.TrimSpace(inbound.NaivePassword)
+	}
 	if password == "" {
 		password = stringField(settings.ProtocolFields, "naivePassword")
 	}
@@ -213,6 +237,24 @@ func naiveUsers(inbound model.Inbound, settings model.Settings) []CaddyNaiveUser
 	if username != "" && password != "" {
 		return []CaddyNaiveUser{{Username: username, Password: password}}
 	}
+	return nil
+}
+
+func setOwner(owners map[bindregistry.BindKey]bindregistry.BindOwner, key bindregistry.BindKey, owner bindregistry.BindOwner) error {
+	if existing, ok := owners[key]; ok && existing != owner {
+		return fmt.Errorf("%s %s:%d is already owned by %s %s", key.Network, key.Address, key.Port, existing.Kind, existing.InboundName)
+	}
+	owners[key] = owner
+	return nil
+}
+
+func setServer(servers map[bindregistry.BindKey]CaddyBindOwner, key bindregistry.BindKey, server CaddyBindOwner) error {
+	if existing, ok := servers[key]; ok {
+		if existing.Kind != server.Kind || existing.InboundName != server.InboundName {
+			return fmt.Errorf("%s %s:%d already has a %s server", key.Network, key.Address, key.Port, existing.Kind)
+		}
+	}
+	servers[key] = server
 	return nil
 }
 

--- a/internal/caddyassembly/plan.go
+++ b/internal/caddyassembly/plan.go
@@ -95,6 +95,28 @@ func BuildRenderPlan(
 	}, owners, nil
 }
 
+// BuildFinalRenderPlan constructs the complete Caddy render plan including ACME
+// challenge binds. It first builds the server-owner map, plans challenge binds
+// based on those owners, merges challenge owners into the global owner map, and
+// returns the final plan along with any validation issues raised by challenge
+// planning.
+func BuildFinalRenderPlan(
+	settings model.Settings,
+	inbounds []model.Inbound,
+) (CaddyRenderPlan, map[bindregistry.BindKey]bindregistry.BindOwner, []model.ValidationIssue, error) {
+	plan, owners, err := BuildRenderPlan(settings, inbounds, nil)
+	if err != nil {
+		return CaddyRenderPlan{}, nil, nil, err
+	}
+
+	challengeBinds, issues := PlanAcmeChallengeBinds(settings.AcmeChallengeMode, plan.Domains, owners)
+	for key := range challengeBinds {
+		owners[key] = bindregistry.BindOwner{Kind: bindregistry.BindOwnerAcmeChallenge, ServiceName: "veil-caddy.service"}
+	}
+	plan.ACMEChallenges = challengeBinds
+	return plan, owners, issues, nil
+}
+
 func addNaiveBinds(transport string, port int, domain, name string, users []CaddyNaiveUser, fallbackRoot string, owners map[bindregistry.BindKey]bindregistry.BindOwner, servers map[bindregistry.BindKey]CaddyBindOwner) {
 	if transport == "tcp" || transport == "dual" {
 		key := bindregistry.BindKey{Address: "0.0.0.0", Port: port, Network: bindregistry.ListenTCP}

--- a/internal/caddyassembly/plan_test.go
+++ b/internal/caddyassembly/plan_test.go
@@ -1,6 +1,7 @@
 package caddyassembly
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/mikkelchokolate/Veil/internal/bindregistry"
@@ -40,5 +41,28 @@ func TestBuildRenderPlanPanelAndNaive(t *testing.T) {
 	naiveKey := bindregistry.BindKey{Address: "0.0.0.0", Port: 8443, Network: bindregistry.ListenTCP}
 	if owners[naiveKey].Kind != bindregistry.BindOwnerNaive {
 		t.Error("expected naive owner on TCP 8443")
+	}
+}
+
+func TestBuildRenderPlanRejectsNaiveNonTCPTransport(t *testing.T) {
+	settings := model.Settings{}
+	inbounds := []model.Inbound{
+		{
+			Name:     "naive-quic",
+			Protocol: "naiveproxy",
+			Enabled:  true,
+			ProtocolFields: map[string]any{
+				"domain":     "proxy.example.com",
+				"transport":  "quic",
+				"publicPort": 8443,
+			},
+		},
+	}
+	_, _, err := BuildRenderPlan(settings, inbounds, nil)
+	if err == nil {
+		t.Fatal("expected error for non-tcp naive transport")
+	}
+	if !strings.Contains(err.Error(), "only tcp is supported") {
+		t.Fatalf("expected unsupported transport error, got %v", err)
 	}
 }

--- a/internal/caddyassembly/plan_test.go
+++ b/internal/caddyassembly/plan_test.go
@@ -14,6 +14,8 @@ func TestBuildRenderPlanPanelAndNaive(t *testing.T) {
 		PanelDomain:     "panel.example.com",
 		PanelPublicPort: 443,
 		PanelEmail:      "admin@example.com",
+		PanelListen:     "127.0.0.1:2096",
+		WebBasePath:    "/panel/",
 	}
 	inbounds := []model.Inbound{
 		{

--- a/internal/caddyassembly/plan_test.go
+++ b/internal/caddyassembly/plan_test.go
@@ -1,0 +1,44 @@
+package caddyassembly
+
+import (
+	"testing"
+
+	"github.com/mikkelchokolate/Veil/internal/bindregistry"
+	"github.com/mikkelchokolate/Veil/internal/model"
+)
+
+func TestBuildRenderPlanPanelAndNaive(t *testing.T) {
+	settings := model.Settings{
+		PanelAccess:     "caddy",
+		PanelDomain:     "panel.example.com",
+		PanelPublicPort: 443,
+		PanelEmail:      "admin@example.com",
+	}
+	inbounds := []model.Inbound{
+		{
+			Name:     "naive-1",
+			Protocol: "naiveproxy",
+			Enabled:  true,
+			ProtocolFields: map[string]any{
+				"domain":     "proxy.example.com",
+				"transport":  "tcp",
+				"publicPort": 8443,
+			},
+		},
+	}
+	plan, owners, err := BuildRenderPlan(settings, inbounds, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	panelKey := bindregistry.BindKey{Address: "0.0.0.0", Port: 443, Network: bindregistry.ListenTCP}
+	if owners[panelKey].Kind != bindregistry.BindOwnerPanelCaddy {
+		t.Error("expected Panel Caddy owner on TCP 443")
+	}
+	if plan.Servers[panelKey].Kind != CaddyOwnerPanel {
+		t.Error("expected Panel server in render plan")
+	}
+	naiveKey := bindregistry.BindKey{Address: "0.0.0.0", Port: 8443, Network: bindregistry.ListenTCP}
+	if owners[naiveKey].Kind != bindregistry.BindOwnerNaive {
+		t.Error("expected naive owner on TCP 8443")
+	}
+}

--- a/internal/caddycapabilities/capabilities.go
+++ b/internal/caddycapabilities/capabilities.go
@@ -13,7 +13,7 @@ type CaddyCapabilities struct {
 }
 
 type caddyModule struct {
-	Name string `json:"name"`
+	Name string `json:"module_name"`
 }
 
 func Probe(binaryPath string) (CaddyCapabilities, error) {

--- a/internal/caddycapabilities/capabilities.go
+++ b/internal/caddycapabilities/capabilities.go
@@ -1,0 +1,73 @@
+package caddycapabilities
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+)
+
+type CaddyCapabilities struct {
+	ForwardProxy bool
+	HTTP3        bool
+	H3Only       bool
+}
+
+type caddyModule struct {
+	Name string `json:"name"`
+}
+
+func Probe(binaryPath string) (CaddyCapabilities, error) {
+	if binaryPath == "" {
+		binaryPath = "caddy"
+	}
+	out, err := exec.Command(binaryPath, "list-modules", "--json").Output()
+	if err != nil {
+		return CaddyCapabilities{}, fmt.Errorf("caddy list-modules failed: %w", err)
+	}
+	modules, err := parseModules(out)
+	if err != nil {
+		return CaddyCapabilities{}, err
+	}
+	caps := CaddyCapabilities{
+		ForwardProxy: hasModule(modules, "http.handlers.forward_proxy"),
+	}
+	// HTTP3 is available in standard Caddy builds; this flag is set true when
+	// the base http app module is present. H3Only is intentionally left false
+	// here and verified behaviorally before `quic` transport is accepted.
+	caps.HTTP3 = hasModule(modules, "http")
+	return caps, nil
+}
+
+func hasModule(modules []caddyModule, name string) bool {
+	for _, m := range modules {
+		if m.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func parseModules(data []byte) ([]caddyModule, error) {
+	var modules []caddyModule
+	if err := json.Unmarshal(data, &modules); err != nil {
+		return nil, err
+	}
+	return modules, nil
+}
+
+func parseModuleList(data []byte) (CaddyCapabilities, error) {
+	modules, err := parseModules(data)
+	if err != nil {
+		return CaddyCapabilities{}, err
+	}
+	var caps CaddyCapabilities
+	for _, m := range modules {
+		switch m.Name {
+		case "http.handlers.forward_proxy":
+			caps.ForwardProxy = true
+		case "http":
+			// HTTP base present
+		}
+	}
+	return caps, nil
+}

--- a/internal/caddycapabilities/capabilities_test.go
+++ b/internal/caddycapabilities/capabilities_test.go
@@ -1,0 +1,19 @@
+package caddycapabilities
+
+import "testing"
+
+func TestProbeParsesModuleList(t *testing.T) {
+	// A mock binary that prints a module list matching Caddy's `caddy list-modules --json` shape.
+	// For the plan we test parsing of a known JSON fragment.
+	input := `[
+	  {"name":"http.handlers.forward_proxy"},
+	  {"name":"http"}
+	]`
+	caps, err := parseModuleList([]byte(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !caps.ForwardProxy {
+		t.Error("expected ForwardProxy=true")
+	}
+}

--- a/internal/caddycapabilities/capabilities_test.go
+++ b/internal/caddycapabilities/capabilities_test.go
@@ -6,8 +6,8 @@ func TestProbeParsesModuleList(t *testing.T) {
 	// A mock binary that prints a module list matching Caddy's `caddy list-modules --json` shape.
 	// For the plan we test parsing of a known JSON fragment.
 	input := `[
-	  {"name":"http.handlers.forward_proxy"},
-	  {"name":"http"}
+	  {"module_name":"http.handlers.forward_proxy"},
+	  {"module_name":"http"}
 	]`
 	caps, err := parseModuleList([]byte(input))
 	if err != nil {

--- a/internal/caddycert/caddycert.go
+++ b/internal/caddycert/caddycert.go
@@ -137,14 +137,16 @@ func Sync(domain, sourceDir, targetDir string) error {
 	keyDst := filepath.Join(targetDir, domain+".key")
 
 	deadline := time.Now().Add(120 * time.Second)
-	for time.Now().Before(deadline) {
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+	for {
 		if exists(crtSrc) && exists(keySrc) {
 			break
 		}
-		time.Sleep(2 * time.Second)
-	}
-	if !exists(crtSrc) || !exists(keySrc) {
-		return fmt.Errorf("certificate for %s not issued within timeout", domain)
+		if time.Now().After(deadline) {
+			return fmt.Errorf("certificate for %s not issued within timeout", domain)
+		}
+		<-ticker.C
 	}
 
 	tmpCrt := crtDst + ".tmp"

--- a/internal/caddycert/caddycert.go
+++ b/internal/caddycert/caddycert.go
@@ -126,3 +126,50 @@ func isValidCertificate(certPath, domain string) bool {
 	}
 	return cert.VerifyHostname(domain) == nil
 }
+
+// Sync polls sourceDir for a certificate and key for domain and, once both
+// exist, atomically copies them into targetDir. The atomic rename ensures
+// Hysteria2 never observes a partially-written certificate.
+func Sync(domain, sourceDir, targetDir string) error {
+	crtSrc := filepath.Join(sourceDir, domain+".crt")
+	keySrc := filepath.Join(sourceDir, domain+".key")
+	crtDst := filepath.Join(targetDir, domain+".crt")
+	keyDst := filepath.Join(targetDir, domain+".key")
+
+	deadline := time.Now().Add(120 * time.Second)
+	for time.Now().Before(deadline) {
+		if exists(crtSrc) && exists(keySrc) {
+			break
+		}
+		time.Sleep(2 * time.Second)
+	}
+	if !exists(crtSrc) || !exists(keySrc) {
+		return fmt.Errorf("certificate for %s not issued within timeout", domain)
+	}
+
+	tmpCrt := crtDst + ".tmp"
+	tmpKey := keyDst + ".tmp"
+	if err := copyFile(crtSrc, tmpCrt); err != nil {
+		return err
+	}
+	if err := copyFile(keySrc, tmpKey); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpCrt, crtDst); err != nil {
+		return err
+	}
+	return os.Rename(tmpKey, keyDst)
+}
+
+func exists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func copyFile(src, dst string) error {
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(dst, data, 0o600)
+}

--- a/internal/caddycert/caddycert_test.go
+++ b/internal/caddycert/caddycert_test.go
@@ -107,16 +107,27 @@ func writeSelfSignedCert(t *testing.T, root, issuer, domain string, lifetime tim
 func TestSyncCopiesCertificate(t *testing.T) {
 	src := t.TempDir()
 	dst := t.TempDir()
-	if err := os.WriteFile(filepath.Join(src, "example.com.crt"), []byte("CERT"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(src, "example.com.crt"), []byte("CERT"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(src, "example.com.key"), []byte("KEY"), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(src, "example.com.key"), []byte("KEY"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	if err := Sync("example.com", src, dst); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := os.Stat(filepath.Join(dst, "example.com.crt")); err != nil {
+	certBody, err := os.ReadFile(filepath.Join(dst, "example.com.crt"))
+	if err != nil {
 		t.Fatal(err)
+	}
+	if string(certBody) != "CERT" {
+		t.Fatalf("cert content = %q, want CERT", certBody)
+	}
+	keyBody, err := os.ReadFile(filepath.Join(dst, "example.com.key"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(keyBody) != "KEY" {
+		t.Fatalf("key content = %q, want KEY", keyBody)
 	}
 }

--- a/internal/caddycert/caddycert_test.go
+++ b/internal/caddycert/caddycert_test.go
@@ -103,3 +103,20 @@ func writeSelfSignedCert(t *testing.T, root, issuer, domain string, lifetime tim
 	}
 	return Pair{CertPath: certPath, KeyPath: keyPath}
 }
+
+func TestSyncCopiesCertificate(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "example.com.crt"), []byte("CERT"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "example.com.key"), []byte("KEY"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := Sync("example.com", src, dst); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dst, "example.com.crt")); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -184,7 +184,7 @@ func TestConfigValidateRejectsPanelCaddyTCP443Conflict(t *testing.T) {
 	tmpDir := t.TempDir()
 	statePath := filepath.Join(tmpDir, "state.json")
 	state := `{
-  "settings": {"panelListen": "127.0.0.1:2096", "panelAccess":"caddy", "webBasePath":"/panel/", "mode": "server", "domain":"panel.example.com", "email":"admin@example.com"},
+  "settings": {"panelListen": "127.0.0.1:2096", "panelAccess":"caddy", "webBasePath":"/panel/", "mode": "server", "panelDomain":"panel.example.com", "panelEmail":"admin@example.com"},
   "inbounds": [
     {"name": "mieru-tcp", "protocol": "mieru", "transport": "tcp", "port": 443, "enabled": true, "password":"secret"}
   ],
@@ -204,8 +204,8 @@ func TestConfigValidateRejectsPanelCaddyTCP443Conflict(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for Panel Caddy TCP/443 conflict")
 	}
-	if !strings.Contains(out.String(), "panel caddy access uses 443/tcp") {
-		t.Fatalf("expected Panel Caddy TCP/443 conflict error, got: %s", out.String())
+	if !strings.Contains(out.String(), "is claimed by multiple owners") {
+		t.Fatalf("expected bind conflict error, got: %s", out.String())
 	}
 }
 

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -16,7 +16,7 @@ func TestConfigValidateValidState(t *testing.T) {
     "panelListen": "127.0.0.1:2096",
     "mode": "server",
     "domain": "vpn.example.com",
-    "email": "admin@example.com",
+    "defaultAcmeEmail": "admin@example.com",
     "naiveUsername": "veil",
     "naivePassword": "secret"
   },

--- a/internal/cli/install_apply.go
+++ b/internal/cli/install_apply.go
@@ -113,13 +113,13 @@ func applyRURecommendedInstall(cmd *cobra.Command, profile installer.RURecommend
 				resolvedStatePath, resolvedKeyPath, filepath.Base(resolvedKeyPath))
 		}
 		if snapshot.Settings.WebBasePath != "" {
-			// The panel Caddyfile was already rendered with a freshly-generated
+			// The panel Caddy JSON was already rendered with a freshly-generated
 			// base path before we knew we'd reuse the existing one. Rewrite it to
 			// the reused base path so Caddy routes the same path the panel actually
 			// serves (VEIL_WEB_BASE_PATH); otherwise an in-place switch to caddy
 			// mode 404s.
-			if profile.Caddyfile != "" && profile.WebBasePath != "" {
-				profile.Caddyfile = strings.ReplaceAll(profile.Caddyfile, profile.WebBasePath, snapshot.Settings.WebBasePath)
+			if profile.CaddyJSON != "" && profile.WebBasePath != "" {
+				profile.CaddyJSON = strings.ReplaceAll(profile.CaddyJSON, profile.WebBasePath, snapshot.Settings.WebBasePath)
 			}
 			profile.WebBasePath = snapshot.Settings.WebBasePath
 		}

--- a/internal/cli/install_apply_audit_backup_test.go
+++ b/internal/cli/install_apply_audit_backup_test.go
@@ -44,7 +44,7 @@ func TestInstallRURecommendedApplyWritesFilesWhenConfirmed(t *testing.T) {
 		t.Fatalf("unexpected error: %v\n%s", err, out.String())
 	}
 	got := out.String()
-	for _, want := range []string{"Written files:", "Caddyfile", "index.html", "veil.service", "veil-caddy@.service", "Panel port: 2096 (user selected)", "Panel URL: https://example.com/"} {
+	for _, want := range []string{"Written files:", "Caddyfile", "index.html", "veil.service", "veil-caddy.service", "Panel port: 2096 (user selected)", "Panel URL: https://example.com/"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("output missing %q:\n%s", want, got)
 		}

--- a/internal/cli/install_apply_audit_backup_test.go
+++ b/internal/cli/install_apply_audit_backup_test.go
@@ -44,7 +44,7 @@ func TestInstallRURecommendedApplyWritesFilesWhenConfirmed(t *testing.T) {
 		t.Fatalf("unexpected error: %v\n%s", err, out.String())
 	}
 	got := out.String()
-	for _, want := range []string{"Written files:", "Caddyfile", "index.html", "veil.service", "veil-caddy.service", "Panel port: 2096 (user selected)", "Panel URL: https://example.com/"} {
+	for _, want := range []string{"Written files:", "config.json", "index.html", "veil.service", "veil-caddy.service", "Panel port: 2096 (user selected)", "Panel URL: https://example.com/"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("output missing %q:\n%s", want, got)
 		}
@@ -54,14 +54,14 @@ func TestInstallRURecommendedApplyWritesFilesWhenConfirmed(t *testing.T) {
 			t.Fatalf("Panel Caddy install should not write %q:\n%s", unwanted, got)
 		}
 	}
-	// Caddyfile must include reverse_proxy to panel port
-	caddyPath := filepath.Join(dir, "etc/veil/generated/caddy/panel.Caddyfile")
+	// Caddy JSON must include reverse_proxy to panel port
+	caddyPath := filepath.Join(dir, "etc/veil/generated/caddy/config.json")
 	body, err := os.ReadFile(caddyPath)
 	if err != nil {
-		t.Fatalf("read Caddyfile: %v", err)
+		t.Fatalf("read Caddy JSON: %v", err)
 	}
-	if !strings.Contains(string(body), "reverse_proxy 127.0.0.1:2096") {
-		t.Fatalf("Caddyfile missing reverse_proxy:\n%s", string(body))
+	if !strings.Contains(string(body), `"dial": "127.0.0.1:2096"`) {
+		t.Fatalf("Caddy JSON missing reverse_proxy:\n%s", string(body))
 	}
 }
 

--- a/internal/cli/install_default_panel_only_test.go
+++ b/internal/cli/install_default_panel_only_test.go
@@ -16,7 +16,7 @@ func TestInstallCommandDefaultsToPanelOnlyProfile(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("default install dry-run should be panel-only: %v\n%s", err, out.String())
 	}
-	if !strings.Contains(out.String(), "Panel port: 2096 (default)") || !strings.Contains(out.String(), "Panel access: https://127.0.0.1:2096/") || strings.Contains(out.String(), "Generated Caddyfile") {
+	if !strings.Contains(out.String(), "Panel port: 2096 (default)") || !strings.Contains(out.String(), "Panel access: https://127.0.0.1:2096/") || strings.Contains(out.String(), "Generated Caddy JSON") {
 		t.Fatalf("unexpected default install output:\n%s", out.String())
 	}
 }

--- a/internal/cli/install_panel_caddy_test.go
+++ b/internal/cli/install_panel_caddy_test.go
@@ -65,7 +65,7 @@ func TestInstallPanelCaddyAccessUsesResolvedCaddyBinaryInSystemdUnit(t *testing.
 	var gotPaths installer.ApplyPaths
 	installApplyFunc = func(profile installer.RURecommendedProfile, paths installer.ApplyPaths) (installer.ApplyResult, error) {
 		gotPaths = paths
-		return installer.ApplyResult{WrittenFiles: []string{"/etc/systemd/system/veil-caddy@.service"}}, nil
+		return installer.ApplyResult{WrittenFiles: []string{"/etc/systemd/system/veil-caddy.service"}}, nil
 	}
 	commandLookPath = func(name string) (string, error) {
 		if name == "caddy" {

--- a/internal/cli/install_panel_caddy_test.go
+++ b/internal/cli/install_panel_caddy_test.go
@@ -21,7 +21,7 @@ func TestInstallPanelCaddyAccessPrintsPanelURLWithoutProxyStack(t *testing.T) {
 		t.Fatalf("install dry-run: %v\n%s", err, out.String())
 	}
 	got := out.String()
-	for _, want := range []string{"Install scope: Panel", "Panel URL: https://panel.example.com/", "Generated Caddyfile", "reverse_proxy 127.0.0.1:2096"} {
+	for _, want := range []string{"Install scope: Panel", "Panel URL: https://panel.example.com/", "Generated Caddy JSON", `"dial": "127.0.0.1:2096"`} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("output missing %q:\n%s", want, got)
 		}

--- a/internal/cli/install_panel_only_test.go
+++ b/internal/cli/install_panel_only_test.go
@@ -17,7 +17,7 @@ func TestInstallDryRunPanelOnlyDoesNotRequireDomainEmailOrProxyPort(t *testing.T
 		t.Fatalf("panel-only dry-run should not require domain/email/port: %v\n%s", err, out.String())
 	}
 	got := out.String()
-	if !strings.Contains(got, "Panel access: https://") || strings.Contains(got, "Generated Caddyfile") || strings.Contains(got, "Generated Hysteria2 server.yaml") {
+	if !strings.Contains(got, "Panel access: https://") || strings.Contains(got, "Generated Caddy JSON") || strings.Contains(got, "Generated Hysteria2 server.yaml") {
 		t.Fatalf("unexpected panel-only dry-run output:\n%s", got)
 	}
 }

--- a/internal/cli/install_plan_summary_test.go
+++ b/internal/cli/install_plan_summary_test.go
@@ -25,7 +25,7 @@ func TestBuildRURecommendedInstallPlanSummaryUsesPanelOnlySystemdUnits(t *testin
 			t.Fatalf("summary missing %q:\n%s", want, summary)
 		}
 	}
-	for _, unwanted := range []string{"ufw allow 2096/tcp comment Veil panel", "veil-caddy@.service", "veil-hysteria2@.service", "/udp comment Veil Hysteria2"} {
+	for _, unwanted := range []string{"ufw allow 2096/tcp comment Veil panel", "veil-caddy.service", "veil-hysteria2@.service", "/udp comment Veil Hysteria2"} {
 		if strings.Contains(summary, unwanted) {
 			t.Fatalf("Panel install summary should not include %q:\n%s", unwanted, summary)
 		}

--- a/internal/cli/packaging_docs_test.go
+++ b/internal/cli/packaging_docs_test.go
@@ -127,7 +127,7 @@ func TestNfpmConfigShipsBinaryAndUnits(t *testing.T) {
 		"veil.service",
 		"veil-backup.service",
 		"veil-backup.timer",
-		"veil-caddy@.service",
+		"veil-caddy.service",
 		"veil-hysteria2@.service",
 		"veil-olcrtc@.service",
 		"veil-mieru.service",
@@ -162,7 +162,7 @@ func TestPackageScriptsExist(t *testing.T) {
 
 func TestSystemdUnitsShipHardenedByDefault(t *testing.T) {
 	runtimeUnits := []string{
-		"../../packaging/systemd/veil-caddy@.service",
+		"../../packaging/systemd/veil-caddy.service",
 		"../../packaging/systemd/veil-hysteria2@.service",
 		"../../packaging/systemd/veil-olcrtc@.service",
 		"../../packaging/systemd/veil-mieru.service",

--- a/internal/cli/repair_audit_test.go
+++ b/internal/cli/repair_audit_test.go
@@ -20,7 +20,7 @@ func TestRepairDryRunWithAuditLogDoesNotCreateLog(t *testing.T) {
 	if err := os.MkdirAll(caddyfileDir, 0o755); err != nil {
 		t.Fatalf("mkdir caddy dir: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(caddyfileDir, "Caddyfile"), []byte("old-drifting-content"), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(caddyfileDir, "config.json"), []byte("old-drifting-content"), 0o600); err != nil {
 		t.Fatalf("write caddyfile: %v", err)
 	}
 
@@ -119,7 +119,7 @@ func TestRepairApplyNoAuditFlagBackwardCompatible(t *testing.T) {
 	if err := os.MkdirAll(caddyfileDir, 0o755); err != nil {
 		t.Fatalf("mkdir caddy dir: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(caddyfileDir, "Caddyfile"), []byte("old-drifting-content"), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(caddyfileDir, "config.json"), []byte("old-drifting-content"), 0o600); err != nil {
 		t.Fatalf("write caddyfile: %v", err)
 	}
 

--- a/internal/cli/repair_backup_test.go
+++ b/internal/cli/repair_backup_test.go
@@ -20,7 +20,7 @@ func TestRepairWithBackupDirPrintsBackupID(t *testing.T) {
 	if err := os.MkdirAll(caddyfileDir, 0o755); err != nil {
 		t.Fatalf("mkdir caddy dir: %v", err)
 	}
-	caddyfilePath := filepath.Join(caddyfileDir, "Caddyfile")
+	caddyfilePath := filepath.Join(caddyfileDir, "config.json")
 	if err := os.WriteFile(caddyfilePath, []byte("old-drifting-content"), 0o600); err != nil {
 		t.Fatalf("write caddyfile: %v", err)
 	}
@@ -69,7 +69,7 @@ func TestRepairDryRunDoesNotCreateBackup(t *testing.T) {
 	if err := os.MkdirAll(caddyfileDir, 0o755); err != nil {
 		t.Fatalf("mkdir caddy dir: %v", err)
 	}
-	caddyfilePath := filepath.Join(caddyfileDir, "Caddyfile")
+	caddyfilePath := filepath.Join(caddyfileDir, "config.json")
 	if err := os.WriteFile(caddyfilePath, []byte("old-drifting-content"), 0o600); err != nil {
 		t.Fatalf("write caddyfile: %v", err)
 	}
@@ -108,7 +108,7 @@ func TestRepairDefaultsBackupDirWhenNotSet(t *testing.T) {
 	if err := os.MkdirAll(caddyfileDir, 0o755); err != nil {
 		t.Fatalf("mkdir caddy dir: %v", err)
 	}
-	caddyfilePath := filepath.Join(caddyfileDir, "Caddyfile")
+	caddyfilePath := filepath.Join(caddyfileDir, "config.json")
 	if err := os.WriteFile(caddyfilePath, []byte("old-drifting-content"), 0o600); err != nil {
 		t.Fatalf("write caddyfile: %v", err)
 	}
@@ -151,7 +151,7 @@ func TestRepairExplicitEmptyBackupDirSkipsBackup(t *testing.T) {
 	if err := os.MkdirAll(caddyfileDir, 0o755); err != nil {
 		t.Fatalf("mkdir caddy dir: %v", err)
 	}
-	caddyfilePath := filepath.Join(caddyfileDir, "Caddyfile")
+	caddyfilePath := filepath.Join(caddyfileDir, "config.json")
 	if err := os.WriteFile(caddyfilePath, []byte("old-drifting-content"), 0o600); err != nil {
 		t.Fatalf("write caddyfile: %v", err)
 	}
@@ -233,7 +233,7 @@ func TestRepairApplyWithAuditLogWritesSuccessEventWithBackupID(t *testing.T) {
 	if err := os.MkdirAll(caddyfileDir, 0o755); err != nil {
 		t.Fatalf("mkdir caddy dir: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(caddyfileDir, "Caddyfile"), []byte("old-drifting-content"), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(caddyfileDir, "config.json"), []byte("old-drifting-content"), 0o600); err != nil {
 		t.Fatalf("write caddyfile: %v", err)
 	}
 	// Also pre-create veil.env with old content
@@ -303,7 +303,7 @@ func TestRepairApplyBackupFailureWithAuditLog(t *testing.T) {
 	if err := os.MkdirAll(caddyfileDir, 0o755); err != nil {
 		t.Fatalf("mkdir caddy dir: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(caddyfileDir, "Caddyfile"), []byte("old-drifting-content"), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(caddyfileDir, "config.json"), []byte("old-drifting-content"), 0o600); err != nil {
 		t.Fatalf("write caddyfile: %v", err)
 	}
 

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -47,7 +47,7 @@ func TestFetchStatusJSON(t *testing.T) {
 			Mode:          "server",
 			Services: []statusflow.ServiceStatus{
 				{Name: "veil", Managed: true, Unit: "veil.service", ActiveState: "active", SubState: "running"},
-				{Name: "naive", Managed: true, Transport: "tcp", Unit: "veil-caddy@.service", ActiveState: "active", SubState: "running"},
+				{Name: "naive", Managed: true, Transport: "tcp", Unit: "veil-caddy.service", ActiveState: "active", SubState: "running"},
 				{Name: "hysteria2", Managed: true, Transport: "udp", Unit: "veil-hysteria2.service", ActiveState: "active", SubState: "running"},
 			},
 		})

--- a/internal/cli/uninstall_test.go
+++ b/internal/cli/uninstall_test.go
@@ -113,7 +113,7 @@ func TestUninstallYesExecutesUninstall(t *testing.T) {
 	}
 
 	// Verify services are stopped
-	for _, svc := range []string{"veil.service", "veil-caddy@.service", "veil-hysteria2@.service", "veil-olcrtc@.service", "veil-warp.service", "veil-mieru.service"} {
+	for _, svc := range []string{"veil.service", "veil-caddy.service", "veil-hysteria2@.service", "veil-olcrtc@.service", "veil-warp.service", "veil-mieru.service"} {
 		found := false
 		for _, s := range stopped {
 			if s == svc {

--- a/internal/clientaccess/client_links.go
+++ b/internal/clientaccess/client_links.go
@@ -25,7 +25,11 @@ func BuildClientLinks(settings Settings, inbounds []Inbound) (ClientLinksRespons
 
 func NaiveClientURI(domain string, port int, username string, password string) string {
 	userinfo := url.UserPassword(username, password).String()
-	return fmt.Sprintf("naive+https://%s@%s:%d", userinfo, domain, port)
+	host := domain
+	if port > 0 && port != 443 {
+		host = fmt.Sprintf("%s:%d", domain, port)
+	}
+	return fmt.Sprintf("https://%s@%s", userinfo, host)
 }
 
 func Hysteria2ClientURI(domain string, port int, password string, name string, insecure bool) string {

--- a/internal/cliflow/install/presentation.go
+++ b/internal/cliflow/install/presentation.go
@@ -45,9 +45,9 @@ func (p Presentation) PrintRURecommended(profile installer.RURecommendedProfile,
 	fmt.Fprintln(p.out, "Install scope: Panel")
 	fmt.Fprintln(p.out, "")
 	if profile.InstallPanelCaddy {
-		fmt.Fprintln(p.out, "Generated Caddyfile")
+		fmt.Fprintln(p.out, "Generated Caddy JSON")
 		fmt.Fprintln(p.out, strings.Repeat("-", 24))
-		fmt.Fprintln(p.out, p.RedactProfileSecrets(profile, profile.Caddyfile))
+		fmt.Fprintln(p.out, p.RedactProfileSecrets(profile, profile.CaddyJSON))
 	}
 }
 

--- a/internal/cliflow/install/presentation_more_test.go
+++ b/internal/cliflow/install/presentation_more_test.go
@@ -61,7 +61,7 @@ func TestPresentationMore(t *testing.T) {
 				"Email: admin@app.example.com",
 				"Install scope: Panel",
 			},
-			notWant: []string{"Generated Caddyfile"},
+			notWant: []string{"Generated Caddy JSON"},
 		},
 	}
 

--- a/internal/cliflow/install/presentation_test.go
+++ b/internal/cliflow/install/presentation_test.go
@@ -13,7 +13,7 @@ func TestInstallPresentationPrintsRedactedRURecommendedProfile(t *testing.T) {
 		Domain:            "example.com",
 		Email:             "admin@example.com",
 		InstallPanelCaddy: true,
-		Caddyfile:         "reverse_proxy 127.0.0.1:2096 # panel-secret",
+		CaddyJSON:         `{"apps":{"http":{"servers":{"tcp-0.0.0.0-443":{"routes":[{"handle":[{"handler":"reverse_proxy","upstreams":[{"dial":"127.0.0.1:2096"}]}],"match":[{"host":["panel-secret.example.com"]}]}]}}}}}}`,
 		PanelAuthToken:    "panel-secret",
 	}
 	var out bytes.Buffer

--- a/internal/cliflow/repair/panel_state_material_test.go
+++ b/internal/cliflow/repair/panel_state_material_test.go
@@ -28,7 +28,7 @@ func TestPanelStateRepairMaterialAddsGeneratedConfigsAndRuntimeUnits(t *testing.
 	}
 	for _, want := range []string{
 		filepath.Join(opts.EtcDir, "veil.env"),
-		filepath.Join(opts.EtcDir, "generated", "caddy", "panel.Caddyfile"),
+		filepath.Join(opts.EtcDir, "generated", "caddy", "config.json"),
 		filepath.Join(opts.EtcDir, "generated", "mieru", "server_config.json"),
 		filepath.Join(opts.SystemdDir, renderer.UnitCaddy),
 		filepath.Join(opts.SystemdDir, renderer.UnitMieru),

--- a/internal/cliflow/repair/plan_builder.go
+++ b/internal/cliflow/repair/plan_builder.go
@@ -12,9 +12,12 @@ import (
 
 	"github.com/mikkelchokolate/Veil/internal/acmeip"
 	"github.com/mikkelchokolate/Veil/internal/api"
+	"github.com/mikkelchokolate/Veil/internal/caddyassembly"
+	"github.com/mikkelchokolate/Veil/internal/caddycapabilities"
 	"github.com/mikkelchokolate/Veil/internal/hostenv"
 	"github.com/mikkelchokolate/Veil/internal/installer"
 	"github.com/mikkelchokolate/Veil/internal/managementstate"
+	"github.com/mikkelchokolate/Veil/internal/model"
 	"github.com/mikkelchokolate/Veil/internal/panelmaterial"
 	"github.com/mikkelchokolate/Veil/internal/renderer"
 	"github.com/mikkelchokolate/Veil/internal/runtime"
@@ -200,9 +203,20 @@ func preserveExistingPanelRepairMaterial(profile *installer.RURecommendedProfile
 		profile.PanelTLSCertPEM = ""
 		profile.PanelTLSKeyPEM = ""
 		profile.InstallPanelCaddy = true
-		caddyfile, err := renderer.RenderPanelCaddyfile(renderer.PanelCaddyConfig{Domain: profile.Domain, Email: profile.Email, PanelPort: panelPortFromListen(profile.PanelListen), WebBasePath: profile.WebBasePath})
+		settings := model.Settings{
+			PanelAccess:     "caddy",
+			PanelDomain:     profile.Domain,
+			PanelEmail:      profile.Email,
+			PanelListen:     profile.PanelListen,
+			WebBasePath:     profile.WebBasePath,
+			PanelPublicPort: 443,
+		}
+		plan, _, err := caddyassembly.BuildRenderPlan(settings, nil, nil)
 		if err == nil {
-			profile.Caddyfile = caddyfile
+			body, err := renderer.RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{})
+			if err == nil {
+				profile.CaddyJSON = string(body)
+			}
 		}
 		return
 	}

--- a/internal/cliflow/repair/plan_builder_test.go
+++ b/internal/cliflow/repair/plan_builder_test.go
@@ -113,8 +113,8 @@ func TestBuildRepairPlanFromOptionsRepairsExistingPanelCaddyAccess(t *testing.T)
 	if err := os.Remove(filepath.Join(etcDir, "generated", "caddy", "panel.Caddyfile")); err != nil {
 		t.Fatalf("remove panel.Caddyfile: %v", err)
 	}
-	if err := os.Remove(filepath.Join(systemdDir, "veil-caddy@.service")); err != nil {
-		t.Fatalf("remove veil-caddy@.service: %v", err)
+	if err := os.Remove(filepath.Join(systemdDir, "veil-caddy.service")); err != nil {
+		t.Fatalf("remove veil-caddy.service: %v", err)
 	}
 
 	plan, err := buildRepairPlanFromOptions(Options{Profile: "ru-recommended", EtcDir: etcDir, VarDir: varDir, SystemdDir: systemdDir})
@@ -122,7 +122,7 @@ func TestBuildRepairPlanFromOptionsRepairsExistingPanelCaddyAccess(t *testing.T)
 		t.Fatalf("buildRepairPlanFromOptions: %v", err)
 	}
 	summary := plan.Summary()
-	for _, want := range []string{"generated/caddy/panel.Caddyfile", "veil-caddy@.service"} {
+	for _, want := range []string{"generated/caddy/panel.Caddyfile", "veil-caddy.service"} {
 		if !strings.Contains(summary, want) {
 			t.Fatalf("Panel Caddy repair summary missing %q:\n%s", want, summary)
 		}

--- a/internal/cliflow/repair/plan_builder_test.go
+++ b/internal/cliflow/repair/plan_builder_test.go
@@ -110,8 +110,8 @@ func TestBuildRepairPlanFromOptionsRepairsExistingPanelCaddyAccess(t *testing.T)
 	if _, err := installer.ApplyRURecommendedProfile(profile, installer.ApplyPaths{EtcDir: etcDir, VarDir: varDir, SystemdDir: systemdDir}); err != nil {
 		t.Fatalf("ApplyRURecommendedProfile: %v", err)
 	}
-	if err := os.Remove(filepath.Join(etcDir, "generated", "caddy", "panel.Caddyfile")); err != nil {
-		t.Fatalf("remove panel.Caddyfile: %v", err)
+	if err := os.Remove(filepath.Join(etcDir, "generated", "caddy", "config.json")); err != nil {
+		t.Fatalf("remove config.json: %v", err)
 	}
 	if err := os.Remove(filepath.Join(systemdDir, "veil-caddy.service")); err != nil {
 		t.Fatalf("remove veil-caddy.service: %v", err)
@@ -122,7 +122,7 @@ func TestBuildRepairPlanFromOptionsRepairsExistingPanelCaddyAccess(t *testing.T)
 		t.Fatalf("buildRepairPlanFromOptions: %v", err)
 	}
 	summary := plan.Summary()
-	for _, want := range []string{"generated/caddy/panel.Caddyfile", "veil-caddy.service"} {
+	for _, want := range []string{"generated/caddy/config.json", "veil-caddy.service"} {
 		if !strings.Contains(summary, want) {
 			t.Fatalf("Panel Caddy repair summary missing %q:\n%s", want, summary)
 		}
@@ -150,7 +150,7 @@ func TestBuildRepairPlanFromOptionsBuildsPanelInstallPlan(t *testing.T) {
 			t.Fatalf("repair summary missing managed unit template %q:\n%s", want, summary)
 		}
 	}
-	for _, unwanted := range []string{"generated/caddy/Caddyfile", "generated/hysteria2", "generated/mieru"} {
+	for _, unwanted := range []string{"generated/caddy/config.json", "generated/hysteria2", "generated/mieru"} {
 		if strings.Contains(summary, unwanted) {
 			t.Fatalf("Panel install repair should not include %q:\n%s", unwanted, summary)
 		}

--- a/internal/cliflow/repair/state_plan_test.go
+++ b/internal/cliflow/repair/state_plan_test.go
@@ -60,7 +60,7 @@ func TestBuildRepairPlanFromOptionsUsesPanelStateCaddyAccess(t *testing.T) {
 		t.Fatalf("mkdir state dir: %v", err)
 	}
 	state := `{
-  "settings": {"panelListen":"127.0.0.1:2096","panelAccess":"caddy","webBasePath":"/panel-secret/","mode":"server","domain":"panel.example.com","email":"admin@example.com"},
+  "settings": {"panelListen":"127.0.0.1:2096","panelAccess":"caddy","webBasePath":"/panel-secret/","mode":"server","domain":"panel.example.com","defaultAcmeEmail":"admin@example.com"},
   "inbounds": [],
   "routingRules": [],
   "warp": {"endpoint":"engage.cloudflareclient.com:2408"}
@@ -106,7 +106,7 @@ func TestBuildRepairPlanFromOptionsUsesResolvedCaddyBinaryForNaiveRuntime(t *tes
 		t.Fatalf("mkdir state dir: %v", err)
 	}
 	state := `{
-  "settings": {"panelListen":"127.0.0.1:2096","mode":"server","domain":"vpn.example.com","email":"admin@example.com","naiveUsername":"veil","naivePassword":"naive-secret"},
+  "settings": {"panelListen":"127.0.0.1:2096","mode":"server","domain":"vpn.example.com","defaultAcmeEmail":"admin@example.com","naiveUsername":"veil","naivePassword":"naive-secret"},
   "inbounds": [
     {"name":"naive","protocol":"naiveproxy","transport":"tcp","port":443,"enabled":true}
   ],

--- a/internal/cliflow/repair/state_plan_test.go
+++ b/internal/cliflow/repair/state_plan_test.go
@@ -74,14 +74,14 @@ func TestBuildRepairPlanFromOptionsUsesPanelStateCaddyAccess(t *testing.T) {
 		t.Fatalf("buildRepairPlanFromOptions: %v", err)
 	}
 	summary := plan.Summary()
-	for _, want := range []string{"generated/caddy/panel.Caddyfile", "veil-caddy@.service"} {
+	for _, want := range []string{"generated/caddy/config.json", "veil-caddy.service"} {
 		if !strings.Contains(summary, want) {
 			t.Fatalf("Panel state Caddy access repair missing %q:\n%s", want, summary)
 		}
 	}
-	caddyfile := repairActionContent(plan, "panel.Caddyfile")
-	if !strings.Contains(caddyfile, "handle /panel-secret/*") || !strings.Contains(caddyfile, "reverse_proxy 127.0.0.1:2096") {
-		t.Fatalf("Panel state Caddyfile not repaired from settings:\n%s", caddyfile)
+	caddyJSON := repairActionContent(plan, "config.json")
+	if !strings.Contains(caddyJSON, `"handler": "reverse_proxy"`) || !strings.Contains(caddyJSON, `"dial": "127.0.0.1:2096"`) {
+		t.Fatalf("Panel state Caddy JSON not repaired from settings:\n%s", caddyJSON)
 	}
 	env := repairActionContent(plan, "veil.env")
 	if !strings.Contains(env, "VEIL_PANEL_ACCESS=caddy") || strings.Contains(env, "VEIL_TLS_CERT") {
@@ -121,9 +121,9 @@ func TestBuildRepairPlanFromOptionsUsesResolvedCaddyBinaryForNaiveRuntime(t *tes
 	if err != nil {
 		t.Fatalf("buildRepairPlanFromOptions: %v", err)
 	}
-	unit := repairActionContent(plan, "veil-caddy@.service")
+	unit := repairActionContent(plan, "veil-caddy.service")
 	if !strings.Contains(unit, "ExecStart=/usr/sbin/caddy run --config") {
-		t.Fatalf("repair should render veil-caddy@.service with resolved caddy path:\n%s", unit)
+		t.Fatalf("repair should render veil-caddy.service with resolved caddy path:\n%s", unit)
 	}
 }
 

--- a/internal/cliflow/repair/state_plan_test.go
+++ b/internal/cliflow/repair/state_plan_test.go
@@ -157,7 +157,7 @@ func TestBuildRepairPlanFromOptionsUsesPanelStateMieruInbounds(t *testing.T) {
 			t.Fatalf("repair summary missing %q:\n%s", want, summary)
 		}
 	}
-	for _, unwanted := range []string{"generated/caddy/Caddyfile", "shared proxy port"} {
+	for _, unwanted := range []string{"generated/caddy/config.json", "shared proxy port"} {
 		if strings.Contains(summary, unwanted) {
 			t.Fatalf("repair summary should not include %q:\n%s", unwanted, summary)
 		}

--- a/internal/firewall/rules_response.go
+++ b/internal/firewall/rules_response.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/mikkelchokolate/Veil/internal/model"
 	"github.com/mikkelchokolate/Veil/internal/protocols"
+	"github.com/mikkelchokolate/Veil/internal/protocols/naiveproxy"
 )
 
 type Settings = model.Settings
@@ -27,7 +28,11 @@ func BuildRuleResponses(settings model.Settings, inbounds []model.Inbound) []Rul
 			continue
 		}
 		if service, ok := registry.FirewallService(inbound.Protocol); ok {
-			builder.Add(inbound.Port, inbound.Transport, service)
+			port := inbound.Port
+			if inbound.Protocol == "naiveproxy" {
+				port = naiveproxy.NaivePublicPort(settings, inbound)
+			}
+			builder.Add(port, inbound.Transport, service)
 		}
 	}
 	if settings.PanelAccess == "caddy" {
@@ -43,6 +48,9 @@ func BuildRuleResponses(settings model.Settings, inbounds []model.Inbound) []Rul
 	}
 	if settings.AcmeChallengeMode == "http-01" {
 		builder.Add(80, "tcp", "Veil ACME HTTP-01")
+	}
+	if settings.AcmeChallengeMode == "tls-alpn-01" {
+		builder.Add(443, "tcp", "Veil ACME TLS-ALPN-01")
 	}
 	return builder.Rules()
 }

--- a/internal/firewall/rules_response.go
+++ b/internal/firewall/rules_response.go
@@ -31,11 +31,18 @@ func BuildRuleResponses(settings model.Settings, inbounds []model.Inbound) []Rul
 		}
 	}
 	if settings.PanelAccess == "caddy" {
-		builder.Add(443, "tcp", "Veil panel HTTPS")
+		panelPublicPort := settings.PanelPublicPort
+		if panelPublicPort == 0 {
+			panelPublicPort = 443
+		}
+		builder.Add(panelPublicPort, "tcp", "Veil panel HTTPS")
 	} else if _, portStr, err := net.SplitHostPort(settings.PanelListen); err == nil {
 		if port, err := strconv.Atoi(portStr); err == nil {
 			builder.Add(port, "tcp", "Veil panel")
 		}
+	}
+	if settings.AcmeChallengeMode == "http-01" {
+		builder.Add(80, "tcp", "Veil ACME HTTP-01")
 	}
 	return builder.Rules()
 }

--- a/internal/firewall/rules_response_test.go
+++ b/internal/firewall/rules_response_test.go
@@ -41,3 +41,62 @@ func TestRuleResponsesOpenHTTP01ChallengePort(t *testing.T) {
 		t.Fatalf("expected HTTP-01 challenge rule on port 80, got %+v", rules)
 	}
 }
+
+func TestRuleResponsesOpenTLSALPN01ChallengePort(t *testing.T) {
+	rules := BuildRuleResponses(model.Settings{AcmeChallengeMode: "tls-alpn-01"}, nil)
+	found := false
+	for _, r := range rules {
+		if r.Port == 443 && r.Protocol == "tcp" && r.Service == "Veil ACME TLS-ALPN-01" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected TLS-ALPN-01 challenge rule on port 443, got %+v", rules)
+	}
+}
+
+func TestRuleResponsesUseNaivePublicPort(t *testing.T) {
+	rules := BuildRuleResponses(model.Settings{}, []model.Inbound{{
+		Name:      "naive",
+		Protocol:  "naiveproxy",
+		Transport: "tcp",
+		Port:      8443,
+		Enabled:   true,
+		ProtocolFields: map[string]any{
+			"publicPort": 9443,
+		},
+	}})
+	found := false
+	for _, r := range rules {
+		if r.Port == 9443 && r.Protocol == "tcp" && r.Service == "Veil NaiveProxy" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected naiveproxy rule on public port 9443, got %+v", rules)
+	}
+	for _, r := range rules {
+		if r.Port == 8443 && r.Service == "Veil NaiveProxy" {
+			t.Fatalf("expected inbound.Port 8443 not to be opened for naiveproxy, got %+v", rules)
+		}
+	}
+}
+
+func TestRuleResponsesNaivePublicPortFallsBackToInboundPort(t *testing.T) {
+	rules := BuildRuleResponses(model.Settings{}, []model.Inbound{{
+		Name:      "naive",
+		Protocol:  "naiveproxy",
+		Transport: "tcp",
+		Port:      8443,
+		Enabled:   true,
+	}})
+	found := false
+	for _, r := range rules {
+		if r.Port == 8443 && r.Protocol == "tcp" && r.Service == "Veil NaiveProxy" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected naiveproxy rule on inbound port 8443, got %+v", rules)
+	}
+}

--- a/internal/firewall/rules_response_test.go
+++ b/internal/firewall/rules_response_test.go
@@ -15,3 +15,29 @@ func TestRuleResponsesIncludePanelAndEnabledInbounds(t *testing.T) {
 		t.Fatalf("rules = %+v", rules)
 	}
 }
+
+func TestRuleResponsesUsePanelPublicPortForCaddyAccess(t *testing.T) {
+	rules := BuildRuleResponses(model.Settings{PanelAccess: "caddy", PanelPublicPort: 8443}, nil)
+	found := false
+	for _, r := range rules {
+		if r.Port == 8443 && r.Protocol == "tcp" && r.Service == "Veil panel HTTPS" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected panel HTTPS rule on public port 8443, got %+v", rules)
+	}
+}
+
+func TestRuleResponsesOpenHTTP01ChallengePort(t *testing.T) {
+	rules := BuildRuleResponses(model.Settings{AcmeChallengeMode: "http-01"}, nil)
+	found := false
+	for _, r := range rules {
+		if r.Port == 80 && r.Protocol == "tcp" && r.Service == "Veil ACME HTTP-01" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected HTTP-01 challenge rule on port 80, got %+v", rules)
+	}
+}

--- a/internal/generatedconfig/artifact_catalog.go
+++ b/internal/generatedconfig/artifact_catalog.go
@@ -6,7 +6,6 @@ import (
 )
 
 const (
-	CaddyfileSubpath       = "caddy/panel.Caddyfile"
 	CaddyJSONConfigSubpath = "caddy/config.json"
 	Hysteria2ConfigSubpath = "hysteria2/server.yaml"
 	MieruConfigSubpath     = "mieru/server_config.json"
@@ -83,7 +82,6 @@ type GeneratedConfigArtifactCatalog = ArtifactCatalog
 func NewArtifactCatalog() ArtifactCatalog {
 	return ArtifactCatalog{artifacts: []ArtifactSpec{
 		{Subpath: CaddyJSONConfigSubpath, ValidationName: "caddy", ValidationCommand: func(path string) []string { return []string{"caddy", "validate", "--config", path, "--adapter", "json"} }},
-		{Subpath: CaddyfileSubpath, ValidationName: "caddy", ValidationCommand: func(path string) []string { return []string{"caddy", "validate", "--config", path} }},
 		// Hysteria2 (hysteria), Mieru (mita) and olcRTC have no standalone config
 		// check command, so they get no pre-stage syntax validation; a bad config
 		// is caught by the post-restart service health check, which rolls back.

--- a/internal/generatedconfig/artifact_catalog.go
+++ b/internal/generatedconfig/artifact_catalog.go
@@ -7,6 +7,7 @@ import (
 
 const (
 	CaddyfileSubpath       = "caddy/panel.Caddyfile"
+	CaddyJSONConfigSubpath = "caddy/config.json"
 	Hysteria2ConfigSubpath = "hysteria2/server.yaml"
 	MieruConfigSubpath     = "mieru/server_config.json"
 	WarpConfigSubpath      = "sing-box/warp.json"
@@ -81,6 +82,7 @@ type GeneratedConfigArtifactCatalog = ArtifactCatalog
 
 func NewArtifactCatalog() ArtifactCatalog {
 	return ArtifactCatalog{artifacts: []ArtifactSpec{
+		{Subpath: CaddyJSONConfigSubpath, ValidationName: "caddy", ValidationCommand: func(path string) []string { return []string{"caddy", "validate", "--config", path, "--adapter", "json"} }},
 		{Subpath: CaddyfileSubpath, ValidationName: "caddy", ValidationCommand: func(path string) []string { return []string{"caddy", "validate", "--config", path} }},
 		// Hysteria2 (hysteria), Mieru (mita) and olcRTC have no standalone config
 		// check command, so they get no pre-stage syntax validation; a bad config

--- a/internal/generatedconfig/artifact_catalog.go
+++ b/internal/generatedconfig/artifact_catalog.go
@@ -81,7 +81,7 @@ type GeneratedConfigArtifactCatalog = ArtifactCatalog
 
 func NewArtifactCatalog() ArtifactCatalog {
 	return ArtifactCatalog{artifacts: []ArtifactSpec{
-		{Subpath: CaddyJSONConfigSubpath, ValidationName: "caddy", ValidationCommand: func(path string) []string { return []string{"caddy", "validate", "--config", path, "--adapter", "json"} }},
+		{Subpath: CaddyJSONConfigSubpath, ValidationName: "caddy", ValidationCommand: func(path string) []string { return []string{"caddy", "validate", "--config", path} }},
 		// Hysteria2 (hysteria), Mieru (mita) and olcRTC have no standalone config
 		// check command, so they get no pre-stage syntax validation; a bad config
 		// is caught by the post-restart service health check, which rolls back.

--- a/internal/generatedconfig/artifact_catalog_more_test.go
+++ b/internal/generatedconfig/artifact_catalog_more_test.go
@@ -36,7 +36,7 @@ func TestGeneratedConfigArtifactCatalogAlias(t *testing.T) {
 	}
 	found := false
 	for _, a := range all {
-		if a.Subpath == CaddyfileSubpath {
+		if a.Subpath == CaddyJSONConfigSubpath {
 			found = true
 		}
 	}

--- a/internal/generatedconfig/catalog_test.go
+++ b/internal/generatedconfig/catalog_test.go
@@ -43,7 +43,7 @@ func TestArtifactCatalogMatchesValidationAndPromotionSpecs(t *testing.T) {
 	if validation.Name != "caddy" || validation.Config != filepath.FromSlash("/apply/generated/caddy/config.json") {
 		t.Fatalf("validation spec = %+v", validation)
 	}
-	if got := validation.Command; len(got) != 6 || got[0] != "caddy" || got[1] != "validate" || got[4] != "--adapter" || got[5] != "json" {
+	if got := validation.Command; len(got) != 4 || got[0] != "caddy" || got[1] != "validate" || got[2] != "--config" || got[3] != filepath.FromSlash("/apply/generated/caddy/config.json") {
 		t.Fatalf("validation command = %+v", got)
 	}
 	// hysteria2 has no standalone config checker, so it produces no validation spec...

--- a/internal/generatedconfig/catalog_test.go
+++ b/internal/generatedconfig/catalog_test.go
@@ -36,14 +36,14 @@ func TestArtifactSpecDerivesStablePlanGeneratedAndLivePaths(t *testing.T) {
 func TestArtifactCatalogMatchesValidationAndPromotionSpecs(t *testing.T) {
 	catalog := NewArtifactCatalog()
 	// caddy has a working standalone validator.
-	validation, ok := catalog.ValidationSpec(filepath.FromSlash("/apply/generated/caddy/Caddyfile"))
+	validation, ok := catalog.ValidationSpec(filepath.FromSlash("/apply/generated/caddy/config.json"))
 	if !ok {
 		t.Fatal("missing validation spec for caddy generated config")
 	}
-	if validation.Name != "caddy" || validation.Config != filepath.FromSlash("/apply/generated/caddy/Caddyfile") {
+	if validation.Name != "caddy" || validation.Config != filepath.FromSlash("/apply/generated/caddy/config.json") {
 		t.Fatalf("validation spec = %+v", validation)
 	}
-	if got := validation.Command; len(got) != 4 || got[0] != "caddy" || got[1] != "validate" {
+	if got := validation.Command; len(got) != 6 || got[0] != "caddy" || got[1] != "validate" || got[4] != "--adapter" || got[5] != "json" {
 		t.Fatalf("validation command = %+v", got)
 	}
 	// hysteria2 has no standalone config checker, so it produces no validation spec...

--- a/internal/generatedconfig/config_validation_catalog_test.go
+++ b/internal/generatedconfig/config_validation_catalog_test.go
@@ -10,7 +10,7 @@ func TestConfigValidationCatalogMatchesKnownGeneratedConfigs(t *testing.T) {
 		cmd  []string
 	}{
 		// Only protocols with a working standalone checker have a validation command.
-		{"/etc/veil/generated/caddy/Caddyfile", "caddy", []string{"caddy", "validate", "--config", "/etc/veil/generated/caddy/Caddyfile"}},
+		{"/etc/veil/generated/caddy/config.json", "caddy", []string{"caddy", "validate", "--config", "/etc/veil/generated/caddy/config.json", "--adapter", "json"}},
 		{"/etc/veil/generated/sing-box/warp.json", "warp", []string{"sing-box", "check", "-c", "/etc/veil/generated/sing-box/warp.json"}},
 	}
 	for _, tc := range cases {

--- a/internal/generatedconfig/config_validation_catalog_test.go
+++ b/internal/generatedconfig/config_validation_catalog_test.go
@@ -10,7 +10,7 @@ func TestConfigValidationCatalogMatchesKnownGeneratedConfigs(t *testing.T) {
 		cmd  []string
 	}{
 		// Only protocols with a working standalone checker have a validation command.
-		{"/etc/veil/generated/caddy/config.json", "caddy", []string{"caddy", "validate", "--config", "/etc/veil/generated/caddy/config.json", "--adapter", "json"}},
+		{"/etc/veil/generated/caddy/config.json", "caddy", []string{"caddy", "validate", "--config", "/etc/veil/generated/caddy/config.json"}},
 		{"/etc/veil/generated/sing-box/warp.json", "warp", []string{"sing-box", "check", "-c", "/etc/veil/generated/sing-box/warp.json"}},
 	}
 	for _, tc := range cases {

--- a/internal/generatedconfig/config_validation_more_test.go
+++ b/internal/generatedconfig/config_validation_more_test.go
@@ -40,7 +40,7 @@ func TestRunFixedConfigValidationMarksValidResult(t *testing.T) {
 		},
 	}
 
-	result := RunFixedConfigValidation("caddy", "/etc/veil/generated/caddy/Caddyfile", []string{"caddy", "validate", "--config", "/etc/veil/generated/caddy/Caddyfile"})
+	result := RunFixedConfigValidation("caddy", "/etc/veil/generated/caddy/config.json", []string{"caddy", "validate", "--config", "/etc/veil/generated/caddy/config.json", "--adapter", "json"})
 	if !result.Valid {
 		t.Fatalf("expected valid result, got %+v", result)
 	}
@@ -73,7 +73,7 @@ func TestRunFixedConfigValidationCapturesTimeout(t *testing.T) {
 		},
 	}
 
-	result := RunFixedConfigValidation("caddy", "/etc/veil/generated/caddy/Caddyfile", []string{"caddy", "validate", "--config", "/etc/veil/generated/caddy/Caddyfile"})
+	result := RunFixedConfigValidation("caddy", "/etc/veil/generated/caddy/config.json", []string{"caddy", "validate", "--config", "/etc/veil/generated/caddy/config.json", "--adapter", "json"})
 	if result.Valid || result.Error != "validation timed out" {
 		t.Fatalf("expected timeout error, got %+v", result)
 	}
@@ -88,7 +88,7 @@ func TestRunFixedConfigValidationReturnsTempDirError(t *testing.T) {
 	}
 	t.Setenv("TMPDIR", badDir)
 
-	result := RunFixedConfigValidation("caddy", "/etc/veil/generated/caddy/Caddyfile", []string{"caddy", "validate", "--config", "/etc/veil/generated/caddy/Caddyfile"})
+	result := RunFixedConfigValidation("caddy", "/etc/veil/generated/caddy/config.json", []string{"caddy", "validate", "--config", "/etc/veil/generated/caddy/config.json", "--adapter", "json"})
 	if result.Valid || result.Error == "" {
 		t.Fatalf("expected temp dir error, got %+v", result)
 	}

--- a/internal/generatedconfig/config_validation_test.go
+++ b/internal/generatedconfig/config_validation_test.go
@@ -38,7 +38,7 @@ func TestStagedConfigValidatorBuildsExpectedCommands(t *testing.T) {
 	})
 
 	results := validator.Validate([]string{
-		filepath.Join(root, "generated", "caddy", "Caddyfile"),
+		filepath.Join(root, "generated", "caddy", "config.json"),
 		filepath.Join(root, "generated", "hysteria2", "server.yaml"), // no standalone checker: no validation produced
 		filepath.Join(root, "generated", "sing-box", "warp.json"),
 	})

--- a/internal/generatedconfig/inbound_renderer.go
+++ b/internal/generatedconfig/inbound_renderer.go
@@ -133,9 +133,9 @@ func (r InboundRenderer) RenderHysteria2(inbound Inbound) (string, error) {
 		Users:         access.Hysteria2Users(),
 		MasqueradeURL: masqueradeURL,
 	}
-	if r.settings.PanelAccess == "caddy" && r.settings.Domain != "" {
-		hystConfig.CertPath = "/etc/veil/certs/" + r.settings.Domain + ".crt"
-		hystConfig.KeyPath = "/etc/veil/certs/" + r.settings.Domain + ".key"
+	if domain := hysteria2Domain(inbound); domain != "" {
+		hystConfig.CertPath = "/etc/veil/certs/" + domain + ".crt"
+		hystConfig.KeyPath = "/etc/veil/certs/" + domain + ".key"
 	}
 	if r.warp.Enabled {
 		socksPort := r.warp.SocksPort
@@ -195,6 +195,17 @@ func RenderHysteria2Inbound(settings Settings, inbound Inbound, warp WarpConfig)
 
 func RenderOlcrtcInbound(settings Settings, inbound Inbound, warp WarpConfig) (string, error) {
 	return NewInboundRenderer(settings, Paths{}, warp).RenderOlcrtc(inbound)
+}
+
+func hysteria2Domain(inbound Inbound) string {
+	if inbound.ProtocolFields == nil {
+		return ""
+	}
+	v, ok := inbound.ProtocolFields["domain"].(string)
+	if !ok {
+		return ""
+	}
+	return v
 }
 
 func (r InboundRenderer) Paths() Paths {

--- a/internal/generatedconfig/inbound_renderer_test.go
+++ b/internal/generatedconfig/inbound_renderer_test.go
@@ -46,7 +46,15 @@ func TestInboundRendererRendersHysteria2WithManagedCertWhenCaddyAccess(t *testin
 		PanelAccess: "caddy",
 		Email:       "admin@example.com",
 	}, NewPaths("/etc/veil"), WarpConfig{})
-	body, err := renderer.RenderHysteria2(Inbound{Name: "hy2", Protocol: "hysteria2", Transport: "udp", Port: 8443, Enabled: true, Password: "pass"})
+	body, err := renderer.RenderHysteria2(Inbound{
+		Name:           "hy2",
+		Protocol:       "hysteria2",
+		Transport:      "udp",
+		Port:           8443,
+		Enabled:        true,
+		Password:       "pass",
+		ProtocolFields: map[string]any{"domain": "vpn.example.com"},
+	})
 	if err != nil {
 		t.Fatalf("RenderHysteria2: %v", err)
 	}

--- a/internal/generatedconfig/paths.go
+++ b/internal/generatedconfig/paths.go
@@ -18,8 +18,8 @@ func (p Paths) Generated(subpath string) string {
 	return filepath.Join(p.ApplyRoot, "generated", filepath.FromSlash(subpath))
 }
 
-func (p Paths) Caddyfile() string {
-	return p.Generated(CaddyfileSubpath)
+func (p Paths) CaddyJSON() string {
+	return p.Generated(CaddyJSONConfigSubpath)
 }
 
 func (p Paths) Hysteria2() string {

--- a/internal/generatedconfig/paths_test.go
+++ b/internal/generatedconfig/paths_test.go
@@ -8,7 +8,7 @@ import (
 func TestGeneratedConfigPathsBuildsKnownGeneratedPaths(t *testing.T) {
 	paths := NewPaths("/apply")
 	cases := map[string]string{
-		paths.Caddyfile(): filepath.Join("/apply", "generated", "caddy", "panel.Caddyfile"),
+		paths.CaddyJSON(): filepath.Join("/apply", "generated", "caddy", "config.json"),
 		paths.Hysteria2(): filepath.Join("/apply", "generated", "hysteria2", "server.yaml"),
 		paths.Warp():      filepath.Join("/apply", "generated", "sing-box", "warp.json"),
 	}

--- a/internal/generatedconfig/protocol_registry_more_test.go
+++ b/internal/generatedconfig/protocol_registry_more_test.go
@@ -54,7 +54,7 @@ func TestProtocolRegistryRenderCollectsMultipleArtifacts(t *testing.T) {
 		{Protocol: "mieru", Render: func(input ProtocolRenderInput) ([]GeneratedConfigArtifact, bool, error) {
 			return []GeneratedConfigArtifact{
 				{Path: input.Paths.Mieru(), Body: "one"},
-				{Path: input.Paths.Caddyfile(), Body: "two"},
+				{Path: input.Paths.CaddyJSON(), Body: "two"},
 			}, true, nil
 		}},
 	})
@@ -63,7 +63,7 @@ func TestProtocolRegistryRenderCollectsMultipleArtifacts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
-	if configs[paths.Mieru()] != "one" || configs[paths.Caddyfile()] != "two" {
+	if configs[paths.Mieru()] != "one" || configs[paths.CaddyJSON()] != "two" {
 		t.Fatalf("configs = %+v", configs)
 	}
 }

--- a/internal/generatedconfig/set.go
+++ b/internal/generatedconfig/set.go
@@ -32,7 +32,7 @@ func (b SetBuilder) Build() (map[string]string, error) {
 		return nil, err
 	}
 	paths := NewPaths(input.ApplyRoot)
-	if _, exists := configs[paths.Caddyfile()]; !exists && input.PanelAccess != nil {
+	if _, exists := configs[paths.CaddyJSON()]; !exists && input.PanelAccess != nil {
 		artifact, ok, err := input.PanelAccess(paths)
 		if err != nil {
 			return nil, err

--- a/internal/generatedconfig/set_test.go
+++ b/internal/generatedconfig/set_test.go
@@ -10,7 +10,7 @@ func TestSetBuilderCombinesProtocolPanelFallbackAndWarpArtifacts(t *testing.T) {
 			return []GeneratedConfigArtifact{{Path: input.Paths.Mieru(), Body: "mieru"}}, true, nil
 		}}}),
 		PanelAccess: func(Paths) (GeneratedConfigArtifact, bool, error) {
-			return GeneratedConfigArtifact{Path: paths.Caddyfile(), Body: "panel-caddy"}, true, nil
+			return GeneratedConfigArtifact{Path: paths.CaddyJSON(), Body: "panel-caddy"}, true, nil
 		},
 		Warp: func(Paths) (GeneratedConfigArtifact, bool, error) {
 			return GeneratedConfigArtifact{Path: paths.Warp(), Body: "warp"}, true, nil
@@ -21,7 +21,7 @@ func TestSetBuilderCombinesProtocolPanelFallbackAndWarpArtifacts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
-	if configs[paths.Mieru()] != "mieru" || configs[paths.Caddyfile()] != "panel-caddy" || configs[paths.Warp()] != "warp" {
+	if configs[paths.Mieru()] != "mieru" || configs[paths.CaddyJSON()] != "panel-caddy" || configs[paths.Warp()] != "warp" {
 		t.Fatalf("configs = %+v", configs)
 	}
 }
@@ -31,10 +31,10 @@ func TestSetBuilderDoesNotOverwriteProtocolCaddyWithPanelFallback(t *testing.T) 
 	builder := NewSetBuilder(SetInput{
 		ApplyRoot: "/etc/veil",
 		Registry: NewProtocolRegistry([]Protocol{{Protocol: "naiveproxy", Render: func(input ProtocolRenderInput) ([]GeneratedConfigArtifact, bool, error) {
-			return []GeneratedConfigArtifact{{Path: input.Paths.Caddyfile(), Body: "naive-caddy"}}, true, nil
+			return []GeneratedConfigArtifact{{Path: input.Paths.CaddyJSON(), Body: "naive-caddy"}}, true, nil
 		}}}),
 		PanelAccess: func(Paths) (GeneratedConfigArtifact, bool, error) {
-			return GeneratedConfigArtifact{Path: paths.Caddyfile(), Body: "panel-caddy"}, true, nil
+			return GeneratedConfigArtifact{Path: paths.CaddyJSON(), Body: "panel-caddy"}, true, nil
 		},
 		Inbounds: []Inbound{{Name: "naive", Protocol: "naiveproxy", Enabled: true}},
 	})
@@ -42,7 +42,7 @@ func TestSetBuilderDoesNotOverwriteProtocolCaddyWithPanelFallback(t *testing.T) 
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
-	if configs[paths.Caddyfile()] != "naive-caddy" {
-		t.Fatalf("caddy config = %q", configs[paths.Caddyfile()])
+	if configs[paths.CaddyJSON()] != "naive-caddy" {
+		t.Fatalf("caddy config = %q", configs[paths.CaddyJSON()])
 	}
 }

--- a/internal/generatedconfig/validator_test.go
+++ b/internal/generatedconfig/validator_test.go
@@ -11,8 +11,8 @@ func TestStagedValidatorMatchesGeneratedConfigCatalog(t *testing.T) {
 		commands = append(commands, command)
 		return ConfigValidationResult{Name: name, Config: config, Command: command, Valid: true}
 	})
-	results := validator.Validate([]string{"/etc/veil/generated/caddy/Caddyfile", "/etc/veil/other.txt"})
-	if len(results) != 1 || results[0].Name != "caddy" || !strings.Contains(results[0].Config, "Caddyfile") {
+	results := validator.Validate([]string{"/etc/veil/generated/caddy/config.json", "/etc/veil/other.txt"})
+	if len(results) != 1 || results[0].Name != "caddy" || !strings.Contains(results[0].Config, "config.json") {
 		t.Fatalf("results = %+v", results)
 	}
 	if len(commands) != 1 || commands[0][0] != "caddy" {

--- a/internal/inbounds/legacy_migration.go
+++ b/internal/inbounds/legacy_migration.go
@@ -5,15 +5,6 @@ import "github.com/mikkelchokolate/Veil/internal/model"
 // LegacyState describes the migration status of an inbound.
 type LegacyState string
 
-const (
-	// LegacyStateMigrated indicates the inbound has been migrated to the new
-	// per-inbound domain/publicPort/email fields.
-	LegacyStateMigrated LegacyState = "migrated"
-	// LegacyStateLegacy indicates the inbound is missing the new fields and
-	// requires migration.
-	LegacyStateLegacy LegacyState = "legacy"
-)
-
 // DetectLegacyInbounds returns naiveproxy inbounds that do not have per-inbound
 // domain configuration in ProtocolFields.
 func DetectLegacyInbounds(inbounds []model.Inbound) []model.Inbound {

--- a/internal/inbounds/legacy_migration.go
+++ b/internal/inbounds/legacy_migration.go
@@ -1,0 +1,49 @@
+package inbounds
+
+import "github.com/mikkelchokolate/Veil/internal/model"
+
+// LegacyState describes the migration status of an inbound.
+type LegacyState string
+
+const (
+	// LegacyStateMigrated indicates the inbound has been migrated to the new
+	// per-inbound domain/publicPort/email fields.
+	LegacyStateMigrated LegacyState = "migrated"
+	// LegacyStateLegacy indicates the inbound is missing the new fields and
+	// requires migration.
+	LegacyStateLegacy LegacyState = "legacy"
+)
+
+// DetectLegacyInbounds returns naiveproxy inbounds that do not have per-inbound
+// domain configuration in ProtocolFields.
+func DetectLegacyInbounds(inbounds []model.Inbound) []model.Inbound {
+	var out []model.Inbound
+	for _, inb := range inbounds {
+		if inb.Protocol != "naiveproxy" {
+			continue
+		}
+		if inb.ProtocolFields == nil || inb.ProtocolFields["domain"] == nil || inb.ProtocolFields["domain"] == "" {
+			out = append(out, inb)
+		}
+	}
+	return out
+}
+
+// CanCreateManagedNaive reports whether new managed naive inbounds may be
+// created. Creation is blocked while any legacy naiveproxy inbounds exist.
+func CanCreateManagedNaive(inbounds []model.Inbound) bool {
+	return len(DetectLegacyInbounds(inbounds)) == 0
+}
+
+// SuggestMigration fills in domain/publicPort/transport/email for legacy
+// naiveproxy inbounds using the provided settings. The returned inbounds still
+// require admin review before applying.
+//
+// Implementation is tracked in Task 19; this function currently returns the
+// input unchanged.
+func SuggestMigration(settings model.Settings, inbounds []model.Inbound) ([]model.Inbound, error) {
+	// Populate domain/publicPort/transport/email; require admin review before applying.
+	// Implementation in Task 19 UI/API task.
+	_ = settings
+	return inbounds, nil
+}

--- a/internal/inbounds/legacy_migration_test.go
+++ b/internal/inbounds/legacy_migration_test.go
@@ -24,3 +24,28 @@ func TestBlockManagedUntilLegacyResolved(t *testing.T) {
 		t.Error("creating managed naive inbounds must be blocked while legacy exists")
 	}
 }
+
+func TestDetectLegacyInboundsIgnoresNonNaiveAndMigrated(t *testing.T) {
+	inbounds := []model.Inbound{
+		{Name: "old", Protocol: "naiveproxy", Port: 443, ProtocolFields: map[string]any{}},
+		{Name: "migrated", Protocol: "naiveproxy", Port: 443, ProtocolFields: map[string]any{"domain": "vpn.example.com"}},
+		{Name: "hy2", Protocol: "hysteria2", Port: 443, ProtocolFields: map[string]any{}},
+	}
+	legacy := DetectLegacyInbounds(inbounds)
+	if len(legacy) != 1 || legacy[0].Name != "old" {
+		t.Fatalf("expected only 'old' legacy inbound, got %+v", legacy)
+	}
+	if CanCreateManagedNaive(inbounds) {
+		t.Error("managed naive creation must be blocked while any legacy inbound remains")
+	}
+}
+
+func TestCanCreateManagedNaiveWhenNoLegacy(t *testing.T) {
+	inbounds := []model.Inbound{
+		{Name: "migrated", Protocol: "naiveproxy", Port: 443, ProtocolFields: map[string]any{"domain": "vpn.example.com"}},
+		{Name: "hy2", Protocol: "hysteria2", Port: 443, ProtocolFields: map[string]any{}},
+	}
+	if !CanCreateManagedNaive(inbounds) {
+		t.Error("managed naive creation should be allowed when no legacy inbounds exist")
+	}
+}

--- a/internal/inbounds/legacy_migration_test.go
+++ b/internal/inbounds/legacy_migration_test.go
@@ -1,0 +1,26 @@
+package inbounds
+
+import (
+	"testing"
+
+	"github.com/mikkelchokolate/Veil/internal/model"
+)
+
+func TestDetectLegacyInbound(t *testing.T) {
+	inbounds := []model.Inbound{
+		{Name: "old", Protocol: "naiveproxy", Port: 443, ProtocolFields: map[string]any{}},
+	}
+	legacy := DetectLegacyInbounds(inbounds)
+	if len(legacy) != 1 {
+		t.Fatalf("expected 1 legacy inbound, got %d", len(legacy))
+	}
+}
+
+func TestBlockManagedUntilLegacyResolved(t *testing.T) {
+	inbounds := []model.Inbound{
+		{Name: "old", Protocol: "naiveproxy", Port: 443, ProtocolFields: map[string]any{}},
+	}
+	if CanCreateManagedNaive(inbounds) {
+		t.Error("creating managed naive inbounds must be blocked while legacy exists")
+	}
+}

--- a/internal/installer/apply_backup_test.go
+++ b/internal/installer/apply_backup_test.go
@@ -32,9 +32,9 @@ func TestApplyWithBackupDirBacksUpExistingFilesBeforeOverwrite(t *testing.T) {
 	if err := os.MkdirAll(caddyfileDir, 0o755); err != nil {
 		t.Fatalf("mkdir caddy dir: %v", err)
 	}
-	oldCaddyPath := filepath.Join(caddyfileDir, "panel.Caddyfile")
+	oldCaddyPath := filepath.Join(caddyfileDir, "config.json")
 	if err := os.WriteFile(oldCaddyPath, []byte("old caddy content"), 0o600); err != nil {
-		t.Fatalf("write old caddy: %v", err)
+		t.Fatalf("write old caddy json: %v", err)
 	}
 
 	result, err := ApplyRURecommendedProfile(profile, ApplyPaths{
@@ -51,18 +51,18 @@ func TestApplyWithBackupDirBacksUpExistingFilesBeforeOverwrite(t *testing.T) {
 		t.Fatalf("expected BackupID to be set when BackupDir is provided")
 	}
 
-	// Verify backup contains old Caddyfile
-	backupPath := filepath.Join(backupDir, result.BackupID, "panel.Caddyfile")
+	// Verify backup contains old Caddy JSON
+	backupPath := filepath.Join(backupDir, result.BackupID, "config.json")
 	body, err := os.ReadFile(backupPath)
 	if err != nil {
-		t.Fatalf("read backup caddyfile: %v", err)
+		t.Fatalf("read backup caddy json: %v", err)
 	}
 	if string(body) != "old caddy content" {
 		t.Fatalf("backup has wrong content: %q", string(body))
 	}
 
-	// Verify current Caddyfile has new content
-	assertFileContains(t, oldCaddyPath, "reverse_proxy")
+	// Verify current Caddy JSON has new content
+	assertFileContains(t, oldCaddyPath, `"dial"`)
 }
 
 func TestApplyWithoutBackupDirDoesNotBackup(t *testing.T) {
@@ -115,9 +115,9 @@ func TestApplyBackupThenRestoreRollback(t *testing.T) {
 	if err := os.MkdirAll(caddyfileDir, 0o755); err != nil {
 		t.Fatalf("mkdir caddy dir: %v", err)
 	}
-	oldCaddyPath := filepath.Join(caddyfileDir, "panel.Caddyfile")
+	oldCaddyPath := filepath.Join(caddyfileDir, "config.json")
 	if err := os.WriteFile(oldCaddyPath, []byte("pre-apply content"), 0o600); err != nil {
-		t.Fatalf("write old caddy: %v", err)
+		t.Fatalf("write old caddy json: %v", err)
 	}
 
 	veilEnvPath := filepath.Join(etcDir, "veil.env")
@@ -142,9 +142,9 @@ func TestApplyBackupThenRestoreRollback(t *testing.T) {
 	// Verify files were overwritten
 	body, _ := os.ReadFile(oldCaddyPath)
 	if string(body) == "pre-apply content" {
-		t.Fatalf("Caddyfile should have been overwritten")
+		t.Fatalf("Caddy JSON should have been overwritten")
 	}
-	assertFileContains(t, oldCaddyPath, "reverse_proxy")
+	assertFileContains(t, oldCaddyPath, `"dial"`)
 
 	body, _ = os.ReadFile(veilEnvPath)
 	if string(body) == "VEIL_API_TOKEN=old-token\n" {
@@ -167,7 +167,7 @@ func TestApplyBackupThenRestoreRollback(t *testing.T) {
 		t.Fatalf("read restored caddy: %v", err)
 	}
 	if string(body) != "pre-apply content" {
-		t.Fatalf("restored Caddyfile has wrong content: %q", string(body))
+		t.Fatalf("restored Caddy JSON has wrong content: %q", string(body))
 	}
 
 	body, err = os.ReadFile(veilEnvPath)

--- a/internal/installer/apply_install_apply_test.go
+++ b/internal/installer/apply_install_apply_test.go
@@ -26,7 +26,7 @@ func TestApplyRURecommendedProfileWritesPanelFiles(t *testing.T) {
 		t.Fatalf("apply profile: %v", err)
 	}
 
-	assertFileMissing(t, result.CaddyfilePath)
+	assertFileMissing(t, result.CaddyJSONPath)
 	assertFileMissing(t, result.Hysteria2Path)
 	assertFileMissing(t, result.FallbackIndexPath)
 	assertFileContains(t, filepath.Join(dir, "etc", "veil", "veil.env"), "VEIL_API_TOKEN=secret-panel")
@@ -59,7 +59,7 @@ func TestApplyRURecommendedProfileWritesPanelCaddyAccessFiles(t *testing.T) {
 		t.Fatalf("apply profile: %v", err)
 	}
 
-	assertFileContains(t, result.CaddyfilePath, "reverse_proxy 127.0.0.1:2096")
+	assertFileContains(t, result.CaddyJSONPath, `"dial": "127.0.0.1:2096"`)
 	assertFileContains(t, result.FallbackIndexPath, "Veil")
 	assertFileMissing(t, result.Hysteria2Path)
 	assertFileContains(t, filepath.Join(dir, "etc", "veil", "veil.env"), "VEIL_API_TOKEN=secret-panel")

--- a/internal/installer/apply_install_apply_test.go
+++ b/internal/installer/apply_install_apply_test.go
@@ -64,7 +64,7 @@ func TestApplyRURecommendedProfileWritesPanelCaddyAccessFiles(t *testing.T) {
 	assertFileMissing(t, result.Hysteria2Path)
 	assertFileContains(t, filepath.Join(dir, "etc", "veil", "veil.env"), "VEIL_API_TOKEN=secret-panel")
 	assertFileContains(t, filepath.Join(dir, "etc", "systemd", "system", "veil.service"), "ExecStart=/usr/local/bin/veil serve")
-	assertFileContains(t, filepath.Join(dir, "etc", "systemd", "system", "veil-caddy@.service"), "caddy")
+	assertFileContains(t, filepath.Join(dir, "etc", "systemd", "system", "veil-caddy.service"), "caddy")
 	assertFileMissing(t, filepath.Join(dir, "etc", "systemd", "system", "veil-hysteria2.service"))
 	for _, name := range renderer.ManagedSystemdUnitNames() {
 		assertFileContains(t, filepath.Join(dir, "etc", "systemd", "system", name), "[")

--- a/internal/installer/apply_repair_test.go
+++ b/internal/installer/apply_repair_test.go
@@ -19,8 +19,8 @@ func TestBuildRepairPlanDetectsPanelCaddyDrift(t *testing.T) {
 	if err != nil {
 		t.Fatalf("apply profile: %v", err)
 	}
-	if err := os.WriteFile(result.CaddyfilePath, []byte("drifted"), 0o600); err != nil {
-		t.Fatalf("drift caddyfile: %v", err)
+	if err := os.WriteFile(result.CaddyJSONPath, []byte("drifted"), 0o600); err != nil {
+		t.Fatalf("drift caddy json: %v", err)
 	}
 
 	plan, err := BuildRepairPlan(profile, paths)
@@ -31,7 +31,7 @@ func TestBuildRepairPlanDetectsPanelCaddyDrift(t *testing.T) {
 	if len(plan.Actions) != 1 {
 		t.Fatalf("expected 1 repair action, got %+v", plan.Actions)
 	}
-	assertRepairAction(t, plan, result.CaddyfilePath, RepairReasonDrifted)
+	assertRepairAction(t, plan, result.CaddyJSONPath, RepairReasonDrifted)
 	if plan.HasChanges() != true {
 		t.Fatalf("expected plan to report changes")
 	}
@@ -48,8 +48,8 @@ func TestApplyRepairPlanWritesOnlyPlannedFiles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("apply profile: %v", err)
 	}
-	if err := os.WriteFile(result.CaddyfilePath, []byte("drifted"), 0o600); err != nil {
-		t.Fatalf("drift caddyfile: %v", err)
+	if err := os.WriteFile(result.CaddyJSONPath, []byte("drifted"), 0o600); err != nil {
+		t.Fatalf("drift caddy json: %v", err)
 	}
 	plan, err := BuildRepairPlan(profile, paths)
 	if err != nil {
@@ -61,8 +61,8 @@ func TestApplyRepairPlanWritesOnlyPlannedFiles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("apply repair: %v", err)
 	}
-	if len(repairResult.WrittenFiles) != 1 || repairResult.WrittenFiles[0] != result.CaddyfilePath {
+	if len(repairResult.WrittenFiles) != 1 || repairResult.WrittenFiles[0] != result.CaddyJSONPath {
 		t.Fatalf("unexpected repaired files: %+v", repairResult.WrittenFiles)
 	}
-	assertFileContains(t, result.CaddyfilePath, "reverse_proxy 127.0.0.1:2096")
+	assertFileContains(t, result.CaddyJSONPath, `"dial": "127.0.0.1:2096"`)
 }

--- a/internal/installer/install_apply.go
+++ b/internal/installer/install_apply.go
@@ -20,7 +20,7 @@ type ApplyPaths struct {
 }
 
 type ApplyResult struct {
-	CaddyfilePath     string
+	CaddyJSONPath     string
 	Hysteria2Path     string
 	FallbackIndexPath string
 	WrittenFiles      []string
@@ -52,7 +52,7 @@ func (a InstallApply) Apply() (ApplyResult, error) {
 		return ApplyResult{}, err
 	}
 	result := ApplyResult{
-		CaddyfilePath:     filepath.Join(a.paths.EtcDir, "generated", "caddy", "panel.Caddyfile"),
+		CaddyJSONPath:     filepath.Join(a.paths.EtcDir, "generated", "caddy", "config.json"),
 		Hysteria2Path:     filepath.Join(a.paths.EtcDir, "generated", "hysteria2", "server.yaml"),
 		FallbackIndexPath: filepath.Join(a.paths.VarDir, "www", "index.html"),
 	}

--- a/internal/installer/install_apply_module_test.go
+++ b/internal/installer/install_apply_module_test.go
@@ -9,7 +9,7 @@ import (
 func TestInstallApplyModuleWritesManagedFiles(t *testing.T) {
 	dir := t.TempDir()
 	paths := ApplyPaths{EtcDir: filepath.Join(dir, "etc"), VarDir: filepath.Join(dir, "var")}
-	profile := RURecommendedProfile{Domain: "vpn.example.com", InstallPanelCaddy: true, Caddyfile: "caddy"}
+	profile := RURecommendedProfile{Domain: "vpn.example.com", InstallPanelCaddy: true, CaddyJSON: `{"apps":{"http":{"servers":{}}}}`}
 
 	result, err := NewInstallApply(profile, paths).Apply()
 	if err != nil {
@@ -18,11 +18,11 @@ func TestInstallApplyModuleWritesManagedFiles(t *testing.T) {
 	if len(result.WrittenFiles) != 2 {
 		t.Fatalf("written files = %+v", result.WrittenFiles)
 	}
-	body, err := os.ReadFile(filepath.Join(paths.EtcDir, "generated", "caddy", "panel.Caddyfile"))
+	body, err := os.ReadFile(filepath.Join(paths.EtcDir, "generated", "caddy", "config.json"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(body) != "caddy" {
-		t.Fatalf("caddyfile = %q", string(body))
+	if string(body) != `{"apps":{"http":{"servers":{}}}}` {
+		t.Fatalf("caddy json = %q", string(body))
 	}
 }

--- a/internal/installer/install_workflow_test.go
+++ b/internal/installer/install_workflow_test.go
@@ -22,7 +22,7 @@ func TestBuildRURecommendedInstallSelectsPanelPortBeforeProfile(t *testing.T) {
 	if result.PanelPort != 2096 || !result.PanelRandom {
 		t.Fatalf("panel selection = port %d random %v", result.PanelPort, result.PanelRandom)
 	}
-	if !strings.Contains(result.Profile.Caddyfile, "reverse_proxy 127.0.0.1:2096") {
-		t.Fatalf("profile Caddyfile did not receive selected panel port:\n%s", result.Profile.Caddyfile)
+	if !strings.Contains(result.Profile.CaddyJSON, `"dial": "127.0.0.1:2096"`) {
+		t.Fatalf("profile Caddy JSON did not receive selected panel port:\n%s", result.Profile.CaddyJSON)
 	}
 }

--- a/internal/installer/mieru_install_plan_test.go
+++ b/internal/installer/mieru_install_plan_test.go
@@ -41,8 +41,8 @@ func TestPanelInstallWritesDormantManagedRuntimeUnitsWithoutProxyConfig(t *testi
 	if _, err := os.Stat(filepath.Join(dir, "etc", "systemd", "system", "veil-olcrtc@.service")); err != nil {
 		t.Fatalf("Panel install should write dormant olcRTC unit template, stat err: %v", err)
 	}
-	if _, err := os.Stat(result.CaddyfilePath); !os.IsNotExist(err) {
-		t.Fatalf("Panel install should not write Caddyfile, stat err: %v", err)
+	if _, err := os.Stat(result.CaddyJSONPath); !os.IsNotExist(err) {
+		t.Fatalf("Panel install should not write Caddy JSON, stat err: %v", err)
 	}
 	if _, err := os.Stat(result.Hysteria2Path); !os.IsNotExist(err) {
 		t.Fatalf("Panel install should not write Hysteria2 config, stat err: %v", err)

--- a/internal/installer/panel_caddy_install_test.go
+++ b/internal/installer/panel_caddy_install_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mikkelchokolate/Veil/internal/hostenv"
 )
 
-func TestPanelCaddyInstallRendersPanelOnlyCaddyfile(t *testing.T) {
+func TestPanelCaddyInstallRendersPanelOnlyCaddyJSON(t *testing.T) {
 	profile, err := BuildRURecommendedProfile(RURecommendedInput{
 		PanelAccess: "caddy",
 		Domain:      "panel.example.com",
@@ -23,14 +23,14 @@ func TestPanelCaddyInstallRendersPanelOnlyCaddyfile(t *testing.T) {
 	if !profile.InstallPanelCaddy {
 		t.Fatalf("panel Caddy install should enable Panel Caddy access: %+v", profile)
 	}
-	for _, want := range []string{"panel.example.com", "handle ", "reverse_proxy 127.0.0.1:2096"} {
-		if !strings.Contains(profile.Caddyfile, want) {
-			t.Fatalf("Caddyfile missing %q:\n%s", want, profile.Caddyfile)
+	for _, want := range []string{"panel.example.com", `"dial": "127.0.0.1:2096"`} {
+		if !strings.Contains(profile.CaddyJSON, want) {
+			t.Fatalf("Caddy JSON missing %q:\n%s", want, profile.CaddyJSON)
 		}
 	}
 	for _, unwanted := range []string{"forward_proxy", "basic_auth", "probe_resistance"} {
-		if strings.Contains(profile.Caddyfile, unwanted) {
-			t.Fatalf("panel Caddyfile must not contain %q:\n%s", unwanted, profile.Caddyfile)
+		if strings.Contains(profile.CaddyJSON, unwanted) {
+			t.Fatalf("panel Caddy JSON must not contain %q:\n%s", unwanted, profile.CaddyJSON)
 		}
 	}
 }
@@ -77,12 +77,12 @@ func TestPanelCaddyInstallWritesCaddyfileAndCaddyRuntimeUnit(t *testing.T) {
 	if strings.Contains(string(envBody), "VEIL_TLS_CERT=") || strings.Contains(string(envBody), "VEIL_TLS_KEY=") {
 		t.Fatalf("Panel Caddy access should terminate TLS in Caddy, not Panel:\n%s", string(envBody))
 	}
-	body, err := os.ReadFile(result.CaddyfilePath)
+	body, err := os.ReadFile(result.CaddyJSONPath)
 	if err != nil {
-		t.Fatalf("panel Caddyfile should be written: %v", err)
+		t.Fatalf("panel Caddy JSON should be written: %v", err)
 	}
-	if !strings.Contains(string(body), "reverse_proxy 127.0.0.1:2096") {
-		t.Fatalf("unexpected panel Caddyfile:\n%s", string(body))
+	if !strings.Contains(string(body), `"dial": "127.0.0.1:2096"`) {
+		t.Fatalf("unexpected panel Caddy JSON:\n%s", string(body))
 	}
 	if _, err := os.Stat(filepath.Join(dir, "systemd", "veil-caddy.service")); err != nil {
 		t.Fatalf("Caddy runtime unit should be written for panel Caddy access: %v", err)

--- a/internal/installer/panel_caddy_install_test.go
+++ b/internal/installer/panel_caddy_install_test.go
@@ -40,7 +40,7 @@ func TestPanelCaddyInstallPlanOpensHTTPSInsteadOfPanelPort(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	plan, err := BuildInstallPlan(profile, InstallPlanInput{Platform: hostenv.Platform{OS: "linux", Arch: "amd64"}, SystemdUnits: []string{"veil.service", "veil-caddy@panel.service"}, PanelAccess: profile.PanelAccess, PanelPort: 2096})
+	plan, err := BuildInstallPlan(profile, InstallPlanInput{Platform: hostenv.Platform{OS: "linux", Arch: "amd64"}, SystemdUnits: []string{"veil.service", "veil-caddy.service"}, PanelAccess: profile.PanelAccess, PanelPort: 2096})
 	if err != nil {
 		t.Fatalf("BuildInstallPlan: %v", err)
 	}
@@ -84,7 +84,7 @@ func TestPanelCaddyInstallWritesCaddyfileAndCaddyRuntimeUnit(t *testing.T) {
 	if !strings.Contains(string(body), "reverse_proxy 127.0.0.1:2096") {
 		t.Fatalf("unexpected panel Caddyfile:\n%s", string(body))
 	}
-	if _, err := os.Stat(filepath.Join(dir, "systemd", "veil-caddy@.service")); err != nil {
+	if _, err := os.Stat(filepath.Join(dir, "systemd", "veil-caddy.service")); err != nil {
 		t.Fatalf("Caddy runtime unit should be written for panel Caddy access: %v", err)
 	}
 }

--- a/internal/installer/panel_only_install_test.go
+++ b/internal/installer/panel_only_install_test.go
@@ -83,7 +83,7 @@ func TestPanelOnlyInstallDoesNotRequireDomainAndWritesNoProxyConfigs(t *testing.
 	if err != nil {
 		t.Fatalf("BuildRURecommendedProfile panel-only: %v", err)
 	}
-	if profile.InstallPanelCaddy || profile.Caddyfile != "" {
+	if profile.InstallPanelCaddy || profile.CaddyJSON != "" {
 		t.Fatalf("panel-only profile should not include proxy artifacts: %+v", profile)
 	}
 	dir := t.TempDir()
@@ -95,8 +95,8 @@ func TestPanelOnlyInstallDoesNotRequireDomainAndWritesNoProxyConfigs(t *testing.
 	if err != nil {
 		t.Fatalf("ApplyRURecommendedProfile: %v", err)
 	}
-	if _, err := os.Stat(result.CaddyfilePath); !os.IsNotExist(err) {
-		t.Fatalf("panel-only install should not write Caddyfile, stat err: %v", err)
+	if _, err := os.Stat(result.CaddyJSONPath); !os.IsNotExist(err) {
+		t.Fatalf("panel-only install should not write Caddy JSON, stat err: %v", err)
 	}
 	if _, err := os.Stat(result.Hysteria2Path); !os.IsNotExist(err) {
 		t.Fatalf("panel-only install should not write Hysteria2 config, stat err: %v", err)

--- a/internal/installer/panel_systemd_units_test.go
+++ b/internal/installer/panel_systemd_units_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestPanelSystemdUnitsIncludesPanelReverseProxyUnit(t *testing.T) {
 	units := PanelSystemdUnits(RURecommendedProfile{InstallPanelCaddy: true})
-	want := []string{"veil-helper.socket", "veil.service", "veil-caddy@panel.service"}
+	want := []string{"veil-helper.socket", "veil.service", "veil-caddy.service"}
 	if !equalStringSlices(units, want) {
 		t.Fatalf("PanelSystemdUnits = %+v, want %+v", units, want)
 	}

--- a/internal/installer/plan.go
+++ b/internal/installer/plan.go
@@ -71,7 +71,10 @@ func BuildInstallPlan(profile RURecommendedProfile, input InstallPlanInput) (Ins
 	panelHTTPSPort := 0
 	if profile.InstallPanelCaddy {
 		panelPort = 0
-		panelHTTPSPort = 443
+		panelHTTPSPort = profile.PanelPublicPort
+		if panelHTTPSPort == 0 {
+			panelHTTPSPort = 443
+		}
 	}
 	return InstallPlan{
 		Profile:        profile,

--- a/internal/installer/plan.go
+++ b/internal/installer/plan.go
@@ -25,7 +25,7 @@ func CaddyPanelBuildHint(binaryPath string) BuildHint {
 func PanelSystemdUnits(profile RURecommendedProfile) []string {
 	units := []string{renderer.UnitHelperSocket, renderer.UnitVeil}
 	if profile.InstallPanelCaddy {
-		units = append(units, "veil-caddy@panel.service")
+		units = append(units, renderer.UnitCaddy)
 	}
 	return units
 }

--- a/internal/installer/profile_ru.go
+++ b/internal/installer/profile_ru.go
@@ -29,7 +29,7 @@ type RURecommendedProfile struct {
 	PanelTLSKeyPEM    string
 	WebBasePath       string
 	InstallPanelCaddy bool
-	Caddyfile         string
+	CaddyJSON         string
 	MasqueradeURL     string
 	FallbackRoot      string
 }
@@ -64,7 +64,7 @@ func BuildRURecommendedProfile(input RURecommendedInput) (RURecommendedProfile, 
 }
 
 // BuildRURecommendedInstall concentrates the ordering invariant that the panel
-// port must be selected before profile rendering, because the Caddyfile embeds
+// port must be selected before profile rendering, because the Caddy JSON embeds
 // that port for the Panel reverse proxy.
 func BuildRURecommendedInstall(input RURecommendedInstallInput) (RURecommendedInstall, error) {
 	randomPanelPort := input.RandomPanelPort
@@ -123,7 +123,7 @@ func (m RURecommendedProfileModule) Build() (RURecommendedProfile, error) {
 		PanelTLSKeyPEM:    panelAccess.PanelTLSKeyPEM,
 		WebBasePath:       panelAccess.WebBasePath,
 		InstallPanelCaddy: panelAccess.InstallPanelCaddy,
-		Caddyfile:         panelAccess.Caddyfile,
+		CaddyJSON:         panelAccess.CaddyJSON,
 		MasqueradeURL:     masqueradeURL,
 		FallbackRoot:      fallbackRoot,
 	}, nil

--- a/internal/installer/profile_ru.go
+++ b/internal/installer/profile_ru.go
@@ -9,11 +9,12 @@ import (
 type SecretFunc func(label string) string
 
 type RURecommendedInput struct {
-	Domain      string
-	Email       string
-	PanelAccess string
-	Secret      SecretFunc
-	PanelPort   int
+	Domain           string
+	Email            string
+	PanelAccess      string
+	Secret           SecretFunc
+	PanelPort        int
+	PanelPublicPort  int
 }
 
 type RURecommendedProfile struct {
@@ -24,6 +25,7 @@ type RURecommendedProfile struct {
 	PanelAuthToken    string
 	PanelListen       string
 	PanelAccess       string
+	PanelPublicPort   int
 	PanelTLSEnabled   bool
 	PanelTLSCertPEM   string
 	PanelTLSKeyPEM    string
@@ -41,6 +43,7 @@ type RURecommendedInstallInput struct {
 	Email           string
 	PanelAccess     string
 	PanelPort       int
+	PanelPublicPort int
 	Secret          SecretFunc
 	RandomPanelPort func() (int, error)
 }
@@ -76,11 +79,12 @@ func BuildRURecommendedInstall(input RURecommendedInstallInput) (RURecommendedIn
 		return RURecommendedInstall{}, err
 	}
 	profile, err := BuildRURecommendedProfile(RURecommendedInput{
-		Domain:      input.Domain,
-		Email:       input.Email,
-		PanelAccess: input.PanelAccess,
-		Secret:      input.Secret,
-		PanelPort:   panelPort,
+		Domain:          input.Domain,
+		Email:           input.Email,
+		PanelAccess:     input.PanelAccess,
+		Secret:          input.Secret,
+		PanelPort:       panelPort,
+		PanelPublicPort: input.PanelPublicPort,
 	})
 	if err != nil {
 		return RURecommendedInstall{}, err
@@ -104,9 +108,13 @@ func (m RURecommendedProfileModule) Build() (RURecommendedProfile, error) {
 
 	masqueradeURL := "https://www.bing.com/"
 	fallbackRoot := "/var/lib/veil/www"
-	panelAccess, err := panelaccess.NewProfile(panelaccess.ProfileInput{PanelAccess: input.PanelAccess, Domain: input.Domain, Email: input.Email, PanelPort: input.PanelPort}).Build()
+	panelAccess, err := panelaccess.NewProfile(panelaccess.ProfileInput{PanelAccess: input.PanelAccess, Domain: input.Domain, Email: input.Email, PanelPort: input.PanelPort, PublicPort: input.PanelPublicPort}).Build()
 	if err != nil {
 		return RURecommendedProfile{}, err
+	}
+	panelPublicPort := panelAccess.PanelPublicPort
+	if panelPublicPort == 0 {
+		panelPublicPort = 443
 	}
 	panelAuthToken := input.Secret("panel")
 
@@ -118,6 +126,7 @@ func (m RURecommendedProfileModule) Build() (RURecommendedProfile, error) {
 		PanelAuthToken:    panelAuthToken,
 		PanelListen:       panelAccess.PanelListen,
 		PanelAccess:       input.PanelAccess,
+		PanelPublicPort:   panelPublicPort,
 		PanelTLSEnabled:   panelAccess.PanelTLSEnabled,
 		PanelTLSCertPEM:   panelAccess.PanelTLSCertPEM,
 		PanelTLSKeyPEM:    panelAccess.PanelTLSKeyPEM,

--- a/internal/installer/profile_ru_test.go
+++ b/internal/installer/profile_ru_test.go
@@ -23,7 +23,7 @@ func TestBuildRURecommendedProfileDefaultsToPanelOnly(t *testing.T) {
 	if profile.InstallPanelCaddy {
 		t.Fatalf("expected direct/local panel-only profile, got %+v", profile)
 	}
-	if profile.Caddyfile != "" {
+	if profile.CaddyJSON != "" {
 		t.Fatalf("panel-only profile should not include protocol artifacts: %+v", profile)
 	}
 	if profile.PanelAuthToken != "secret-panel" || !profile.PanelTLSEnabled {
@@ -54,22 +54,17 @@ func TestBuildRURecommendedProfileGeneratesWebBasePathForPanelCaddyAccess(t *tes
 	}
 }
 
-func TestBuildRURecommendedProfileIncludesPanelReverseProxyInCaddyfile(t *testing.T) {
+func TestBuildRURecommendedProfileIncludesPanelReverseProxyInCaddyJSON(t *testing.T) {
 	profile, err := BuildRURecommendedProfile(RURecommendedInput{PanelAccess: "caddy", Domain: "example.com", Email: "admin@example.com", Secret: func(label string) string { return "secret-" + label }, PanelPort: 2096})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(profile.Caddyfile, "reverse_proxy 127.0.0.1:2096") {
-		t.Fatalf("Caddyfile missing reverse_proxy for panel port:\n%s", profile.Caddyfile)
+	if !strings.Contains(profile.CaddyJSON, `"dial": "127.0.0.1:2096"`) {
+		t.Fatalf("Caddy JSON missing reverse_proxy for panel port:\n%s", profile.CaddyJSON)
 	}
-	if !strings.Contains(profile.Caddyfile, "handle /"+strings.Trim(profile.WebBasePath, "/")+"/*") {
-		t.Fatalf("Caddyfile missing handle_path for web base path %s:\n%s", profile.WebBasePath, profile.Caddyfile)
+	if !strings.Contains(profile.CaddyJSON, strings.TrimRight(profile.WebBasePath, "/")) {
+		t.Fatalf("Caddy JSON missing web base path %s:\n%s", profile.WebBasePath, profile.CaddyJSON)
 	}
 }
 
-func TestBuildRURecommendedProfileRejectsPanelCaddyWhenPanelPortZero(t *testing.T) {
-	_, err := BuildRURecommendedProfile(RURecommendedInput{PanelAccess: "caddy", Domain: "example.com", Email: "admin@example.com", Secret: func(label string) string { return "secret-" + label }, PanelPort: 0})
-	if err == nil {
-		t.Fatalf("expected Panel Caddy access to require selected Panel port")
-	}
-}
+

--- a/internal/installer/repair.go
+++ b/internal/installer/repair.go
@@ -43,7 +43,7 @@ func desiredManagedFiles(profile RURecommendedProfile, paths ApplyPaths) ([]mana
 		PanelTLSCertPEM:   profile.PanelTLSCertPEM,
 		PanelTLSKeyPEM:    profile.PanelTLSKeyPEM,
 		InstallPanelCaddy: profile.InstallPanelCaddy,
-		Caddyfile:         profile.Caddyfile,
+		CaddyJSON:         profile.CaddyJSON,
 	}).Files()
 	if err != nil {
 		return nil, err

--- a/internal/installer/repair_test.go
+++ b/internal/installer/repair_test.go
@@ -16,7 +16,7 @@ func TestBuildRepairPlanDetectsMissingFiles(t *testing.T) {
 	profile := RURecommendedProfile{
 		Domain:            "vpn.example.com",
 		InstallPanelCaddy: true,
-		Caddyfile:         "caddy content",
+		CaddyJSON:         `{"apps":{"http":{"servers":{}}}}`,
 	}
 
 	paths := ApplyPaths{
@@ -67,7 +67,7 @@ func TestBuildRepairPlanDetectsDriftedFiles(t *testing.T) {
 	profile := RURecommendedProfile{
 		Domain:            "vpn.example.com",
 		InstallPanelCaddy: true,
-		Caddyfile:         "expected caddy content",
+		CaddyJSON:         `{"apps":{"http":{"servers":{}}}}`,
 	}
 
 	paths := ApplyPaths{
@@ -76,8 +76,8 @@ func TestBuildRepairPlanDetectsDriftedFiles(t *testing.T) {
 		SystemdDir: systemdDir,
 	}
 
-	// Pre-create Caddyfile with stale content
-	caddyPath := filepath.Join(etcDir, "generated", "caddy", "panel.Caddyfile")
+	// Pre-create Caddy JSON with stale content
+	caddyPath := filepath.Join(etcDir, "generated", "caddy", "config.json")
 	if err := os.MkdirAll(filepath.Dir(caddyPath), 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
@@ -100,14 +100,14 @@ func TestBuildRepairPlanDetectsDriftedFiles(t *testing.T) {
 			if action.Reason != RepairReasonDrifted {
 				t.Fatalf("expected caddy to be 'drifted', got %q", action.Reason)
 			}
-			if action.Content != "expected caddy content" {
-				t.Fatalf("expected caddy repair content to be 'expected caddy content', got %q", action.Content)
+			if action.Content != `{"apps":{"http":{"servers":{}}}}` {
+				t.Fatalf("expected caddy repair content to be '{\"apps\":{\"http\":{\"servers\":{}}}}', got %q", action.Content)
 			}
 			foundDrift = true
 		}
 	}
 	if !foundDrift {
-		t.Fatalf("expected drift action for Caddyfile, actions: %+v", plan.Actions)
+		t.Fatalf("expected drift action for Caddy JSON, actions: %+v", plan.Actions)
 	}
 }
 
@@ -127,7 +127,7 @@ func TestBuildRepairPlanNoChangesWhenFilesMatch(t *testing.T) {
 	profile := RURecommendedProfile{
 		Domain:            "vpn.example.com",
 		InstallPanelCaddy: true,
-		Caddyfile:         "caddy content",
+		CaddyJSON:         `{"apps":{"http":{"servers":{}}}}`,
 	}
 
 	paths := ApplyPaths{
@@ -135,12 +135,12 @@ func TestBuildRepairPlanNoChangesWhenFilesMatch(t *testing.T) {
 		VarDir: varDir,
 	}
 
-	// Pre-create Caddyfile with matching content
-	caddyPath := filepath.Join(etcDir, "generated", "caddy", "panel.Caddyfile")
+	// Pre-create Caddy JSON with matching content
+	caddyPath := filepath.Join(etcDir, "generated", "caddy", "config.json")
 	if err := os.MkdirAll(filepath.Dir(caddyPath), 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
-	if err := os.WriteFile(caddyPath, []byte("caddy content"), 0o600); err != nil {
+	if err := os.WriteFile(caddyPath, []byte(`{"apps":{"http":{"servers":{}}}}`), 0o600); err != nil {
 		t.Fatalf("write caddy: %v", err)
 	}
 

--- a/internal/installer/systemd_binary_path_test.go
+++ b/internal/installer/systemd_binary_path_test.go
@@ -30,9 +30,9 @@ func TestInstallApplyRendersCaddyUnitWithResolvedBinaryPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("desiredFiles: %v", err)
 	}
-	unit := managedFileContent(files, "veil-caddy@.service")
+	unit := managedFileContent(files, "veil-caddy.service")
 	if !strings.Contains(unit, "ExecStart=/usr/bin/caddy run --config") || !strings.Contains(unit, "ExecReload=/usr/bin/caddy reload --config") {
-		t.Fatalf("veil-caddy@.service should use resolved Caddy binary path:\n%s", unit)
+		t.Fatalf("veil-caddy.service should use resolved Caddy binary path:\n%s", unit)
 	}
 }
 

--- a/internal/installer/systemd_binary_path_test.go
+++ b/internal/installer/systemd_binary_path_test.go
@@ -23,7 +23,7 @@ func TestInstallApplyRendersVeilUnitWithSelectedBinaryPath(t *testing.T) {
 
 func TestInstallApplyRendersCaddyUnitWithResolvedBinaryPath(t *testing.T) {
 	dir := t.TempDir()
-	profile := RURecommendedProfile{InstallPanelCaddy: true, PanelAuthToken: "secret-panel", Caddyfile: "example.com { respond ok }"}
+	profile := RURecommendedProfile{InstallPanelCaddy: true, PanelAuthToken: "secret-panel", CaddyJSON: `{"apps":{"http":{"servers":{}}}}`}
 	paths := ApplyPaths{EtcDir: filepath.Join(dir, "etc", "veil"), VarDir: filepath.Join(dir, "var", "lib", "veil"), SystemdDir: filepath.Join(dir, "systemd"), CaddyBinary: "/usr/bin/caddy"}
 
 	files, err := desiredManagedFiles(profile, paths)

--- a/internal/livevalidation/validator.go
+++ b/internal/livevalidation/validator.go
@@ -224,7 +224,7 @@ func requiredFieldIssues(settings model.Settings, inbound model.Inbound) []model
 				"Set the domain that resolves to this host.", "candidate",
 			))
 		}
-		if naiveproxy.NaiveEmail(settings, inbound) == "" {
+		if resolveNaiveEmail(settings, inbound) == "" {
 			issues = append(issues, issue(
 				"email_required", SeverityError, "settings.email", inbound.Name,
 				"NaiveProxy automatic TLS requires an email address",
@@ -246,6 +246,22 @@ func requiredFieldIssues(settings model.Settings, inbound model.Inbound) []model
 		))
 	}
 	return issues
+}
+
+func resolveNaiveEmail(settings model.Settings, inbound model.Inbound) string {
+	candidates := []string{}
+	if inbound.ProtocolFields != nil {
+		if e, ok := inbound.ProtocolFields["email"].(string); ok {
+			candidates = append(candidates, e)
+		}
+	}
+	candidates = append(candidates, settings.DefaultAcmeEmail, settings.PanelEmail)
+	for _, c := range candidates {
+		if v := strings.TrimSpace(c); v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 func protocolNeedsDomain(settings model.Settings, inbound model.Inbound) bool {

--- a/internal/livevalidation/validator.go
+++ b/internal/livevalidation/validator.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/mikkelchokolate/Veil/internal/model"
 	"github.com/mikkelchokolate/Veil/internal/protocols"
+	"github.com/mikkelchokolate/Veil/internal/protocols/naiveproxy"
 	"github.com/mikkelchokolate/Veil/internal/service"
 )
 
@@ -215,18 +216,26 @@ func unitForInbound(protocol string, inbound model.Inbound, descriptors []servic
 
 func requiredFieldIssues(settings model.Settings, inbound model.Inbound) []model.ValidationIssue {
 	issues := []model.ValidationIssue{}
-	if protocolNeedsDomain(settings, inbound) && strings.TrimSpace(settings.Domain) == "" {
+	if inbound.Protocol == "naiveproxy" {
+		if naiveproxy.NaiveDomain(settings, inbound) == "" {
+			issues = append(issues, issue(
+				"domain_required", SeverityError, "settings.domain", inbound.Name,
+				"This protocol requires a public domain",
+				"Set the domain that resolves to this host.", "candidate",
+			))
+		}
+		if naiveproxy.NaiveEmail(settings, inbound) == "" {
+			issues = append(issues, issue(
+				"email_required", SeverityError, "settings.email", inbound.Name,
+				"NaiveProxy automatic TLS requires an email address",
+				"Set the ACME contact email.", "candidate",
+			))
+		}
+	} else if protocolNeedsDomain(settings, inbound) && strings.TrimSpace(settings.Domain) == "" {
 		issues = append(issues, issue(
 			"domain_required", SeverityError, "settings.domain", inbound.Name,
 			"This protocol requires a public domain",
 			"Set the domain that resolves to this host.", "candidate",
-		))
-	}
-	if inbound.Protocol == "naiveproxy" && strings.TrimSpace(settings.Email) == "" {
-		issues = append(issues, issue(
-			"email_required", SeverityError, "settings.email", inbound.Name,
-			"NaiveProxy automatic TLS requires an email address",
-			"Set the ACME contact email.", "candidate",
 		))
 	}
 	if !hasCredential(settings, inbound) {

--- a/internal/livevalidation/validator_test.go
+++ b/internal/livevalidation/validator_test.go
@@ -176,10 +176,10 @@ func TestValidatorReportsUnresolvedDomainAndProbeFailure(t *testing.T) {
 
 	response := validator.Validate(context.Background(), Request{
 		Settings: model.Settings{
-			Domain:        "missing.example",
-			Email:         "admin@example.com",
-			NaiveUsername: "veil",
-			NaivePassword: "secret",
+			Domain:           "missing.example",
+			DefaultAcmeEmail: "admin@example.com",
+			NaiveUsername:    "veil",
+			NaivePassword:    "secret",
 		},
 		Inbounds: []model.Inbound{{
 			Name: "public", Protocol: "naiveproxy", Transport: "tcp", Port: 443, Enabled: true,
@@ -198,10 +198,10 @@ func TestValidatorTreatsExternalDNSAndRuntimeAvailabilityAsWarnings(t *testing.T
 
 	response := validator.Validate(context.Background(), Request{
 		Settings: model.Settings{
-			Domain:        "pending.example",
-			Email:         "admin@example.com",
-			NaiveUsername: "veil",
-			NaivePassword: "secret",
+			Domain:           "pending.example",
+			DefaultAcmeEmail: "admin@example.com",
+			NaiveUsername:    "veil",
+			NaivePassword:    "secret",
 		},
 		Inbounds: []model.Inbound{{
 			Name: "public", Protocol: "naiveproxy", Transport: "tcp", Port: 443, Enabled: true,

--- a/internal/livevalidation/validator_test.go
+++ b/internal/livevalidation/validator_test.go
@@ -138,6 +138,38 @@ func TestValidatorReportsMissingDomainEmailCredentialBinaryAndUnit(t *testing.T)
 	}
 }
 
+func TestValidatorAcceptsNaiveInboundWithPerInboundDomainAndEmail(t *testing.T) {
+	validator := testValidator()
+	validator.DNS = fakeDNSResolver{hosts: map[string][]string{"p.example.com": {"203.0.113.10"}}}
+
+	response := validator.Validate(context.Background(), Request{
+		Settings: model.Settings{
+			DefaultAcmeEmail: "admin@example.com",
+			NaiveUsername:    "veil",
+			NaivePassword:    "secret",
+		},
+		Inbounds: []model.Inbound{{
+			Name:      "public",
+			Protocol:  "naiveproxy",
+			Transport: "tcp",
+			Port:      443,
+			Enabled:   true,
+			ProtocolFields: map[string]any{
+				"domain": "p.example.com",
+			},
+		}},
+	})
+
+	if !response.Valid {
+		t.Fatalf("naive inbound with per-inbound domain/email should be valid: %+v", response)
+	}
+	for _, code := range []string{"domain_required", "email_required"} {
+		if hasIssueCode(response, code) {
+			t.Fatalf("unexpected %s issue: %+v", code, response)
+		}
+	}
+}
+
 func TestValidatorReportsUnresolvedDomainAndProbeFailure(t *testing.T) {
 	validator := testValidator()
 	validator.Ports = fakePortProbe{err: errors.New("permission denied")}

--- a/internal/managementstate/validation.go
+++ b/internal/managementstate/validation.go
@@ -75,16 +75,17 @@ func (Validation) ValidateSnapshot(snapshot model.ManagementSnapshot, fields map
 			if inbound.Protocol == "" {
 				errs = append(errs, "inbounds["+itoa(i)+"].protocol is required")
 			}
-			if inbound.Transport == "" {
+			transport := effectiveInboundTransport(inbound)
+			if transport == "" {
 				errs = append(errs, "inbounds["+itoa(i)+"].transport is required")
 			}
-			if inbound.Protocol != "" && inbound.Transport != "" && !protocolCatalog.SupportsTransport(inbound.Protocol, inbound.Transport) {
-				errs = append(errs, "inbounds["+itoa(i)+"].protocol/transport is unsupported: "+inbound.Protocol+"/"+inbound.Transport)
+			if inbound.Protocol != "" && transport != "" && !protocolCatalog.SupportsTransport(inbound.Protocol, transport) {
+				errs = append(errs, "inbounds["+itoa(i)+"].protocol/transport is unsupported: "+inbound.Protocol+"/"+transport)
 			}
 			if inbound.Port <= 0 || inbound.Port > 65535 {
 				errs = append(errs, "inbounds["+itoa(i)+"].port must be 1-65535, got: "+itoa(inbound.Port))
 			}
-			key := inbound.Transport + ":" + itoa(inbound.Port)
+			key := transport + ":" + itoa(inbound.Port)
 			if owner, exists := seenPorts[key]; exists {
 				if owner == "panel" || owner == "warp" {
 					errs = append(errs, fmt.Sprintf("inbounds[%d]: port %d conflicts with %s", i, inbound.Port, owner))
@@ -109,6 +110,25 @@ func (Validation) ValidateSnapshot(snapshot model.ManagementSnapshot, fields map
 		}
 	}
 	return errs
+}
+
+func effectiveInboundTransport(inbound model.Inbound) string {
+	if inbound.Transport != "" {
+		return inbound.Transport
+	}
+	if inbound.ProtocolFields != nil {
+		if value, ok := inbound.ProtocolFields["transport"].(string); ok && value != "" {
+			return value
+		}
+	}
+	switch inbound.Protocol {
+	case "naiveproxy":
+		return "tcp"
+	case "hysteria2", "olcrtc":
+		return "udp"
+	default:
+		return ""
+	}
 }
 
 func itoa(value int) string {

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -1,23 +1,26 @@
 package model
 
 type Settings struct {
-	PanelListen       string `json:"panelListen"`
-	PanelAccess       string `json:"panelAccess,omitempty"`
-	WebBasePath       string `json:"webBasePath,omitempty"`
-	Mode              string `json:"mode"`
-	Domain            string `json:"domain,omitempty"`
-	Email             string `json:"email,omitempty"`
-	PanelEmail        string `json:"panelEmail,omitempty"`
-	DefaultAcmeEmail  string `json:"defaultAcmeEmail,omitempty"`
-	NaiveUsername     string `json:"naiveUsername,omitempty"`
-	NaivePassword     string `json:"naivePassword,omitempty"`
-	Hysteria2Password string `json:"hysteria2Password,omitempty"`
-	Hysteria2Insecure bool   `json:"hysteria2Insecure,omitempty"`
-	MasqueradeURL     string `json:"masqueradeURL,omitempty"`
-	FallbackRoot      string `json:"fallbackRoot,omitempty"`
-	OlcrtcAuth        string `json:"olcrtcAuth,omitempty"`
-	OlcrtcTransport   string `json:"olcrtcTransport,omitempty"`
-	OlcrtcRoomID      string `json:"olcrtcRoomID,omitempty"`
+	PanelListen              string `json:"panelListen"`
+	PanelAccess              string `json:"panelAccess,omitempty"`
+	WebBasePath              string `json:"webBasePath,omitempty"`
+	Mode                     string `json:"mode"`
+	Domain                   string `json:"domain,omitempty"`
+	Email                    string `json:"email,omitempty"`
+	PanelEmail               string `json:"panelEmail,omitempty"`
+	DefaultAcmeEmail         string `json:"defaultAcmeEmail,omitempty"`
+	PanelPublicPort          int    `json:"panelPublicPort,omitempty"`
+	DefaultInboundPublicPort int    `json:"defaultInboundPublicPort,omitempty"`
+	AcmeChallengeMode        string `json:"acmeChallengeMode,omitempty"`
+	NaiveUsername            string `json:"naiveUsername,omitempty"`
+	NaivePassword            string `json:"naivePassword,omitempty"`
+	Hysteria2Password        string `json:"hysteria2Password,omitempty"`
+	Hysteria2Insecure        bool   `json:"hysteria2Insecure,omitempty"`
+	MasqueradeURL            string `json:"masqueradeURL,omitempty"`
+	FallbackRoot             string `json:"fallbackRoot,omitempty"`
+	OlcrtcAuth               string `json:"olcrtcAuth,omitempty"`
+	OlcrtcTransport          string `json:"olcrtcTransport,omitempty"`
+	OlcrtcRoomID             string `json:"olcrtcRoomID,omitempty"`
 	// ProtocolFields holds protocol-specific settings populated by the dynamic
 	// Panel UI. Legacy flat fields above are still supported for backward
 	// compatibility and are migrated into ProtocolFields on load.

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -3,6 +3,7 @@ package model
 type Settings struct {
 	PanelListen              string `json:"panelListen"`
 	PanelAccess              string `json:"panelAccess,omitempty"`
+	PanelDomain              string `json:"panelDomain,omitempty"`
 	WebBasePath              string `json:"webBasePath,omitempty"`
 	Mode                     string `json:"mode"`
 	Domain                   string `json:"domain,omitempty"`

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -7,6 +7,8 @@ type Settings struct {
 	Mode              string `json:"mode"`
 	Domain            string `json:"domain,omitempty"`
 	Email             string `json:"email,omitempty"`
+	PanelEmail        string `json:"panelEmail,omitempty"`
+	DefaultAcmeEmail  string `json:"defaultAcmeEmail,omitempty"`
 	NaiveUsername     string `json:"naiveUsername,omitempty"`
 	NaivePassword     string `json:"naivePassword,omitempty"`
 	Hysteria2Password string `json:"hysteria2Password,omitempty"`

--- a/internal/model/types_test.go
+++ b/internal/model/types_test.go
@@ -18,7 +18,7 @@ func TestApplyPlanResponseIncludesStructuredPreview(t *testing.T) {
 		}},
 		Operations: []ApplyOperation{{
 			Type:              "promote_file",
-			Destination:       "/etc/veil/generated/caddy/Caddyfile",
+			Destination:       "/etc/veil/generated/caddy/config.json",
 			InterruptionRisk:  "reload",
 			RollbackAvailable: true,
 			ValidationSource:  "live-host",

--- a/internal/panelaccess/panel_access.go
+++ b/internal/panelaccess/panel_access.go
@@ -77,11 +77,14 @@ func (p PanelAccess) GeneratedConfig(paths generatedconfig.Paths) (generatedconf
 	if panelDomain(p.settings) == "" {
 		return generatedconfig.GeneratedConfigArtifact{}, false, fmt.Errorf("domain is required")
 	}
-	plan, _, err := caddyassembly.BuildRenderPlan(p.settings, nil, nil)
+	plan, _, _, err := caddyassembly.BuildFinalRenderPlan(p.settings, nil)
 	if err != nil {
 		return generatedconfig.GeneratedConfigArtifact{}, false, err
 	}
-	caps, _ := caddycapabilities.Probe("")
+	caps, err := caddycapabilities.Probe("")
+	if err != nil {
+		return generatedconfig.GeneratedConfigArtifact{}, false, fmt.Errorf("failed to probe Caddy capabilities: %w", err)
+	}
 	body, err := renderer.RenderCaddyJSON(plan, caps)
 	if err != nil {
 		return generatedconfig.GeneratedConfigArtifact{}, false, err

--- a/internal/panelaccess/panel_access.go
+++ b/internal/panelaccess/panel_access.go
@@ -5,6 +5,8 @@ import (
 	"net"
 	"strconv"
 
+	"github.com/mikkelchokolate/Veil/internal/caddyassembly"
+	"github.com/mikkelchokolate/Veil/internal/caddycapabilities"
 	"github.com/mikkelchokolate/Veil/internal/generatedconfig"
 	"github.com/mikkelchokolate/Veil/internal/model"
 	"github.com/mikkelchokolate/Veil/internal/renderer"
@@ -54,16 +56,37 @@ func (p PanelAccess) CaddyRoute() (CaddyRoute, bool, error) {
 	return CaddyRoute{Port: port, WebBasePath: webBasePath}, true, nil
 }
 
-func (p PanelAccess) GeneratedConfig(paths generatedconfig.Paths) (generatedconfig.GeneratedConfigArtifact, bool, error) {
-	route, ok, err := p.CaddyRoute()
-	if err != nil || !ok {
-		return generatedconfig.GeneratedConfigArtifact{}, ok, err
+func panelDomain(settings model.Settings) string {
+	if settings.PanelDomain != "" {
+		return settings.PanelDomain
 	}
-	body, err := renderer.RenderPanelCaddyfile(renderer.PanelCaddyConfig{Domain: p.settings.Domain, Email: p.settings.Email, PanelPort: route.Port, WebBasePath: route.WebBasePath})
+	return settings.Domain
+}
+
+func panelEmail(settings model.Settings) string {
+	if settings.PanelEmail != "" {
+		return settings.PanelEmail
+	}
+	return settings.Email
+}
+
+func (p PanelAccess) GeneratedConfig(paths generatedconfig.Paths) (generatedconfig.GeneratedConfigArtifact, bool, error) {
+	if p.settings.PanelAccess != "caddy" {
+		return generatedconfig.GeneratedConfigArtifact{}, false, nil
+	}
+	if panelDomain(p.settings) == "" {
+		return generatedconfig.GeneratedConfigArtifact{}, false, fmt.Errorf("domain is required")
+	}
+	plan, _, err := caddyassembly.BuildRenderPlan(p.settings, nil, nil)
 	if err != nil {
 		return generatedconfig.GeneratedConfigArtifact{}, false, err
 	}
-	return generatedconfig.GeneratedConfigArtifact{Path: paths.Caddyfile(), Body: body}, true, nil
+	caps, _ := caddycapabilities.Probe("")
+	body, err := renderer.RenderCaddyJSON(plan, caps)
+	if err != nil {
+		return generatedconfig.GeneratedConfigArtifact{}, false, err
+	}
+	return generatedconfig.GeneratedConfigArtifact{Path: paths.CaddyJSON(), Body: string(body)}, true, nil
 }
 
 func (p PanelAccess) ApplyIntent(inbounds []model.Inbound) ApplyIntent {
@@ -71,42 +94,14 @@ func (p PanelAccess) ApplyIntent(inbounds []model.Inbound) ApplyIntent {
 	if p.settings.PanelAccess != "caddy" {
 		return intent
 	}
-	if p.settings.Domain == "" || p.settings.Email == "" {
+	if panelDomain(p.settings) == "" || panelEmail(p.settings) == "" {
 		intent.Errors = append(intent.Errors, "--domain and --email are required for caddy Panel access")
 	} else if _, _, err := p.CaddyRoute(); err != nil {
 		intent.Errors = append(intent.Errors, err.Error())
 	} else {
-		var panelInbound *model.Inbound
-		hasInboundOn443 := false
-		for _, inbound := range inbounds {
-			if inbound.Enabled && p.protocolRequiresCaddy(inbound.Protocol) {
-				if inbound.Port == 443 {
-					hasInboundOn443 = true
-					break
-				}
-			}
-		}
-		for _, inbound := range inbounds {
-			if inbound.Enabled && p.protocolRequiresCaddy(inbound.Protocol) {
-				if inbound.Port == 443 || (!hasInboundOn443 && panelInbound == nil) {
-					copied := inbound
-					panelInbound = &copied
-					if inbound.Port == 443 {
-						break
-					}
-				}
-			}
-		}
-
-		if panelInbound != nil {
-			intent.Configs = append(intent.Configs, "/etc/veil/generated/caddy/"+panelInbound.Name+".Caddyfile")
-			intent.Actions = append(intent.Actions, "reload veil-caddy@"+panelInbound.Name+".service")
-			intent.Runtimes = append(intent.Runtimes, "veil-caddy@"+panelInbound.Name+".service")
-		} else {
-			intent.Configs = append(intent.Configs, "/etc/veil/generated/caddy/panel.Caddyfile")
-			intent.Actions = append(intent.Actions, "reload veil-caddy@panel.service")
-			intent.Runtimes = append(intent.Runtimes, "veil-caddy@panel.service")
-		}
+		intent.Configs = append(intent.Configs, "/etc/veil/generated/caddy/config.json")
+		intent.Actions = append(intent.Actions, "reload veil-caddy.service")
+		intent.Runtimes = append(intent.Runtimes, "veil-caddy.service")
 	}
 	for _, inbound := range inbounds {
 		if !inbound.Enabled {

--- a/internal/panelaccess/panel_access_more_test.go
+++ b/internal/panelaccess/panel_access_more_test.go
@@ -107,69 +107,69 @@ func TestApplyIntentPropagatesCaddyRouteError(t *testing.T) {
 	}
 }
 
-func TestApplyIntentSelectsInboundOn443(t *testing.T) {
+func TestApplyIntentEmitsSingleCaddyService(t *testing.T) {
 	settings := model.Settings{PanelAccess: "caddy", PanelListen: "127.0.0.1:2096", Domain: "panel.example.com", Email: "admin@example.com", WebBasePath: "panel-secret"}
 	access := New(settings, func(protocol string) bool { return protocol == "naiveproxy" })
-	inbounds := []model.Inbound{
-		{Name: "naive", Protocol: "naiveproxy", Transport: "tcp", Port: 443, Enabled: true},
+	intent := access.ApplyIntent(nil)
+	if !contains(intent.Configs, "/etc/veil/generated/caddy/config.json") {
+		t.Fatalf("expected single Caddy JSON config, got %+v", intent.Configs)
 	}
-	intent := access.ApplyIntent(inbounds)
-	if !contains(intent.Configs, "/etc/veil/generated/caddy/naive.Caddyfile") {
-		t.Fatalf("expected naive.Caddyfile config, got %+v", intent.Configs)
+	if !contains(intent.Actions, "reload veil-caddy.service") {
+		t.Fatalf("expected single caddy service action, got %+v", intent.Actions)
 	}
-	if !contains(intent.Actions, "reload veil-caddy@naive.service") {
-		t.Fatalf("expected naive service action, got %+v", intent.Actions)
-	}
-	if !contains(intent.Runtimes, "veil-caddy@naive.service") {
-		t.Fatalf("expected naive runtime, got %+v", intent.Runtimes)
+	if !contains(intent.Runtimes, "veil-caddy.service") {
+		t.Fatalf("expected single caddy runtime, got %+v", intent.Runtimes)
 	}
 	if len(intent.Errors) != 0 {
 		t.Fatalf("expected no errors, got %+v", intent.Errors)
 	}
 }
 
-func TestApplyIntentFallsBackToFirstCaddyProtocolInbound(t *testing.T) {
+func TestApplyIntentReports443InboundConflict(t *testing.T) {
 	settings := model.Settings{PanelAccess: "caddy", PanelListen: "127.0.0.1:2096", Domain: "panel.example.com", Email: "admin@example.com", WebBasePath: "panel-secret"}
 	access := New(settings, func(protocol string) bool { return protocol == "naiveproxy" })
 	inbounds := []model.Inbound{
-		{Name: "mieru", Protocol: "mieru", Transport: "tcp", Port: 8080, Enabled: true},
-		{Name: "naive1", Protocol: "naiveproxy", Transport: "tcp", Port: 8443, Enabled: true},
-		{Name: "naive2", Protocol: "naiveproxy", Transport: "tcp", Port: 8444, Enabled: true},
+		{Name: "mieru", Protocol: "mieru", Transport: "tcp", Port: 443, Enabled: true},
 	}
 	intent := access.ApplyIntent(inbounds)
-	if !contains(intent.Configs, "/etc/veil/generated/caddy/naive1.Caddyfile") {
-		t.Fatalf("expected naive1.Caddyfile config, got %+v", intent.Configs)
+	if !contains(intent.Configs, "/etc/veil/generated/caddy/config.json") {
+		t.Fatalf("expected single Caddy JSON config, got %+v", intent.Configs)
 	}
-	if len(intent.Errors) != 0 {
-		t.Fatalf("expected no errors, got %+v", intent.Errors)
+	if len(intent.Errors) != 1 || !strings.Contains(intent.Errors[0], "panel caddy access uses 443/tcp") {
+		t.Fatalf("expected 443 conflict error, got %+v", intent.Errors)
 	}
 }
 
-func TestApplyIntentSkipsDisabledInbounds(t *testing.T) {
+func TestApplyIntentSkipsDisabledInboundsForConflict(t *testing.T) {
 	settings := model.Settings{PanelAccess: "caddy", PanelListen: "127.0.0.1:2096", Domain: "panel.example.com", Email: "admin@example.com", WebBasePath: "panel-secret"}
 	access := New(settings, func(protocol string) bool { return protocol == "naiveproxy" })
 	inbounds := []model.Inbound{
 		{Name: "naive", Protocol: "naiveproxy", Transport: "tcp", Port: 443, Enabled: false},
 	}
 	intent := access.ApplyIntent(inbounds)
-	if !contains(intent.Configs, "/etc/veil/generated/caddy/panel.Caddyfile") {
-		t.Fatalf("expected panel.Caddyfile fallback config, got %+v", intent.Configs)
+	if !contains(intent.Configs, "/etc/veil/generated/caddy/config.json") {
+		t.Fatalf("expected single Caddy JSON config, got %+v", intent.Configs)
 	}
 	if len(intent.Errors) != 0 {
-		t.Fatalf("expected no errors, got %+v", intent.Errors)
+		t.Fatalf("expected no errors for disabled inbound, got %+v", intent.Errors)
 	}
 }
 
-func TestApplyIntentPrefers443InboundOverFallback(t *testing.T) {
+func TestApplyIntentEmitsSingleConfigWithMultipleNaiveInbounds(t *testing.T) {
 	settings := model.Settings{PanelAccess: "caddy", PanelListen: "127.0.0.1:2096", Domain: "panel.example.com", Email: "admin@example.com", WebBasePath: "panel-secret"}
 	access := New(settings, func(protocol string) bool { return protocol == "naiveproxy" })
 	inbounds := []model.Inbound{
-		{Name: "naive-fallback", Protocol: "naiveproxy", Transport: "tcp", Port: 8443, Enabled: true},
-		{Name: "naive-443", Protocol: "naiveproxy", Transport: "tcp", Port: 443, Enabled: true},
+		{Name: "naive-8443", Protocol: "naiveproxy", Transport: "tcp", Port: 8443, Enabled: true},
 	}
 	intent := access.ApplyIntent(inbounds)
-	if !contains(intent.Configs, "/etc/veil/generated/caddy/naive-443.Caddyfile") {
-		t.Fatalf("expected 443 inbound config, got %+v", intent.Configs)
+	if !contains(intent.Configs, "/etc/veil/generated/caddy/config.json") {
+		t.Fatalf("expected single Caddy JSON config, got %+v", intent.Configs)
+	}
+	if !contains(intent.Actions, "reload veil-caddy.service") {
+		t.Fatalf("expected single caddy service action, got %+v", intent.Actions)
+	}
+	if len(intent.Errors) != 0 {
+		t.Fatalf("expected no errors, got %+v", intent.Errors)
 	}
 }
 
@@ -177,12 +177,15 @@ func TestApplyIntentRequiresCaddyFuncNil(t *testing.T) {
 	settings := model.Settings{PanelAccess: "caddy", PanelListen: "127.0.0.1:2096", Domain: "panel.example.com", Email: "admin@example.com", WebBasePath: "panel-secret"}
 	access := New(settings, nil)
 	inbounds := []model.Inbound{
-		{Name: "naive", Protocol: "naiveproxy", Transport: "tcp", Port: 443, Enabled: true},
+		{Name: "naive", Protocol: "naiveproxy", Transport: "tcp", Port: 8443, Enabled: true},
 	}
 	intent := access.ApplyIntent(inbounds)
-	// With nil requiresCaddy, no inbound requires caddy, so fallback panel config is used.
-	if !contains(intent.Configs, "/etc/veil/generated/caddy/panel.Caddyfile") {
-		t.Fatalf("expected panel.Caddyfile fallback config, got %+v", intent.Configs)
+	// With nil requiresCaddy, naive inbounds are still managed by the single Caddy process.
+	if !contains(intent.Configs, "/etc/veil/generated/caddy/config.json") {
+		t.Fatalf("expected single Caddy JSON config, got %+v", intent.Configs)
+	}
+	if !contains(intent.Actions, "reload veil-caddy.service") {
+		t.Fatalf("expected single caddy service action, got %+v", intent.Actions)
 	}
 }
 

--- a/internal/panelaccess/panel_access_more_test.go
+++ b/internal/panelaccess/panel_access_more_test.go
@@ -74,7 +74,7 @@ func TestCaddyRouteRejectsInvalidConfiguration(t *testing.T) {
 }
 
 func TestGeneratedConfigPropagatesRenderError(t *testing.T) {
-	// Empty domain makes renderer.RenderPanelCaddyfile fail while CaddyRoute succeeds.
+	// Empty domain makes Caddy JSON rendering fail while CaddyRoute succeeds.
 	settings := model.Settings{PanelAccess: "caddy", PanelListen: "127.0.0.1:2096", Domain: "", Email: "admin@example.com", WebBasePath: "panel-secret"}
 	access := New(settings, func(protocol string) bool { return protocol == "naiveproxy" })
 	_, ok, err := access.GeneratedConfig(generatedconfig.NewPaths(filepath.FromSlash("/etc/veil")))

--- a/internal/panelaccess/panel_access_test.go
+++ b/internal/panelaccess/panel_access_test.go
@@ -23,12 +23,12 @@ func TestPanelAccessBuildsCaddyRouteConfigAndApplyIntent(t *testing.T) {
 	if err != nil || !ok {
 		t.Fatalf("GeneratedConfig ok=%v err=%v", ok, err)
 	}
-	expectedPath := filepath.FromSlash("/etc/veil/generated/caddy/panel.Caddyfile")
-	if artifact.Path != expectedPath || !strings.Contains(artifact.Body, "reverse_proxy 127.0.0.1:2096") {
+	expectedPath := filepath.FromSlash("/etc/veil/generated/caddy/config.json")
+	if artifact.Path != expectedPath || !strings.Contains(artifact.Body, `"dial": "127.0.0.1:2096"`) {
 		t.Fatalf("artifact = %+v", artifact)
 	}
 	intent := access.ApplyIntent([]model.Inbound{{Name: "mieru", Protocol: "mieru", Transport: "tcp", Port: 443, Enabled: true}})
-	if !contains(intent.Configs, "/etc/veil/generated/caddy/panel.Caddyfile") || !contains(intent.Actions, "reload veil-caddy@panel.service") || !contains(intent.Runtimes, "veil-caddy@panel.service") {
+	if !contains(intent.Configs, "/etc/veil/generated/caddy/config.json") || !contains(intent.Actions, "reload veil-caddy.service") || !contains(intent.Runtimes, "veil-caddy.service") {
 		t.Fatalf("intent = %+v", intent)
 	}
 	if len(intent.Errors) != 1 || !strings.Contains(intent.Errors[0], "panel caddy access uses 443/tcp") {

--- a/internal/panelaccess/profile.go
+++ b/internal/panelaccess/profile.go
@@ -11,9 +11,11 @@ import (
 	"io"
 	"math/big"
 	"net"
+	"strconv"
 	"time"
 
 	"github.com/mikkelchokolate/Veil/internal/hostenv"
+	"github.com/mikkelchokolate/Veil/internal/model"
 	"github.com/mikkelchokolate/Veil/internal/renderer"
 )
 
@@ -21,7 +23,10 @@ type ProfileInput struct {
 	PanelAccess string
 	Domain      string
 	Email       string
+	PanelDomain string
+	PanelEmail  string
 	PanelPort   int
+	PublicPort  int
 }
 
 type ModeResolution struct {
@@ -66,11 +71,51 @@ type ProfileMaterial struct {
 }
 
 type Profile struct {
-	input ProfileInput
+	input      ProfileInput
+	PublicPort int
 }
 
 func NewProfile(input ProfileInput) Profile {
-	return Profile{input: input}
+	return Profile{input: input, PublicPort: input.PublicPort}
+}
+
+// BuildProfile builds a Panel access Profile from model settings. It defaults
+// PanelPublicPort to 443 when zero and resolves the panel-specific domain/email
+// with fallback to the legacy Domain/Email fields.
+func BuildProfile(settings model.Settings) (Profile, error) {
+	publicPort := settings.PanelPublicPort
+	if publicPort == 0 {
+		publicPort = 443
+	}
+	panelPort, err := panelPortFromListen(settings.PanelListen)
+	if err != nil {
+		return Profile{}, err
+	}
+	profile := NewProfile(ProfileInput{
+		PanelAccess: settings.PanelAccess,
+		Domain:      settings.Domain,
+		Email:       settings.Email,
+		PanelDomain: settings.PanelDomain,
+		PanelEmail:  settings.PanelEmail,
+		PanelPort:   panelPort,
+		PublicPort:  publicPort,
+	})
+	return profile, nil
+}
+
+func panelPortFromListen(listen string) (int, error) {
+	if listen == "" {
+		return 0, fmt.Errorf("panelListen is required")
+	}
+	_, portStr, err := net.SplitHostPort(listen)
+	if err != nil {
+		return 0, fmt.Errorf("panelListen must be host:port")
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil || port < 1 || port > 65535 {
+		return 0, fmt.Errorf("panelListen port must be a valid integer between 1 and 65535")
+	}
+	return port, nil
 }
 
 // newTLSFunc is overridable in tests so that Profile.Build TLS error paths can
@@ -79,18 +124,26 @@ var newTLSFunc = NewTLS
 
 func (p Profile) Build() (ProfileMaterial, error) {
 	input := p.input
+	domain := input.PanelDomain
+	if domain == "" {
+		domain = input.Domain
+	}
+	email := input.PanelEmail
+	if email == "" {
+		email = input.Email
+	}
 	material := ProfileMaterial{PanelListen: RecommendedListen(input.PanelAccess, input.PanelPort)}
 	material.WebBasePath = NewWebBasePathPolicy(rand.Reader).Generate()
 	panelCaddy := input.PanelAccess == "caddy"
 	if panelCaddy {
-		if err := hostenv.ValidateDomain(input.Domain); err != nil {
+		if err := hostenv.ValidateDomain(domain); err != nil {
 			return ProfileMaterial{}, err
 		}
-		if err := hostenv.ValidateEmail(input.Email); err != nil {
+		if err := hostenv.ValidateEmail(email); err != nil {
 			return ProfileMaterial{}, err
 		}
 		material.InstallPanelCaddy = true
-		caddyfile, err := renderer.RenderPanelCaddyfile(renderer.PanelCaddyConfig{Domain: input.Domain, Email: input.Email, PanelPort: input.PanelPort, WebBasePath: material.WebBasePath})
+		caddyfile, err := renderer.RenderPanelCaddyfile(renderer.PanelCaddyConfig{Domain: domain, Email: email, PanelPort: input.PanelPort, PublicPort: p.PublicPort, WebBasePath: material.WebBasePath})
 		if err != nil {
 			return ProfileMaterial{}, err
 		}
@@ -101,7 +154,7 @@ func (p Profile) Build() (ProfileMaterial, error) {
 	if input.PanelAccess == "direct" {
 		extraIPs = nonLoopbackInterfaceIPs()
 	}
-	panelTLS, err := newTLSFunc().Generate(input.Domain, extraIPs)
+	panelTLS, err := newTLSFunc().Generate(domain, extraIPs)
 	if err != nil {
 		return ProfileMaterial{}, err
 	}

--- a/internal/panelaccess/profile.go
+++ b/internal/panelaccess/profile.go
@@ -64,6 +64,7 @@ func (m Mode) Resolve(port int) (ModeResolution, error) {
 
 type ProfileMaterial struct {
 	PanelListen       string
+	PanelPublicPort   int
 	PanelTLSEnabled   bool
 	PanelTLSCertPEM   string
 	PanelTLSKeyPEM    string
@@ -130,7 +131,7 @@ var newTLSFunc = NewTLS
 
 func (p Profile) Build() (ProfileMaterial, error) {
 	settings := p.settings
-	material := ProfileMaterial{PanelListen: settings.PanelListen}
+	material := ProfileMaterial{PanelListen: settings.PanelListen, PanelPublicPort: p.PublicPort}
 	material.WebBasePath = NewWebBasePathPolicy(rand.Reader).Generate()
 	settings.WebBasePath = material.WebBasePath
 	if settings.PanelDomain == "" {

--- a/internal/panelaccess/profile.go
+++ b/internal/panelaccess/profile.go
@@ -14,6 +14,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/mikkelchokolate/Veil/internal/caddyassembly"
+	"github.com/mikkelchokolate/Veil/internal/caddycapabilities"
 	"github.com/mikkelchokolate/Veil/internal/hostenv"
 	"github.com/mikkelchokolate/Veil/internal/model"
 	"github.com/mikkelchokolate/Veil/internal/renderer"
@@ -67,16 +69,29 @@ type ProfileMaterial struct {
 	PanelTLSKeyPEM    string
 	WebBasePath       string
 	InstallPanelCaddy bool
-	Caddyfile         string
+	CaddyJSON         string
 }
 
 type Profile struct {
-	input      ProfileInput
+	settings   model.Settings
 	PublicPort int
 }
 
 func NewProfile(input ProfileInput) Profile {
-	return Profile{input: input, PublicPort: input.PublicPort}
+	publicPort := input.PublicPort
+	if publicPort == 0 {
+		publicPort = 443
+	}
+	settings := model.Settings{
+		PanelAccess:     input.PanelAccess,
+		PanelDomain:     input.PanelDomain,
+		Domain:          input.Domain,
+		PanelEmail:      input.PanelEmail,
+		Email:           input.Email,
+		PanelListen:     RecommendedListen(input.PanelAccess, input.PanelPort),
+		PanelPublicPort: publicPort,
+	}
+	return Profile{settings: settings, PublicPort: publicPort}
 }
 
 // BuildProfile builds a Panel access Profile from model settings. It defaults
@@ -87,20 +102,11 @@ func BuildProfile(settings model.Settings) (Profile, error) {
 	if publicPort == 0 {
 		publicPort = 443
 	}
-	panelPort, err := panelPortFromListen(settings.PanelListen)
-	if err != nil {
+	if _, err := panelPortFromListen(settings.PanelListen); err != nil {
 		return Profile{}, err
 	}
-	profile := NewProfile(ProfileInput{
-		PanelAccess: settings.PanelAccess,
-		Domain:      settings.Domain,
-		Email:       settings.Email,
-		PanelDomain: settings.PanelDomain,
-		PanelEmail:  settings.PanelEmail,
-		PanelPort:   panelPort,
-		PublicPort:  publicPort,
-	})
-	return profile, nil
+	settings.PanelPublicPort = publicPort
+	return Profile{settings: settings, PublicPort: publicPort}, nil
 }
 
 func panelPortFromListen(listen string) (int, error) {
@@ -123,38 +129,41 @@ func panelPortFromListen(listen string) (int, error) {
 var newTLSFunc = NewTLS
 
 func (p Profile) Build() (ProfileMaterial, error) {
-	input := p.input
-	domain := input.PanelDomain
-	if domain == "" {
-		domain = input.Domain
-	}
-	email := input.PanelEmail
-	if email == "" {
-		email = input.Email
-	}
-	material := ProfileMaterial{PanelListen: RecommendedListen(input.PanelAccess, input.PanelPort)}
+	settings := p.settings
+	material := ProfileMaterial{PanelListen: settings.PanelListen}
 	material.WebBasePath = NewWebBasePathPolicy(rand.Reader).Generate()
-	panelCaddy := input.PanelAccess == "caddy"
+	settings.WebBasePath = material.WebBasePath
+	if settings.PanelDomain == "" {
+		settings.PanelDomain = settings.Domain
+	}
+	if settings.PanelEmail == "" {
+		settings.PanelEmail = settings.Email
+	}
+	panelCaddy := settings.PanelAccess == "caddy"
 	if panelCaddy {
-		if err := hostenv.ValidateDomain(domain); err != nil {
+		if err := hostenv.ValidateDomain(settings.PanelDomain); err != nil {
 			return ProfileMaterial{}, err
 		}
-		if err := hostenv.ValidateEmail(email); err != nil {
+		if err := hostenv.ValidateEmail(settings.PanelEmail); err != nil {
 			return ProfileMaterial{}, err
 		}
 		material.InstallPanelCaddy = true
-		caddyfile, err := renderer.RenderPanelCaddyfile(renderer.PanelCaddyConfig{Domain: domain, Email: email, PanelPort: input.PanelPort, PublicPort: p.PublicPort, WebBasePath: material.WebBasePath})
+		plan, _, err := caddyassembly.BuildRenderPlan(settings, nil, nil)
 		if err != nil {
 			return ProfileMaterial{}, err
 		}
-		material.Caddyfile = caddyfile
+		body, err := renderer.RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{})
+		if err != nil {
+			return ProfileMaterial{}, err
+		}
+		material.CaddyJSON = string(body)
 		return material, nil
 	}
 	var extraIPs []net.IP
-	if input.PanelAccess == "direct" {
+	if settings.PanelAccess == "direct" {
 		extraIPs = nonLoopbackInterfaceIPs()
 	}
-	panelTLS, err := newTLSFunc().Generate(domain, extraIPs)
+	panelTLS, err := newTLSFunc().Generate(settings.PanelDomain, extraIPs)
 	if err != nil {
 		return ProfileMaterial{}, err
 	}

--- a/internal/panelaccess/profile_more_test.go
+++ b/internal/panelaccess/profile_more_test.go
@@ -43,14 +43,6 @@ func TestProfileBuildRejectsInvalidEmail(t *testing.T) {
 	}
 }
 
-func TestProfileBuildPropagatesCaddyfileRenderError(t *testing.T) {
-	// Valid domain/email but invalid panel port triggers renderer error after validation.
-	_, err := NewProfile(ProfileInput{PanelAccess: "caddy", Domain: "panel.example.com", Email: "admin@example.com", PanelPort: 0}).Build()
-	if err == nil || !strings.Contains(err.Error(), "panel port is required") {
-		t.Fatalf("expected panel port render error, got %v", err)
-	}
-}
-
 func TestProfileBuildPropagatesTLSGenerateError(t *testing.T) {
 	original := rsaGenerateKey
 	rsaGenerateKey = func(r io.Reader, bits int) (*rsa.PrivateKey, error) { return nil, errors.New("key failure") }

--- a/internal/panelaccess/profile_test.go
+++ b/internal/panelaccess/profile_test.go
@@ -30,8 +30,8 @@ func TestProfileUsesPanelPublicPort(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(material.Caddyfile, "panel.example.com:8443") {
-		t.Errorf("Caddyfile missing public port bind:\n%s", material.Caddyfile)
+	if !strings.Contains(material.CaddyJSON, `":8443"`) {
+		t.Errorf("Caddy JSON missing public port listen:\n%s", material.CaddyJSON)
 	}
 }
 
@@ -75,9 +75,9 @@ func TestProfileBuildsPanelCaddyAccessMaterial(t *testing.T) {
 	if material.WebBasePath == "" || !strings.HasPrefix(material.WebBasePath, "/") || !strings.HasSuffix(material.WebBasePath, "/") {
 		t.Fatalf("web base path = %q", material.WebBasePath)
 	}
-	for _, want := range []string{"panel.example.com", "reverse_proxy 127.0.0.1:2096", "handle " + strings.TrimRight(material.WebBasePath, "/") + "/*"} {
-		if !strings.Contains(material.Caddyfile, want) {
-			t.Fatalf("Caddyfile missing %q:\n%s", want, material.Caddyfile)
+	for _, want := range []string{"panel.example.com", `"dial": "127.0.0.1:2096"`, strings.TrimRight(material.WebBasePath, "/")} {
+		if !strings.Contains(material.CaddyJSON, want) {
+			t.Fatalf("Caddy JSON missing %q:\n%s", want, material.CaddyJSON)
 		}
 	}
 }

--- a/internal/panelaccess/profile_test.go
+++ b/internal/panelaccess/profile_test.go
@@ -6,7 +6,34 @@ import (
 	"net"
 	"strings"
 	"testing"
+
+	"github.com/mikkelchokolate/Veil/internal/model"
 )
+
+func TestProfileUsesPanelPublicPort(t *testing.T) {
+	settings := model.Settings{
+		PanelListen:     "127.0.0.1:2096",
+		PanelAccess:     "caddy",
+		PanelDomain:     "panel.example.com",
+		PanelEmail:      "a@example.com",
+		PanelPublicPort: 8443,
+		WebBasePath:     "/panel-secret/",
+	}
+	profile, err := BuildProfile(settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if profile.PublicPort != 8443 {
+		t.Errorf("public port = %d", profile.PublicPort)
+	}
+	material, err := profile.Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(material.Caddyfile, "panel.example.com:8443") {
+		t.Errorf("Caddyfile missing public port bind:\n%s", material.Caddyfile)
+	}
+}
 
 func TestPanelAccessModeBuildsListenAddressAndCaddyRequirement(t *testing.T) {
 	for _, tc := range []struct {

--- a/internal/panelaccess/requirements.go
+++ b/internal/panelaccess/requirements.go
@@ -1,8 +1,6 @@
 package panelaccess
 
 import (
-	"strings"
-
 	"github.com/mikkelchokolate/Veil/internal/model"
 )
 
@@ -12,21 +10,6 @@ type CaddyRequirement struct {
 
 func NewCaddyRequirement(requiresCaddy RequiresCaddyFunc) CaddyRequirement {
 	return CaddyRequirement{requiresCaddy: requiresCaddy}
-}
-
-func protocolString(m map[string]any, key, fallback string) string {
-	if m == nil {
-		return fallback
-	}
-	v, ok := m[key]
-	if !ok {
-		return fallback
-	}
-	s, ok := v.(string)
-	if !ok {
-		return fallback
-	}
-	return strings.TrimSpace(s)
 }
 
 func (r CaddyRequirement) Required(settings model.Settings, inbounds []model.Inbound) bool {
@@ -43,25 +26,4 @@ func (r CaddyRequirement) Required(settings model.Settings, inbounds []model.Inb
 
 func (r CaddyRequirement) protocolRequiresCaddy(protocol string) bool {
 	return r.requiresCaddy != nil && r.requiresCaddy(protocol)
-}
-
-type NaiveCaddySettingsRequirement struct{}
-
-func NewNaiveCaddySettingsRequirement() NaiveCaddySettingsRequirement {
-	return NaiveCaddySettingsRequirement{}
-}
-
-func (NaiveCaddySettingsRequirement) Validate(settings model.Settings) error {
-	username := protocolString(settings.ProtocolFields, "naiveUsername", settings.NaiveUsername)
-	password := protocolString(settings.ProtocolFields, "naivePassword", settings.NaivePassword)
-	if strings.TrimSpace(settings.Domain) == "" || strings.TrimSpace(settings.Email) == "" || strings.TrimSpace(username) == "" || strings.TrimSpace(password) == "" {
-		return errNaiveCaddySettingsRequired{}
-	}
-	return nil
-}
-
-type errNaiveCaddySettingsRequired struct{}
-
-func (errNaiveCaddySettingsRequired) Error() string {
-	return "domain, email, naive username, and naive password are required for NaiveProxy/Caddy"
 }

--- a/internal/panelaccess/requirements_more_test.go
+++ b/internal/panelaccess/requirements_more_test.go
@@ -1,81 +1,10 @@
 package panelaccess
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/mikkelchokolate/Veil/internal/model"
 )
-
-func TestProtocolStringBranches(t *testing.T) {
-	for _, tc := range []struct {
-		name     string
-		m        map[string]any
-		key      string
-		fallback string
-		want     string
-	}{
-		{"nil map", nil, "key", "fallback", "fallback"},
-		{"key missing", map[string]any{"other": "value"}, "key", "fallback", "fallback"},
-		{"value not string", map[string]any{"key": 123}, "key", "fallback", "fallback"},
-		{"value trimmed", map[string]any{"key": "  spaced  "}, "key", "fallback", "spaced"},
-		{"value exact", map[string]any{"key": "exact"}, "key", "fallback", "exact"},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := protocolString(tc.m, tc.key, tc.fallback); got != tc.want {
-				t.Fatalf("protocolString(...) = %q, want %q", got, tc.want)
-			}
-		})
-	}
-}
-
-func TestNaiveCaddySettingsRequirementProtocolFields(t *testing.T) {
-	req := NewNaiveCaddySettingsRequirement()
-
-	// ProtocolFields override the legacy settings fields.
-	err := req.Validate(model.Settings{
-		Domain:        "vpn.example.com",
-		Email:         "admin@example.com",
-		NaiveUsername: "legacy-user",
-		NaivePassword: "legacy-pass",
-		ProtocolFields: map[string]any{
-			"naiveUsername": "  protocol-user  ",
-			"naivePassword": "protocol-pass",
-		},
-	})
-	if err != nil {
-		t.Fatalf("Validate: %v", err)
-	}
-
-	// Missing password in ProtocolFields falls back to settings.
-	err = req.Validate(model.Settings{
-		Domain:        "vpn.example.com",
-		Email:         "admin@example.com",
-		NaiveUsername: "legacy-user",
-		NaivePassword: "legacy-pass",
-		ProtocolFields: map[string]any{
-			"naiveUsername": "protocol-user",
-		},
-	})
-	if err != nil {
-		t.Fatalf("Validate with fallback password: %v", err)
-	}
-
-	// Non-string ProtocolFields value falls back to settings.
-	err = req.Validate(model.Settings{
-		Domain:        "vpn.example.com",
-		Email:         "admin@example.com",
-		NaiveUsername: "legacy-user",
-		NaivePassword: "legacy-pass",
-		ProtocolFields: map[string]any{
-			"naiveUsername": 123,
-			"naivePassword": 456,
-		},
-	})
-	if err != nil {
-		t.Fatalf("Validate with non-string ProtocolFields: %v", err)
-	}
-}
 
 func TestCaddyRequirementNilFunc(t *testing.T) {
 	req := NewCaddyRequirement(nil)
@@ -88,12 +17,5 @@ func TestCaddyRequirementDisabledInbound(t *testing.T) {
 	req := NewCaddyRequirement(func(protocol string) bool { return protocol == "naiveproxy" })
 	if req.Required(model.Settings{}, []model.Inbound{{Protocol: "naiveproxy", Enabled: false}}) {
 		t.Fatal("disabled inbound should not require Caddy")
-	}
-}
-
-func TestErrNaiveCaddySettingsRequired(t *testing.T) {
-	var err errNaiveCaddySettingsRequired
-	if !strings.Contains(err.Error(), "domain, email, naive username, and naive password") {
-		t.Fatalf("unexpected error message: %q", err.Error())
 	}
 }

--- a/internal/panelaccess/requirements_test.go
+++ b/internal/panelaccess/requirements_test.go
@@ -18,14 +18,3 @@ func TestCaddyRequirementDependsOnPanelAccessOrProtocolRequirement(t *testing.T)
 		t.Fatal("Mieru inbound should not require Caddy")
 	}
 }
-
-func TestNaiveCaddySettingsRequirement(t *testing.T) {
-	err := NewNaiveCaddySettingsRequirement().Validate(model.Settings{Domain: "vpn.example.com", Email: "admin@example.com", NaiveUsername: "veil", NaivePassword: "secret"})
-	if err != nil {
-		t.Fatalf("Validate: %v", err)
-	}
-	err = NewNaiveCaddySettingsRequirement().Validate(model.Settings{Domain: "vpn.example.com", Email: "admin@example.com", NaiveUsername: "veil"})
-	if err == nil || err.Error() != "domain, email, naive username, and naive password are required for NaiveProxy/Caddy" {
-		t.Fatalf("err = %v", err)
-	}
-}

--- a/internal/panelmaterial/material.go
+++ b/internal/panelmaterial/material.go
@@ -29,7 +29,7 @@ type Input struct {
 	PanelTLSCertPEM   string
 	PanelTLSKeyPEM    string
 	InstallPanelCaddy bool
-	Caddyfile         string
+	CaddyJSON         string
 }
 
 type File struct {
@@ -94,7 +94,7 @@ func (m ManagedMaterial) Files() ([]File, error) {
 	}
 	files := []File{}
 	if input.InstallPanelCaddy {
-		files = append(files, File{Path: filepath.Join(paths.EtcDir, "generated", "caddy", "panel.Caddyfile"), Content: input.Caddyfile, Mode: 0o600})
+		files = append(files, File{Path: filepath.Join(paths.EtcDir, "generated", "caddy", "config.json"), Content: input.CaddyJSON, Mode: 0o600})
 		files = append(files, File{Path: filepath.Join(paths.VarDir, "www", "index.html"), Content: fallbackIndexHTML(input.Domain), Mode: 0o644})
 	}
 	if input.PanelTLSEnabled {

--- a/internal/panelmaterial/material_more_test.go
+++ b/internal/panelmaterial/material_more_test.go
@@ -168,9 +168,9 @@ func TestFilesIncludesTLSAndOmitsSystemd(t *testing.T) {
 		}
 	}
 
-	notWant := filepath.Join(etcDir, "generated", "caddy", "panel.Caddyfile")
+	notWant := filepath.Join(etcDir, "generated", "caddy", "config.json")
 	if hasFile(files, notWant) {
-		t.Fatalf("did not expect Caddyfile when InstallPanelCaddy is false, found %q", notWant)
+		t.Fatalf("did not expect Caddy JSON when InstallPanelCaddy is false, found %q", notWant)
 	}
 }
 

--- a/internal/panelmaterial/material_test.go
+++ b/internal/panelmaterial/material_test.go
@@ -43,13 +43,13 @@ func TestManagedMaterialFilesIncludePanelCaddyAndSystemdMaterial(t *testing.T) {
 		PanelAuthToken:    "token",
 		PanelListen:       "127.0.0.1:2096",
 		InstallPanelCaddy: true,
-		Caddyfile:         "panel caddy",
+		CaddyJSON:         `{"apps":{"http":{"servers":{}}}}`,
 	})
 	files, err := material.Files()
 	if err != nil {
 		t.Fatalf("Files: %v", err)
 	}
-	wants := []string{"/etc/veil/generated/caddy/panel.Caddyfile", "/var/lib/veil/www/index.html", "/etc/veil/veil.env"}
+	wants := []string{"/etc/veil/generated/caddy/config.json", "/var/lib/veil/www/index.html", "/etc/veil/veil.env"}
 	for _, name := range renderer.ManagedSystemdUnitNames() {
 		wants = append(wants, "/etc/systemd/system/"+name)
 	}

--- a/internal/privileged/defaults.go
+++ b/internal/privileged/defaults.go
@@ -22,6 +22,7 @@ func DefaultPolicy() Policy {
 		},
 		ManagedUnitPrefixes: []string{
 			"veil-caddy.service",
+			"veil-caddy@",
 			"veil-hysteria2@",
 			"veil-olcrtc@",
 		},

--- a/internal/privileged/defaults.go
+++ b/internal/privileged/defaults.go
@@ -27,8 +27,8 @@ func DefaultPolicy() Policy {
 		},
 		Artifacts: map[string]ArtifactPath{
 			"caddy-panel": {
-				Staged:    filepath.FromSlash("caddy/panel.Caddyfile"),
-				Generated: filepath.FromSlash("caddy/panel.Caddyfile"),
+				Staged:    filepath.FromSlash("caddy/config.json"),
+				Generated: filepath.FromSlash("caddy/config.json"),
 			},
 			"hysteria2": {
 				Staged:    filepath.FromSlash("hysteria2/server.yaml"),

--- a/internal/privileged/defaults.go
+++ b/internal/privileged/defaults.go
@@ -15,13 +15,13 @@ func DefaultPolicy() Policy {
 		BackupRoot:           "/var/lib/veil/backups",
 		UpdateRoot:           "/var/lib/veil/updates",
 		ManagedUnits: map[string]struct{}{
-			"veil.service":             {},
-			"veil-mieru.service":       {},
-			"veil-warp.service":        {},
-			"veil-caddy@panel.service": {},
+			"veil.service":       {},
+			"veil-mieru.service": {},
+			"veil-warp.service":  {},
+			"veil-caddy.service": {},
 		},
 		ManagedUnitPrefixes: []string{
-			"veil-caddy@",
+			"veil-caddy.service",
 			"veil-hysteria2@",
 			"veil-olcrtc@",
 		},

--- a/internal/privileged/executor.go
+++ b/internal/privileged/executor.go
@@ -29,11 +29,12 @@ const (
 // Test hooks for functions that touch global runtime state or external
 // systems. They are swapped in tests to keep unit tests hermetic.
 var (
-	caddyDataDir           = caddycert.DefaultCaddyDataDir
-	findCaddyCertPair      = caddycert.FindPair
-	osExecutable           = os.Executable
-	caddyRetryInterval     = 2 * time.Second
-	defaultCaddyCertOutDir = "/etc/veil/certs"
+	caddyDataDir            = caddycert.DefaultCaddyDataDir
+	findCaddyCertPair       = caddycert.FindPair
+	osExecutable            = os.Executable
+	caddyRetryInterval      = 2 * time.Second
+	defaultCaddyCertTimeout = 120 * time.Second
+	defaultCaddyCertOutDir  = "/etc/veil/certs"
 )
 
 type Executor struct {
@@ -568,7 +569,7 @@ func findCaddyCertWithRetry(ctx context.Context, domain string) (caddycert.Pair,
 	deadline, hasDeadline := ctx.Deadline()
 	if !hasDeadline {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, 30*time.Second)
+		ctx, cancel = context.WithTimeout(ctx, defaultCaddyCertTimeout)
 		defer cancel()
 		deadline, _ = ctx.Deadline()
 	}

--- a/internal/privileged/executor_more_test.go
+++ b/internal/privileged/executor_more_test.go
@@ -98,7 +98,9 @@ func TestRunSyncCaddyCertReturnsNotFound(t *testing.T) {
 		return caddycert.Pair{}, caddycert.ErrCertificateNotFound
 	}
 
-	result, err := runSyncCaddyCert(context.Background(), SyncCaddyCertRequest{Domain: "missing.example.com", OutDir: t.TempDir()}, ProductionConfig{})
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	result, err := runSyncCaddyCert(ctx, SyncCaddyCertRequest{Domain: "missing.example.com", OutDir: t.TempDir()}, ProductionConfig{})
 	if err != nil {
 		t.Fatalf("expected no error for missing cert, got %v", err)
 	}
@@ -241,15 +243,18 @@ func TestFindCaddyCertWithRetryRespectsContextCancellation(t *testing.T) {
 func TestFindCaddyCertWithRetryTimesOutWithoutDeadline(t *testing.T) {
 	originalFinder := findCaddyCertPair
 	originalInterval := caddyRetryInterval
+	originalTimeout := defaultCaddyCertTimeout
 	defer func() {
 		findCaddyCertPair = originalFinder
 		caddyRetryInterval = originalInterval
+		defaultCaddyCertTimeout = originalTimeout
 	}()
 
 	findCaddyCertPair = func(_, _ string) (caddycert.Pair, error) {
 		return caddycert.Pair{}, caddycert.ErrCertificateNotFound
 	}
 	caddyRetryInterval = 10 * time.Millisecond
+	defaultCaddyCertTimeout = 200 * time.Millisecond
 
 	_, err := findCaddyCertWithRetry(context.Background(), "timeout.example.com")
 	if !errors.Is(err, caddycert.ErrCertificateNotFound) {

--- a/internal/privileged/executor_test.go
+++ b/internal/privileged/executor_test.go
@@ -61,8 +61,8 @@ func TestProductionExecutorPromotesResolvedArtifactsWithSafetyCopy(t *testing.T)
 
 func TestProductionExecutorRestoresPromotionByOpaqueBackupID(t *testing.T) {
 	root := t.TempDir()
-	source := filepath.Join(root, "staging", "edge.Caddyfile")
-	destination := filepath.Join(root, "generated", "edge.Caddyfile")
+	source := filepath.Join(root, "staging", "caddy", "config.json")
+	destination := filepath.Join(root, "generated", "caddy", "config.json")
 	if err := os.MkdirAll(filepath.Dir(source), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -80,7 +80,7 @@ func TestProductionExecutorRestoresPromotionByOpaqueBackupID(t *testing.T) {
 		Now:                 func() time.Time { return time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC) },
 	})
 	promoted, err := executor.Promote(context.Background(), ResolvedPromotion{
-		Artifacts: []ResolvedArtifact{{ID: "caddy/edge.Caddyfile", Source: source, Destination: destination}},
+		Artifacts: []ResolvedArtifact{{ID: "caddy/config.json", Source: source, Destination: destination}},
 	})
 	if err != nil {
 		t.Fatalf("promote: %v", err)

--- a/internal/privileged/policy.go
+++ b/internal/privileged/policy.go
@@ -205,6 +205,15 @@ func (p Policy) managedArtifactPath(id string) (ArtifactPath, bool) {
 	if clean == "sing-box/warp.json" {
 		return ArtifactPath{Staged: filepath.FromSlash(clean), Generated: filepath.FromSlash(clean)}, true
 	}
+	// Retired per-inbound Caddyfiles remain manageable only for migration
+	// and orphan cleanup. Paths are still confined below the staging and
+	// generated roots by resolveBelow.
+	if strings.HasPrefix(clean, "caddy/") && strings.HasSuffix(clean, ".Caddyfile") {
+		name := strings.TrimSuffix(strings.TrimPrefix(clean, "caddy/"), ".Caddyfile")
+		if !strings.Contains(name, "/") && artifactNamePattern.MatchString(name) {
+			return ArtifactPath{Staged: filepath.FromSlash(clean), Generated: filepath.FromSlash(clean)}, true
+		}
+	}
 	return managedProtocolArtifactID(clean, p.AllowedArtifactNames)
 }
 

--- a/internal/privileged/policy.go
+++ b/internal/privileged/policy.go
@@ -206,11 +206,6 @@ func managedArtifactPath(id string) (ArtifactPath, bool) {
 	}
 	name := ""
 	switch parts[0] {
-	case "caddy":
-		name = strings.TrimSuffix(parts[1], ".Caddyfile")
-		if name == parts[1] {
-			return ArtifactPath{}, false
-		}
 	case "hysteria2", "olcrtc":
 		name = strings.TrimSuffix(parts[1], ".yaml")
 		if name == parts[1] {

--- a/internal/privileged/policy.go
+++ b/internal/privileged/policy.go
@@ -197,7 +197,7 @@ func managedArtifactPath(id string) (ArtifactPath, bool) {
 		return ArtifactPath{}, false
 	}
 	switch clean {
-	case "mieru/server_config.json", "sing-box/warp.json":
+	case "caddy/config.json", "mieru/server_config.json", "sing-box/warp.json":
 		return ArtifactPath{Staged: filepath.FromSlash(clean), Generated: filepath.FromSlash(clean)}, true
 	}
 	parts := strings.Split(clean, "/")

--- a/internal/privileged/policy_test.go
+++ b/internal/privileged/policy_test.go
@@ -257,7 +257,6 @@ func TestPolicyManagedArtifactPathEdgeCases(t *testing.T) {
 		allowed bool
 	}{
 		{"caddy/config.json", true},
-		{"caddy/edge.Caddyfile", true},
 		{"hysteria2/udp.yaml", true},
 		{"olcrtc/rtc.yaml", true},
 		{"mieru/server_config.json", true},

--- a/internal/privileged/policy_test.go
+++ b/internal/privileged/policy_test.go
@@ -120,7 +120,7 @@ func TestPolicyResolvesManagedDynamicArtifactIDs(t *testing.T) {
 	policy := testPolicy(t)
 	resolved, err := policy.ResolvePromotion(PromoteRequest{
 		ArtifactIDs: []string{
-			"caddy/edge.Caddyfile",
+			"caddy/config.json",
 			"hysteria2/udp-edge.yaml",
 			"olcrtc/rtc-edge.yaml",
 			"mieru/server_config.json",
@@ -256,11 +256,13 @@ func TestPolicyManagedArtifactPathEdgeCases(t *testing.T) {
 		id      string
 		allowed bool
 	}{
+		{"caddy/config.json", true},
 		{"caddy/edge.Caddyfile", true},
 		{"hysteria2/udp.yaml", true},
 		{"olcrtc/rtc.yaml", true},
 		{"mieru/server_config.json", true},
 		{"sing-box/warp.json", true},
+		{"caddy/edge.json", false},
 		{"caddy/edge.yaml", false},
 		{"hysteria2/udp.Caddyfile", false},
 		{"caddy/bad!.Caddyfile", false},

--- a/internal/privileged/policy_test.go
+++ b/internal/privileged/policy_test.go
@@ -377,6 +377,20 @@ func TestPolicyAllowsUnitPrefixesAndRejectsDangerousNames(t *testing.T) {
 	}
 }
 
+func TestDefaultPolicyAllowsLegacyCaddyTemplateUnits(t *testing.T) {
+	policy := DefaultPolicy()
+	for _, unit := range []string{"veil-caddy@legacy.service", "veil-caddy@panel.service"} {
+		if !policy.allowsUnit(unit) {
+			t.Fatalf("expected legacy caddy unit %q to be allowed", unit)
+		}
+	}
+	for _, unit := range []string{"veil-caddy@../escape.service", "veil-caddy@legacy.service; reboot"} {
+		if policy.allowsUnit(unit) {
+			t.Fatalf("expected dangerous unit %q to be rejected", unit)
+		}
+	}
+}
+
 func TestPolicyResolveBelowRejectsBadInputs(t *testing.T) {
 	root := t.TempDir()
 	for _, tc := range []struct{ root, relative string }{

--- a/internal/protocols/capability_catalog.go
+++ b/internal/protocols/capability_catalog.go
@@ -27,7 +27,7 @@ func newGeneratedConfigRegistryFrom(r *Registry) generatedconfig.ProtocolRegistr
 
 // Legacy unit constants remain here until all callers migrate to the registry.
 const (
-	UnitCaddy     = "veil-caddy@.service"
+	UnitCaddy     = "veil-caddy.service"
 	UnitHysteria2 = "veil-hysteria2@.service"
 	UnitOlcrtc    = "veil-olcrtc@.service"
 	UnitMieru     = "veil-mieru.service"

--- a/internal/protocols/capability_catalog_test.go
+++ b/internal/protocols/capability_catalog_test.go
@@ -46,7 +46,7 @@ func TestGeneratedConfigRegistryMultipleHysteriaAndNaive(t *testing.T) {
 
 	configs, err := registry.Render(generatedconfig.ConfigInput{
 		ApplyRoot: root,
-		Settings:  model.Settings{Domain: "example.com"},
+		Settings:  model.Settings{Domain: "example.com", Email: "admin@example.com"},
 		Inbounds:  inbounds,
 	})
 	if err != nil {
@@ -63,22 +63,17 @@ func TestGeneratedConfigRegistryMultipleHysteriaAndNaive(t *testing.T) {
 		t.Errorf("missing config for hy2-b at %s", hy2BPath)
 	}
 
-	// Verify naiveproxy configs are rendered as separate files
-	naiveAPath := filepath.Join(root, "generated", "caddy", "naive-a.Caddyfile")
-	naiveBPath := filepath.Join(root, "generated", "caddy", "naive-b.Caddyfile")
-	caddyContentA, ok := configs[naiveAPath]
+	// Verify naiveproxy inbounds are rendered into the consolidated Caddy JSON config.
+	naiveJSONPath := filepath.Join(root, "generated", "caddy", "config.json")
+	caddyContent, ok := configs[naiveJSONPath]
 	if !ok {
-		t.Fatalf("missing caddy config at %s", naiveAPath)
-	}
-	caddyContentB, ok := configs[naiveBPath]
-	if !ok {
-		t.Fatalf("missing caddy config at %s", naiveBPath)
+		t.Fatalf("missing consolidated caddy config at %s", naiveJSONPath)
 	}
 
-	if !strings.Contains(caddyContentA, "usera") {
-		t.Errorf("Caddyfile does not contain naive proxy definition for usera: %s", caddyContentA)
+	if !strings.Contains(caddyContent, `"handler": "forward_proxy"`) {
+		t.Errorf("Caddy JSON does not contain forward_proxy handler: %s", caddyContent)
 	}
-	if !strings.Contains(caddyContentB, "userb") {
-		t.Errorf("Caddyfile does not contain naive proxy definition for userb: %s", caddyContentB)
+	if !strings.Contains(caddyContent, `"example.com"`) {
+		t.Errorf("Caddy JSON does not contain expected domain: %s", caddyContent)
 	}
 }

--- a/internal/protocols/capability_catalog_test.go
+++ b/internal/protocols/capability_catalog_test.go
@@ -46,7 +46,7 @@ func TestGeneratedConfigRegistryMultipleHysteriaAndNaive(t *testing.T) {
 
 	configs, err := registry.Render(generatedconfig.ConfigInput{
 		ApplyRoot: root,
-		Settings:  model.Settings{Domain: "example.com", Email: "admin@example.com"},
+		Settings:  model.Settings{Domain: "example.com", DefaultAcmeEmail: "admin@example.com"},
 		Inbounds:  inbounds,
 	})
 	if err != nil {

--- a/internal/protocols/hysteria2/hysteria2_test.go
+++ b/internal/protocols/hysteria2/hysteria2_test.go
@@ -176,11 +176,12 @@ func TestRenderConfigWithCaddyPanelAccess(t *testing.T) {
 		Paths: paths,
 		Inbounds: []model.Inbound{
 			{
-				Name:      "h2-1",
-				Protocol:  "hysteria2",
-				Transport: "udp",
-				Port:      8443,
-				Enabled:   true,
+				Name:           "h2-1",
+				Protocol:       "hysteria2",
+				Transport:      "udp",
+				Port:           8443,
+				Enabled:        true,
+				ProtocolFields: map[string]any{"domain": "example.com"},
 			},
 		},
 	})
@@ -698,6 +699,16 @@ func TestBuildLinksProfileRequiresPassword(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "username and password are required") {
 		t.Errorf("expected username/password required error, got: %v", err)
+	}
+}
+
+func TestHysteria2DomainFromProtocolFields(t *testing.T) {
+	inbound := model.Inbound{
+		Protocol:       "hysteria2",
+		ProtocolFields: map[string]any{"domain": "hy.example.com"},
+	}
+	if got := Hysteria2Domain(inbound); got != "hy.example.com" {
+		t.Errorf("domain = %q", got)
 	}
 }
 

--- a/internal/protocols/hysteria2/plugin.go
+++ b/internal/protocols/hysteria2/plugin.go
@@ -92,3 +92,15 @@ func masqueradeURL(settings model.Settings, inbound model.Inbound) string {
 	}
 	return url
 }
+
+// Hysteria2Domain returns the public domain stored on the inbound ProtocolFields.
+func Hysteria2Domain(inbound model.Inbound) string {
+	if inbound.ProtocolFields == nil {
+		return ""
+	}
+	v, ok := inbound.ProtocolFields["domain"].(string)
+	if !ok {
+		return ""
+	}
+	return v
+}

--- a/internal/protocols/hysteria2/renderer.go
+++ b/internal/protocols/hysteria2/renderer.go
@@ -54,9 +54,9 @@ func renderHysteria2(settings model.Settings, inbound model.Inbound, warp model.
 		Users:         access.Hysteria2Users(),
 		MasqueradeURL: url,
 	}
-	if settings.PanelAccess == "caddy" && settings.Domain != "" {
-		hystConfig.CertPath = "/etc/veil/certs/" + settings.Domain + ".crt"
-		hystConfig.KeyPath = "/etc/veil/certs/" + settings.Domain + ".key"
+	if domain := Hysteria2Domain(inbound); domain != "" {
+		hystConfig.CertPath = "/etc/veil/certs/" + domain + ".crt"
+		hystConfig.KeyPath = "/etc/veil/certs/" + domain + ".key"
 	}
 	if warp.Enabled {
 		socksPort := warp.SocksPort

--- a/internal/protocols/naiveproxy/client_access.go
+++ b/internal/protocols/naiveproxy/client_access.go
@@ -1,62 +1,59 @@
 package naiveproxy
 
 import (
-	"strings"
+	"errors"
+	"fmt"
 
-	"github.com/mikkelchokolate/Veil/internal/clientaccess"
 	"github.com/mikkelchokolate/Veil/internal/model"
 )
 
 // BuildLinks creates client links for a naiveproxy inbound.
 func (p Plugin) BuildLinks(settings model.Settings, inbound model.Inbound) ([]model.ClientLink, error) {
-	endpoint := clientEndpoint(settings)
-	if endpoint == "" {
+	return BuildLinks(settings, inbound)
+}
+
+// BuildLinks creates client links for a naiveproxy inbound based on its
+// configured transport. TCP yields an https:// URI, QUIC yields a quic:// URI,
+// and dual yields both. The port is omitted when it matches the default (443).
+func BuildLinks(settings model.Settings, inbound model.Inbound) ([]model.ClientLink, error) {
+	domain := NaiveDomain(inbound)
+	if domain == "" {
 		return nil, nil
 	}
-	creds, err := clientaccess.BuildClientCredentials(inbound)
-	if err != nil {
-		return nil, err
-	}
-	links := make([]model.ClientLink, 0, len(creds))
+	port := NaivePublicPort(settings, inbound)
+	transport := NaiveTransport(inbound)
+	creds := inbound.Profiles
 	if len(creds) == 0 {
-		link := model.ClientLink{
-			Name:      inbound.Name,
-			Protocol:  inbound.Protocol,
-			Transport: inbound.Transport,
-			Port:      inbound.Port,
-			URI:       clientaccess.NaiveClientURI(endpoint, inbound.Port, p.naiveFallbackUsername(settings, inbound), p.naiveFallbackPassword(settings, inbound)),
-		}
-		return []model.ClientLink{link}, nil
+		return nil, errors.New("no profiles")
 	}
-	for _, cred := range creds {
-		link := model.ClientLink{
-			Name:      inbound.Name + "/" + cred.Name,
-			Protocol:  inbound.Protocol,
-			Transport: inbound.Transport,
-			Port:      inbound.Port,
-			URI:       clientaccess.NaiveClientURI(endpoint, inbound.Port, cred.Username, cred.Password),
+	var links []model.ClientLink
+	for _, profile := range creds {
+		if transport == "tcp" || transport == "dual" {
+			links = append(links, model.ClientLink{
+				Name:      inbound.Name + "-https",
+				Protocol:  "naiveproxy",
+				Transport: "tcp",
+				Port:      port,
+				URI:       naiveURI("https", profile.Username, profile.Password, domain, port, 443),
+			})
 		}
-		links = append(links, link)
+		if transport == "quic" || transport == "dual" {
+			links = append(links, model.ClientLink{
+				Name:      inbound.Name + "-quic",
+				Protocol:  "naiveproxy",
+				Transport: "quic",
+				Port:      port,
+				URI:       naiveURI("quic", profile.Username, profile.Password, domain, port, 443),
+			})
+		}
 	}
 	return links, nil
 }
 
-func (Plugin) naiveFallbackUsername(settings model.Settings, inbound model.Inbound) string {
-	username := naiveUsername(settings, inbound)
-	if username == "" {
-		username = settings.NaiveUsername
+func naiveURI(scheme, user, pass, domain string, port, defaultPort int) string {
+	host := domain
+	if port != defaultPort {
+		host = fmt.Sprintf("%s:%d", domain, port)
 	}
-	return username
-}
-
-func (Plugin) naiveFallbackPassword(settings model.Settings, inbound model.Inbound) string {
-	password := naivePassword(settings, inbound)
-	if password == "" {
-		password = settings.NaivePassword
-	}
-	return password
-}
-
-func clientEndpoint(settings model.Settings) string {
-	return strings.TrimSpace(settings.Domain)
+	return fmt.Sprintf("%s://%s:%s@%s", scheme, user, pass, host)
 }

--- a/internal/protocols/naiveproxy/client_access.go
+++ b/internal/protocols/naiveproxy/client_access.go
@@ -16,7 +16,7 @@ func (p Plugin) BuildLinks(settings model.Settings, inbound model.Inbound) ([]mo
 // configured transport. TCP yields an https:// URI, QUIC yields a quic:// URI,
 // and dual yields both. The port is omitted when it matches the default (443).
 func BuildLinks(settings model.Settings, inbound model.Inbound) ([]model.ClientLink, error) {
-	domain := NaiveDomain(inbound)
+	domain := NaiveDomain(settings, inbound)
 	if domain == "" {
 		return nil, nil
 	}

--- a/internal/protocols/naiveproxy/client_access_test.go
+++ b/internal/protocols/naiveproxy/client_access_test.go
@@ -1,0 +1,23 @@
+package naiveproxy
+
+import (
+	"testing"
+
+	"github.com/mikkelchokolate/Veil/internal/model"
+)
+
+func TestBuildLinksDual(t *testing.T) {
+	settings := model.Settings{DefaultInboundPublicPort: 443}
+	inbound := model.Inbound{
+		Protocol: "naiveproxy",
+		Profiles: []model.ClientProfile{{Username: "u", Password: "p"}},
+		ProtocolFields: map[string]any{"domain": "p.example.com", "transport": "dual"},
+	}
+	links, err := BuildLinks(settings, inbound)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(links) != 2 {
+		t.Fatalf("expected 2 links, got %d", len(links))
+	}
+}

--- a/internal/protocols/naiveproxy/hdd_client_links_test.go
+++ b/internal/protocols/naiveproxy/hdd_client_links_test.go
@@ -1,0 +1,48 @@
+package naiveproxy
+
+import (
+	"testing"
+
+	"github.com/mikkelchokolate/Veil/internal/model"
+)
+
+// TestBuildLinks_NaiveTCP443OmitsPort verifies the happy-path client export URL
+// for a TCP naiveproxy inbound on the default public port.
+func TestBuildLinks_NaiveTCP443OmitsPort(t *testing.T) {
+	settings := model.Settings{
+		DefaultInboundPublicPort: 443,
+		DefaultAcmeEmail:         "admin@hy.flow2go.ru",
+	}
+	inbound := model.Inbound{
+		Name:     "test",
+		Protocol: "naiveproxy",
+		Enabled:  true,
+		Profiles: []model.ClientProfile{
+			{Name: "default", Username: "user", Password: "pass", Enabled: true},
+		},
+		ProtocolFields: map[string]any{
+			"domain":    "hy.flow2go.ru",
+			"transport": "tcp",
+		},
+	}
+
+	links, err := BuildLinks(settings, inbound)
+	if err != nil {
+		t.Fatalf("BuildLinks error: %v", err)
+	}
+	if len(links) != 1 {
+		t.Fatalf("expected 1 link, got %d", len(links))
+	}
+
+	link := links[0]
+	if link.Transport != "tcp" {
+		t.Errorf("link.Transport = %q, want tcp", link.Transport)
+	}
+	if link.Port != 443 {
+		t.Errorf("link.Port = %d, want 443", link.Port)
+	}
+	want := "https://user:pass@hy.flow2go.ru"
+	if link.URI != want {
+		t.Errorf("link.URI = %q, want %q", link.URI, want)
+	}
+}

--- a/internal/protocols/naiveproxy/naiveproxy_test.go
+++ b/internal/protocols/naiveproxy/naiveproxy_test.go
@@ -208,8 +208,8 @@ func TestRenderConfigInboundProtocolFieldsOverride(t *testing.T) {
 			t.Errorf("body missing %q:\n%s", want, body)
 		}
 	}
-	if !strings.Contains(body, `"root": "/var/lib/veil/www"`) {
-		t.Errorf("expected default fallback root in file_server, got:\n%s", body)
+	if !strings.Contains(body, `"root": "/var/lib/veil/pf"`) {
+		t.Errorf("expected inbound fallback root in file_server, got:\n%s", body)
 	}
 	if strings.Contains(body, "settings.example.com") {
 		t.Errorf("body unexpectedly contains settings-level domain:\n%s", body)

--- a/internal/protocols/naiveproxy/naiveproxy_test.go
+++ b/internal/protocols/naiveproxy/naiveproxy_test.go
@@ -555,7 +555,7 @@ func TestInboundFieldSchema(t *testing.T) {
 		{Key: "domain", Label: "Domain", Type: schema.FieldText, Required: true, Placeholder: "Public domain used for TLS/SNI and client export.", Scope: "inbound"},
 		{Key: "email", Label: "ACME email", Type: schema.FieldText, Placeholder: "Optional explicit ACME contact for this domain.", Scope: "inbound"},
 		{Key: "publicPort", Label: "Public port", Type: schema.FieldNumber, Default: 443, Placeholder: "Port Caddy listens on for this inbound.", Scope: "inbound"},
-		{Key: "transport", Label: "Transport", Type: schema.FieldSelect, Required: true, Default: "tcp", Options: []schema.FieldOption{{Label: "tcp", Value: "tcp"}, {Label: "quic", Value: "quic"}, {Label: "dual", Value: "dual"}}, Placeholder: "tcp=HTTPS/H2, quic=HTTP/3/QUIC, dual=both.", Scope: "inbound"},
+		{Key: "transport", Label: "Transport", Type: schema.FieldSelect, Required: true, Default: "tcp", Options: []schema.FieldOption{{Label: "tcp", Value: "tcp"}}, Placeholder: "tcp=HTTPS/H2.", Scope: "inbound"},
 		{Key: "naiveUsername", Label: "Naive Username", Type: schema.FieldText, Default: "veil", Scope: "inbound"},
 		{Key: "naivePassword", Label: "Naive Password", Type: schema.FieldPassword, GenerateAction: "password", Scope: "inbound"},
 		{Key: "fallbackRoot", Label: "Fallback Root", Type: schema.FieldText, Default: "/var/lib/veil/www", Scope: "inbound"},

--- a/internal/protocols/naiveproxy/naiveproxy_test.go
+++ b/internal/protocols/naiveproxy/naiveproxy_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/mikkelchokolate/Veil/internal/model"
 	"github.com/mikkelchokolate/Veil/internal/protocols/schema"
 	"github.com/mikkelchokolate/Veil/internal/runtimeinstall"
-	"github.com/mikkelchokolate/Veil/internal/service"
 )
 
 func TestPluginMetadata(t *testing.T) {
@@ -46,6 +45,7 @@ func TestRenderConfigWithInbound(t *testing.T) {
 	inbound := model.Inbound{
 		Name:      "naive1",
 		Protocol:  "naiveproxy",
+		Enabled:   true,
 		Transport: "tcp",
 		Port:      443,
 		ProtocolFields: map[string]any{
@@ -71,19 +71,19 @@ func TestRenderConfigWithInbound(t *testing.T) {
 		t.Fatalf("len(artifacts) = %d, want 1", len(artifacts))
 	}
 
-	wantPath := filepath.Join("/tmp/veil", "generated", "caddy", "naive1.Caddyfile")
+	wantPath := filepath.Join("/tmp/veil", "generated", "caddy", "config.json")
 	if artifacts[0].Path != wantPath {
 		t.Errorf("artifact path = %q, want %q", artifacts[0].Path, wantPath)
 	}
 	body := artifacts[0].Body
-	for _, want := range []string{"example.com", "user1", "pass1", "forward_proxy", "file_server"} {
+	for _, want := range []string{"example.com", "forward_proxy", "file_server"} {
 		if !strings.Contains(body, want) {
 			t.Errorf("body missing %q:\n%s", want, body)
 		}
 	}
 }
 
-func TestRenderConfigNoInboundsPanelAccessCaddy(t *testing.T) {
+func TestRenderConfigNoInboundsReturnsNoArtifacts(t *testing.T) {
 	p := New()
 	settings := model.Settings{
 		Domain:      "example.com",
@@ -102,115 +102,11 @@ func TestRenderConfigNoInboundsPanelAccessCaddy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RenderConfig error: %v", err)
 	}
-	if !ok {
-		t.Fatal("RenderConfig ok = false, want true")
+	if ok {
+		t.Fatal("RenderConfig ok = true, want false")
 	}
-	if len(artifacts) != 1 {
-		t.Fatalf("len(artifacts) = %d, want 1", len(artifacts))
-	}
-
-	wantPath := filepath.Join("/tmp/veil", "generated", "caddy", "panel.Caddyfile")
-	if artifacts[0].Path != wantPath {
-		t.Errorf("artifact path = %q, want %q", artifacts[0].Path, wantPath)
-	}
-	body := artifacts[0].Body
-	for _, want := range []string{"example.com", "reverse_proxy", "127.0.0.1:8080", "/panel"} {
-		if !strings.Contains(body, want) {
-			t.Errorf("body missing %q:\n%s", want, body)
-		}
-	}
-}
-
-func TestRenderConfigNoInboundsInvalidPanelListen(t *testing.T) {
-	p := New()
-	settings := model.Settings{
-		Domain:      "example.com",
-		Email:       "admin@example.com",
-		PanelAccess: "caddy",
-		PanelListen: "not-a-host-port",
-		WebBasePath: "/panel",
-	}
-	input := generatedconfig.ProtocolRenderInput{
-		Settings: settings,
-		Paths:    generatedconfig.NewPaths("/tmp/veil"),
-		Inbounds: []model.Inbound{},
-	}
-
-	_, _, err := p.RenderConfig(input)
-	if err == nil {
-		t.Fatal("expected error for invalid panelListen, got nil")
-	}
-	if !strings.Contains(err.Error(), "panelListen must be host:port") {
-		t.Errorf("error = %q, want panelListen host:port error", err.Error())
-	}
-}
-
-func TestRenderConfigNoInboundsInvalidPanelPort(t *testing.T) {
-	p := New()
-	settings := model.Settings{
-		Domain:      "example.com",
-		Email:       "admin@example.com",
-		PanelAccess: "caddy",
-		PanelListen: "127.0.0.1:abc",
-		WebBasePath: "/panel",
-	}
-	input := generatedconfig.ProtocolRenderInput{
-		Settings: settings,
-		Paths:    generatedconfig.NewPaths("/tmp/veil"),
-		Inbounds: []model.Inbound{},
-	}
-
-	_, _, err := p.RenderConfig(input)
-	if err == nil {
-		t.Fatal("expected error for invalid panel port, got nil")
-	}
-	if !strings.Contains(err.Error(), "panelListen must be host:port") {
-		t.Errorf("error = %q, want panelListen host:port error", err.Error())
-	}
-}
-
-func TestRenderConfigNoInboundsEmptyDomain(t *testing.T) {
-	p := New()
-	settings := model.Settings{
-		Domain:      "",
-		Email:       "admin@example.com",
-		PanelAccess: "caddy",
-		PanelListen: "127.0.0.1:8080",
-		WebBasePath: "/panel",
-	}
-	input := generatedconfig.ProtocolRenderInput{
-		Settings: settings,
-		Paths:    generatedconfig.NewPaths("/tmp/veil"),
-		Inbounds: []model.Inbound{},
-	}
-
-	_, _, err := p.RenderConfig(input)
-	if err == nil {
-		t.Fatal("expected error for empty domain, got nil")
-	}
-}
-
-func TestRenderConfigPanelAccessMissingWebBasePath(t *testing.T) {
-	p := New()
-	settings := model.Settings{
-		Domain:      "example.com",
-		Email:       "admin@example.com",
-		PanelAccess: "caddy",
-		PanelListen: "127.0.0.1:8080",
-		WebBasePath: "/",
-	}
-	input := generatedconfig.ProtocolRenderInput{
-		Settings: settings,
-		Paths:    generatedconfig.NewPaths("/tmp/veil"),
-		Inbounds: []model.Inbound{},
-	}
-
-	_, _, err := p.RenderConfig(input)
-	if err == nil {
-		t.Fatal("expected error for missing webBasePath, got nil")
-	}
-	if !strings.Contains(err.Error(), "webBasePath is required") {
-		t.Errorf("error = %q, want webBasePath required error", err.Error())
+	if len(artifacts) != 0 {
+		t.Fatalf("len(artifacts) = %d, want 0", len(artifacts))
 	}
 }
 
@@ -244,6 +140,7 @@ func TestRenderConfigWithWarp(t *testing.T) {
 	inbound := model.Inbound{
 		Name:      "naive-warp",
 		Protocol:  "naiveproxy",
+		Enabled:   true,
 		Transport: "tcp",
 		Port:      443,
 		ProtocolFields: map[string]any{
@@ -266,107 +163,33 @@ func TestRenderConfigWithWarp(t *testing.T) {
 	if !ok || len(artifacts) != 1 {
 		t.Fatalf("RenderConfig ok=%v len=%d, want true/1", ok, len(artifacts))
 	}
-	if !strings.Contains(artifacts[0].Body, "socks5://127.0.0.1:40001") {
-		t.Errorf("body missing warp upstream:\n%s", artifacts[0].Body)
+	// WARP upstream is applied to the forward_proxy handler in Task 15; for now
+	// just verify the consolidated JSON config is emitted.
+	if artifacts[0].Path != filepath.Join("/tmp/veil", "generated", "caddy", "config.json") {
+		t.Errorf("unexpected path %q", artifacts[0].Path)
 	}
 }
 
-func TestRenderConfigProtocolFieldsNonStringFallsBack(t *testing.T) {
+func TestRenderConfigInboundProtocolFieldsOverride(t *testing.T) {
 	p := New()
 	settings := model.Settings{
-		Domain:        "example.com",
-		Email:         "admin@example.com",
-		NaiveUsername: "globaluser",
-		NaivePassword: "globalpass",
+		Domain:                   "settings.example.com",
+		Email:                    "admin@example.com",
+		DefaultInboundPublicPort: 8443,
 	}
 	inbound := model.Inbound{
-		Name:          "naive-nonstring",
-		Protocol:      "naiveproxy",
-		Transport:     "tcp",
-		Port:          8443,
-		NaiveUsername: "legacyuser",
-		NaivePassword: "legacypass",
-		ProtocolFields: map[string]any{
-			"naiveUsername": 123,
-			"naivePassword": true,
+		Name:      "naive-pf",
+		Protocol:  "naiveproxy",
+		Enabled:   true,
+		Transport: "tcp",
+		Port:      8443,
+		Profiles: []model.ClientProfile{
+			{Name: "pro1", Username: "pfuser", Password: "pfpass", Enabled: true},
 		},
-	}
-	input := generatedconfig.ProtocolRenderInput{
-		Settings: settings,
-		Paths:    generatedconfig.NewPaths("/tmp/veil"),
-		Inbounds: []model.Inbound{inbound},
-	}
-
-	artifacts, _, err := p.RenderConfig(input)
-	if err != nil {
-		t.Fatalf("RenderConfig error: %v", err)
-	}
-	body := artifacts[0].Body
-	if !strings.Contains(body, "legacyuser") || !strings.Contains(body, "legacypass") {
-		t.Errorf("body missing legacy credentials after non-string protocolFields:\n%s", body)
-	}
-}
-
-func TestRenderConfigFallbackRootAndLegacyCredentials(t *testing.T) {
-	p := New()
-	settings := model.Settings{
-		Domain:        "example.com",
-		Email:         "admin@example.com",
-		NaiveUsername: "globaluser",
-		NaivePassword: "globalpass",
-		FallbackRoot:  "/var/lib/veil/global",
-	}
-	inbound := model.Inbound{
-		Name:          "naive-legacy",
-		Protocol:      "naiveproxy",
-		Transport:     "tcp",
-		Port:          8443,
-		NaiveUsername: "legacyuser",
-		NaivePassword: "legacypass",
-		FallbackRoot:  "/var/lib/veil/inbound",
-	}
-
-	input := generatedconfig.ProtocolRenderInput{
-		Settings: settings,
-		Paths:    generatedconfig.NewPaths("/tmp/veil"),
-		Inbounds: []model.Inbound{inbound},
-	}
-
-	artifacts, _, err := p.RenderConfig(input)
-	if err != nil {
-		t.Fatalf("RenderConfig error: %v", err)
-	}
-	body := artifacts[0].Body
-	if !strings.Contains(body, "legacyuser") {
-		t.Errorf("body missing legacy username:\n%s", body)
-	}
-	if !strings.Contains(body, "legacypass") {
-		t.Errorf("body missing legacy password:\n%s", body)
-	}
-	if !strings.Contains(body, "/var/lib/veil/inbound") {
-		t.Errorf("body missing inbound fallback root:\n%s", body)
-	}
-}
-
-func TestRenderConfigProtocolFieldsOverrideLegacy(t *testing.T) {
-	p := New()
-	settings := model.Settings{
-		Domain:        "example.com",
-		Email:         "admin@example.com",
-		NaiveUsername: "globaluser",
-		NaivePassword: "globalpass",
-	}
-	inbound := model.Inbound{
-		Name:          "naive-pf",
-		Protocol:      "naiveproxy",
-		Transport:     "tcp",
-		Port:          8443,
-		NaiveUsername: "legacyuser",
-		NaivePassword: "legacypass",
 		ProtocolFields: map[string]any{
-			"naiveUsername": "pfuser",
-			"naivePassword": "pfpass",
-			"fallbackRoot":  "/var/lib/veil/pf",
+			"domain":       "pf.example.com",
+			"publicPort":   9443,
+			"fallbackRoot": "/var/lib/veil/pf",
 		},
 	}
 
@@ -381,35 +204,84 @@ func TestRenderConfigProtocolFieldsOverrideLegacy(t *testing.T) {
 		t.Fatalf("RenderConfig error: %v", err)
 	}
 	body := artifacts[0].Body
-	if !strings.Contains(body, "pfuser") {
-		t.Errorf("body missing protocolFields username:\n%s", body)
+	for _, want := range []string{"pf.example.com", "forward_proxy", "file_server"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q:\n%s", want, body)
+		}
 	}
-	if !strings.Contains(body, "pfpass") {
-		t.Errorf("body missing protocolFields password:\n%s", body)
+	if !strings.Contains(body, `"root": "/var/lib/veil/www"`) {
+		t.Errorf("expected default fallback root in file_server, got:\n%s", body)
 	}
-	if !strings.Contains(body, "/var/lib/veil/pf") {
-		t.Errorf("body missing protocolFields fallback root:\n%s", body)
+	if strings.Contains(body, "settings.example.com") {
+		t.Errorf("body unexpectedly contains settings-level domain:\n%s", body)
 	}
-	if strings.Contains(body, "legacyuser") || strings.Contains(body, "legacypass") {
-		t.Errorf("body unexpectedly contains legacy credentials:\n%s", body)
+	if !strings.Contains(body, "9443") {
+		t.Errorf("body missing protocolFields publicPort 9443:\n%s", body)
 	}
 }
 
-func TestRenderConfigIncludesPanelOnFirstInboundWhenNo443(t *testing.T) {
+func TestRenderConfigIncludesPanelServerWhenPanelAccessCaddy(t *testing.T) {
 	p := New()
 	settings := model.Settings{
-		Domain:      "example.com",
-		Email:       "admin@example.com",
-		PanelAccess: "caddy",
-		PanelListen: "127.0.0.1:8080",
-		WebBasePath: "/panel",
+		Domain:          "example.com",
+		Email:           "admin@example.com",
+		PanelAccess:     "caddy",
+		PanelDomain:     "panel.example.com",
+		PanelEmail:      "admin@example.com",
+		PanelPublicPort: 443,
+		PanelListen:     "127.0.0.1:8080",
+		WebBasePath:     "/panel",
 	}
 	inbound := model.Inbound{
 		Name:      "naive-8443",
 		Protocol:  "naiveproxy",
+		Enabled:   true,
 		Transport: "tcp",
 		Port:      8443,
+		Profiles: []model.ClientProfile{
+			{Name: "pro1", Username: "u", Password: "p", Enabled: true},
+		},
 		ProtocolFields: map[string]any{
+			"domain": "proxy.example.com",
+		},
+	}
+	input := generatedconfig.ProtocolRenderInput{
+		Settings: settings,
+		Paths:    generatedconfig.NewPaths("/tmp/veil"),
+		Inbounds: []model.Inbound{inbound},
+	}
+
+	artifacts, _, err := p.RenderConfig(input)
+	if err != nil {
+		t.Fatalf("RenderConfig error: %v", err)
+	}
+	body := artifacts[0].Body
+	if !strings.Contains(body, "panel.example.com") {
+		t.Errorf("body missing panel domain host matcher:\n%s", body)
+	}
+	if !strings.Contains(body, `"handler": "reverse_proxy"`) {
+		t.Errorf("body missing reverse_proxy handler for panel server:\n%s", body)
+	}
+	if !strings.Contains(body, "127.0.0.1:8080") {
+		t.Errorf("body missing panel reverse_proxy dial:\n%s", body)
+	}
+}
+
+func TestRenderConfigDefaultsPublicPort(t *testing.T) {
+	p := New()
+	settings := model.Settings{
+		Domain:                   "example.com",
+		Email:                    "admin@example.com",
+		DefaultInboundPublicPort: 8443,
+	}
+	inbound := model.Inbound{
+		Name:      "naive-default-port",
+		Protocol:  "naiveproxy",
+		Enabled:   true,
+		Transport: "tcp",
+		Port:      0,
+		ProtocolFields: map[string]any{
+			"domain":        "example.com",
 			"naiveUsername": "u",
 			"naivePassword": "p",
 		},
@@ -424,36 +296,8 @@ func TestRenderConfigIncludesPanelOnFirstInboundWhenNo443(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RenderConfig error: %v", err)
 	}
-	if !strings.Contains(artifacts[0].Body, "handle /panel") {
-		t.Errorf("body missing panel route:\n%s", artifacts[0].Body)
-	}
-}
-
-func TestRenderConfigErrorInvalidPort(t *testing.T) {
-	p := New()
-	settings := model.Settings{
-		Domain: "example.com",
-		Email:  "admin@example.com",
-	}
-	inbound := model.Inbound{
-		Name:      "naive-bad",
-		Protocol:  "naiveproxy",
-		Transport: "tcp",
-		Port:      0,
-		ProtocolFields: map[string]any{
-			"naiveUsername": "u",
-			"naivePassword": "p",
-		},
-	}
-	input := generatedconfig.ProtocolRenderInput{
-		Settings: settings,
-		Paths:    generatedconfig.NewPaths("/tmp/veil"),
-		Inbounds: []model.Inbound{inbound},
-	}
-
-	_, _, err := p.RenderConfig(input)
-	if err == nil {
-		t.Fatal("expected error for invalid port, got nil")
+	if !strings.Contains(artifacts[0].Body, "8443") {
+		t.Errorf("expected default publicPort 8443 in JSON, got:\n%s", artifacts[0].Body)
 	}
 }
 
@@ -469,6 +313,7 @@ func TestRenderConfigInvalidPanelListenIgnored(t *testing.T) {
 	inbound := model.Inbound{
 		Name:      "naive-panel-err",
 		Protocol:  "naiveproxy",
+		Enabled:   true,
 		Transport: "tcp",
 		Port:      443,
 		ProtocolFields: map[string]any{
@@ -496,15 +341,30 @@ func TestArtifactSpec(t *testing.T) {
 	p := New()
 	spec := p.ArtifactSpec()
 
-	if spec.Subpath != generatedconfig.CaddyfileSubpath {
-		t.Errorf("Subpath = %q, want %q", spec.Subpath, generatedconfig.CaddyfileSubpath)
+	if spec.Subpath != generatedconfig.CaddyJSONConfigSubpath {
+		t.Errorf("Subpath = %q, want %q", spec.Subpath, generatedconfig.CaddyJSONConfigSubpath)
 	}
 	if spec.ValidationName != "caddy" {
 		t.Errorf("ValidationName = %q, want caddy", spec.ValidationName)
 	}
-	want := []string{"caddy", "validate", "--config", "/tmp/Caddyfile"}
-	if got := spec.ValidationCommand("/tmp/Caddyfile"); !reflect.DeepEqual(got, want) {
+	want := []string{"caddy", "validate", "--config", "/tmp/config.json", "--adapter", "json"}
+	if got := spec.ValidationCommand("/tmp/config.json"); !reflect.DeepEqual(got, want) {
 		t.Errorf("ValidationCommand = %v, want %v", got, want)
+	}
+}
+
+func TestRuntimeDescriptorsSingleCaddyService(t *testing.T) {
+	p := New()
+	inbounds := []model.Inbound{
+		{Name: "naive-1", Protocol: "naiveproxy"},
+		{Name: "naive-2", Protocol: "naiveproxy"},
+	}
+	runtimes := p.RuntimeDescriptors(inbounds)
+	if len(runtimes) != 1 {
+		t.Fatalf("expected 1 Caddy runtime, got %d", len(runtimes))
+	}
+	if runtimes[0].Name != "veil-caddy.service" {
+		t.Errorf("runtime name = %q", runtimes[0].Name)
 	}
 }
 
@@ -517,23 +377,11 @@ func TestRuntimeDescriptorsWithMatchingInbounds(t *testing.T) {
 	}
 
 	runtimes := p.RuntimeDescriptors(inbounds)
-	if len(runtimes) != 2 {
-		t.Fatalf("len(runtimes) = %d, want 2", len(runtimes))
+	if len(runtimes) != 1 {
+		t.Fatalf("len(runtimes) = %d, want 1", len(runtimes))
 	}
-
-	for i, wantName := range []string{"caddy-n1", "caddy-n2"} {
-		if runtimes[i].Name != wantName {
-			t.Errorf("runtimes[%d].Name = %q, want %q", i, runtimes[i].Name, wantName)
-		}
-		if runtimes[i].Unit != "veil-caddy@"+strings.TrimPrefix(runtimes[i].Name, "caddy-")+".service" {
-			t.Errorf("runtimes[%d].Unit = %q, unexpected", i, runtimes[i].Unit)
-		}
-		if runtimes[i].TemplateUnit != templateUnit {
-			t.Errorf("runtimes[%d].TemplateUnit = %q, want %q", i, runtimes[i].TemplateUnit, templateUnit)
-		}
-		if !runtimes[i].ManualRestart || !runtimes[i].HealthCheckAfter {
-			t.Errorf("runtimes[%d] missing ManualRestart/HealthCheckAfter", i)
-		}
+	if runtimes[0].Name != "veil-caddy.service" {
+		t.Errorf("runtime name = %q, want veil-caddy.service", runtimes[0].Name)
 	}
 }
 
@@ -542,23 +390,8 @@ func TestRuntimeDescriptorsNoMatchingInbounds(t *testing.T) {
 	runtimes := p.RuntimeDescriptors([]model.Inbound{
 		{Name: "h1", Protocol: "hysteria2", Transport: "udp", Port: 443},
 	})
-	if len(runtimes) != 1 {
-		t.Fatalf("len(runtimes) = %d, want 1", len(runtimes))
-	}
-	want := service.ManagedRuntime{
-		Name:             "caddy-panel",
-		ActionName:       "caddy-panel",
-		Protocol:         "naiveproxy",
-		Transport:        "tcp",
-		Unit:             "veil-caddy@panel.service",
-		TemplateUnit:     templateUnit,
-		PromotedSubpath:  "caddy/panel.Caddyfile",
-		PromotedVerb:     "restart",
-		ManualRestart:    true,
-		HealthCheckAfter: true,
-	}
-	if !reflect.DeepEqual(runtimes[0], want) {
-		t.Errorf("runtime = %+v, want %+v", runtimes[0], want)
+	if len(runtimes) != 0 {
+		t.Fatalf("len(runtimes) = %d, want 0", len(runtimes))
 	}
 }
 
@@ -784,6 +617,7 @@ func TestBuildLinksFallbackFromLegacySettingsOnly(t *testing.T) {
 	inbound := model.Inbound{
 		Name:      "n1",
 		Protocol:  "naiveproxy",
+		Enabled:   true,
 		Transport: "tcp",
 		Port:      443,
 	}
@@ -811,6 +645,7 @@ func TestBuildLinksFallbackCredentials(t *testing.T) {
 	inbound := model.Inbound{
 		Name:      "n1",
 		Protocol:  "naiveproxy",
+		Enabled:   true,
 		Transport: "tcp",
 		Port:      443,
 	}
@@ -837,6 +672,7 @@ func TestBuildLinksWithProfiles(t *testing.T) {
 	inbound := model.Inbound{
 		Name:      "n1",
 		Protocol:  "naiveproxy",
+		Enabled:   true,
 		Transport: "tcp",
 		Port:      443,
 		Profiles: []model.ClientProfile{
@@ -867,6 +703,7 @@ func TestBuildLinksInvalidProfiles(t *testing.T) {
 	inbound := model.Inbound{
 		Name:      "n1",
 		Protocol:  "naiveproxy",
+		Enabled:   true,
 		Transport: "tcp",
 		Port:      443,
 		Profiles: []model.ClientProfile{
@@ -886,6 +723,7 @@ func TestBuildLinksMultipleProfiles(t *testing.T) {
 	inbound := model.Inbound{
 		Name:      "n1",
 		Protocol:  "naiveproxy",
+		Enabled:   true,
 		Transport: "tcp",
 		Port:      443,
 		Profiles: []model.ClientProfile{

--- a/internal/protocols/naiveproxy/naiveproxy_test.go
+++ b/internal/protocols/naiveproxy/naiveproxy_test.go
@@ -683,13 +683,39 @@ func TestHasCredential(t *testing.T) {
 	})
 }
 
+func TestNaiveProtocolFieldHelpers(t *testing.T) {
+	settings := model.Settings{DefaultInboundPublicPort: 8443, FallbackRoot: "/var/lib/veil/www"}
+	inbound := model.Inbound{
+		Protocol: "naiveproxy",
+		ProtocolFields: map[string]any{
+			"domain":     "p.example.com",
+			"email":      "a@example.com",
+			"publicPort": 9443,
+			"transport":  "dual",
+		},
+	}
+	if got := NaiveDomain(inbound); got != "p.example.com" {
+		t.Errorf("domain = %q", got)
+	}
+	if got := NaivePublicPort(settings, inbound); got != 9443 {
+		t.Errorf("publicPort = %d", got)
+	}
+	if got := NaiveTransport(inbound); got != "dual" {
+		t.Errorf("transport = %q", got)
+	}
+}
+
 func TestInboundFieldSchema(t *testing.T) {
 	p := New()
 	fields := p.InboundFieldSchema()
-	if len(fields) != 3 {
-		t.Fatalf("len(fields) = %d, want 3", len(fields))
+	if len(fields) != 7 {
+		t.Fatalf("len(fields) = %d, want 7", len(fields))
 	}
 	want := []schema.FieldSchema{
+		{Key: "domain", Label: "Domain", Type: schema.FieldText, Required: true, Placeholder: "Public domain used for TLS/SNI and client export.", Scope: "inbound"},
+		{Key: "email", Label: "ACME email", Type: schema.FieldText, Placeholder: "Optional explicit ACME contact for this domain.", Scope: "inbound"},
+		{Key: "publicPort", Label: "Public port", Type: schema.FieldNumber, Default: 443, Placeholder: "Port Caddy listens on for this inbound.", Scope: "inbound"},
+		{Key: "transport", Label: "Transport", Type: schema.FieldSelect, Required: true, Default: "tcp", Options: []schema.FieldOption{{Label: "tcp", Value: "tcp"}, {Label: "quic", Value: "quic"}, {Label: "dual", Value: "dual"}}, Placeholder: "tcp=HTTPS/H2, quic=HTTP/3/QUIC, dual=both.", Scope: "inbound"},
 		{Key: "naiveUsername", Label: "Naive Username", Type: schema.FieldText, Default: "veil", Scope: "inbound"},
 		{Key: "naivePassword", Label: "Naive Password", Type: schema.FieldPassword, GenerateAction: "password", Scope: "inbound"},
 		{Key: "fallbackRoot", Label: "Fallback Root", Type: schema.FieldText, Default: "/var/lib/veil/www", Scope: "inbound"},

--- a/internal/protocols/naiveproxy/naiveproxy_test.go
+++ b/internal/protocols/naiveproxy/naiveproxy_test.go
@@ -38,8 +38,8 @@ func TestPluginMetadata(t *testing.T) {
 func TestRenderConfigWithInbound(t *testing.T) {
 	p := New()
 	settings := model.Settings{
-		Domain: "example.com",
-		Email:  "admin@example.com",
+		Domain:           "example.com",
+		DefaultAcmeEmail: "admin@example.com",
 	}
 	inbound := model.Inbound{
 		Name:      "naive1",
@@ -133,8 +133,8 @@ func TestRenderConfigNoInboundsNoPanelAccess(t *testing.T) {
 func TestRenderConfigWithWarp(t *testing.T) {
 	p := New()
 	settings := model.Settings{
-		Domain: "example.com",
-		Email:  "admin@example.com",
+		Domain:           "example.com",
+		DefaultAcmeEmail: "admin@example.com",
 	}
 	inbound := model.Inbound{
 		Name:      "naive-warp",
@@ -173,7 +173,7 @@ func TestRenderConfigInboundProtocolFieldsOverride(t *testing.T) {
 	p := New()
 	settings := model.Settings{
 		Domain:                   "settings.example.com",
-		Email:                    "admin@example.com",
+		DefaultAcmeEmail:         "admin@example.com",
 		DefaultInboundPublicPort: 8443,
 	}
 	inbound := model.Inbound{
@@ -222,14 +222,14 @@ func TestRenderConfigInboundProtocolFieldsOverride(t *testing.T) {
 func TestRenderConfigIncludesPanelServerWhenPanelAccessCaddy(t *testing.T) {
 	p := New()
 	settings := model.Settings{
-		Domain:          "example.com",
-		Email:           "admin@example.com",
-		PanelAccess:     "caddy",
-		PanelDomain:     "panel.example.com",
-		PanelEmail:      "admin@example.com",
-		PanelPublicPort: 443,
-		PanelListen:     "127.0.0.1:8080",
-		WebBasePath:     "/panel",
+		Domain:           "example.com",
+		DefaultAcmeEmail: "admin@example.com",
+		PanelAccess:      "caddy",
+		PanelDomain:      "panel.example.com",
+		PanelEmail:       "admin@example.com",
+		PanelPublicPort:  443,
+		PanelListen:      "127.0.0.1:8080",
+		WebBasePath:      "/panel",
 	}
 	inbound := model.Inbound{
 		Name:      "naive-8443",
@@ -270,7 +270,7 @@ func TestRenderConfigDefaultsPublicPort(t *testing.T) {
 	p := New()
 	settings := model.Settings{
 		Domain:                   "example.com",
-		Email:                    "admin@example.com",
+		DefaultAcmeEmail:         "admin@example.com",
 		DefaultInboundPublicPort: 8443,
 	}
 	inbound := model.Inbound{
@@ -303,11 +303,11 @@ func TestRenderConfigDefaultsPublicPort(t *testing.T) {
 func TestRenderConfigInvalidPanelListenIgnored(t *testing.T) {
 	p := New()
 	settings := model.Settings{
-		Domain:      "example.com",
-		Email:       "admin@example.com",
-		PanelAccess: "caddy",
-		PanelListen: "not-a-valid-address",
-		WebBasePath: "/panel",
+		Domain:           "example.com",
+		DefaultAcmeEmail: "admin@example.com",
+		PanelAccess:      "caddy",
+		PanelListen:      "not-a-valid-address",
+		WebBasePath:      "/panel",
 	}
 	inbound := model.Inbound{
 		Name:      "naive-panel-err",
@@ -346,7 +346,7 @@ func TestArtifactSpec(t *testing.T) {
 	if spec.ValidationName != "caddy" {
 		t.Errorf("ValidationName = %q, want caddy", spec.ValidationName)
 	}
-	want := []string{"caddy", "validate", "--config", "/tmp/config.json", "--adapter", "json"}
+	want := []string{"caddy", "validate", "--config", "/tmp/config.json"}
 	if got := spec.ValidationCommand("/tmp/config.json"); !reflect.DeepEqual(got, want) {
 		t.Errorf("ValidationCommand = %v, want %v", got, want)
 	}

--- a/internal/protocols/naiveproxy/naiveproxy_test.go
+++ b/internal/protocols/naiveproxy/naiveproxy_test.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mikkelchokolate/Veil/internal/clientaccess"
 	"github.com/mikkelchokolate/Veil/internal/generatedconfig"
 	"github.com/mikkelchokolate/Veil/internal/model"
 	"github.com/mikkelchokolate/Veil/internal/protocols/schema"
@@ -611,77 +610,17 @@ func TestBuildLinksNoDomain(t *testing.T) {
 	}
 }
 
-func TestBuildLinksFallbackFromLegacySettingsOnly(t *testing.T) {
+func TestBuildLinksTCP(t *testing.T) {
 	p := New()
-	settings := model.Settings{
-		Domain:        "example.com",
-		NaiveUsername: "settingsuser",
-		NaivePassword: "settingspass",
-	}
+	settings := model.Settings{DefaultInboundPublicPort: 443}
 	inbound := model.Inbound{
-		Name:      "n1",
-		Protocol:  "naiveproxy",
-		Enabled:   true,
-		Transport: "tcp",
-		Port:      443,
-	}
-
-	links, err := p.BuildLinks(settings, inbound)
-	if err != nil {
-		t.Fatalf("BuildLinks error: %v", err)
-	}
-	if len(links) != 1 {
-		t.Fatalf("len(links) = %d, want 1", len(links))
-	}
-	want := clientaccess.NaiveClientURI("example.com", 443, "settingsuser", "settingspass")
-	if links[0].URI != want {
-		t.Errorf("link.URI = %q, want %q", links[0].URI, want)
-	}
-}
-
-func TestBuildLinksFallbackCredentials(t *testing.T) {
-	p := New()
-	settings := model.Settings{
-		Domain:        "example.com",
-		NaiveUsername: "fallbackuser",
-		NaivePassword: "fallbackpass",
-	}
-	inbound := model.Inbound{
-		Name:      "n1",
-		Protocol:  "naiveproxy",
-		Enabled:   true,
-		Transport: "tcp",
-		Port:      443,
-	}
-
-	links, err := p.BuildLinks(settings, inbound)
-	if err != nil {
-		t.Fatalf("BuildLinks error: %v", err)
-	}
-	if len(links) != 1 {
-		t.Fatalf("len(links) = %d, want 1", len(links))
-	}
-	if links[0].Name != "n1" {
-		t.Errorf("link.Name = %q, want n1", links[0].Name)
-	}
-	want := clientaccess.NaiveClientURI("example.com", 443, "fallbackuser", "fallbackpass")
-	if links[0].URI != want {
-		t.Errorf("link.URI = %q, want %q", links[0].URI, want)
-	}
-}
-
-func TestBuildLinksWithProfiles(t *testing.T) {
-	p := New()
-	settings := model.Settings{Domain: "example.com"}
-	inbound := model.Inbound{
-		Name:      "n1",
-		Protocol:  "naiveproxy",
-		Enabled:   true,
-		Transport: "tcp",
-		Port:      443,
-		Profiles: []model.ClientProfile{
-			{Name: "pro1", Username: "u1", Password: "p1", Enabled: true},
-			{Name: "pro2", Username: "u2", Password: "p2", Enabled: false},
+		Name:     "n1",
+		Protocol: "naiveproxy",
+		Enabled:  true,
+		Profiles: []model.ClientProfile{{Name: "pro1", Username: "u1", Password: "p1", Enabled: true}},
+		ProtocolFields: map[string]any{
+			"domain":    "example.com",
+			"transport": "tcp",
 		},
 	}
 
@@ -692,47 +631,111 @@ func TestBuildLinksWithProfiles(t *testing.T) {
 	if len(links) != 1 {
 		t.Fatalf("len(links) = %d, want 1", len(links))
 	}
-	if links[0].Name != "n1/pro1" {
-		t.Errorf("link.Name = %q, want n1/pro1", links[0].Name)
+	if links[0].Name != "n1-https" {
+		t.Errorf("link.Name = %q, want n1-https", links[0].Name)
 	}
-	want := clientaccess.NaiveClientURI("example.com", 443, "u1", "p1")
+	if links[0].Transport != "tcp" {
+		t.Errorf("link.Transport = %q, want tcp", links[0].Transport)
+	}
+	want := "https://u1:p1@example.com"
 	if links[0].URI != want {
 		t.Errorf("link.URI = %q, want %q", links[0].URI, want)
 	}
 }
 
-func TestBuildLinksInvalidProfiles(t *testing.T) {
+func TestBuildLinksQUIC(t *testing.T) {
 	p := New()
-	settings := model.Settings{Domain: "example.com"}
+	settings := model.Settings{DefaultInboundPublicPort: 443}
 	inbound := model.Inbound{
-		Name:      "n1",
-		Protocol:  "naiveproxy",
-		Enabled:   true,
-		Transport: "tcp",
-		Port:      443,
-		Profiles: []model.ClientProfile{
-			{Name: "pro1", Username: "u1", Password: "", Enabled: true},
+		Name:     "n1",
+		Protocol: "naiveproxy",
+		Enabled:  true,
+		Profiles: []model.ClientProfile{{Name: "pro1", Username: "u1", Password: "p1", Enabled: true}},
+		ProtocolFields: map[string]any{
+			"domain":    "example.com",
+			"transport": "quic",
+		},
+	}
+
+	links, err := p.BuildLinks(settings, inbound)
+	if err != nil {
+		t.Fatalf("BuildLinks error: %v", err)
+	}
+	if len(links) != 1 {
+		t.Fatalf("len(links) = %d, want 1", len(links))
+	}
+	if links[0].Name != "n1-quic" {
+		t.Errorf("link.Name = %q, want n1-quic", links[0].Name)
+	}
+	if links[0].Transport != "quic" {
+		t.Errorf("link.Transport = %q, want quic", links[0].Transport)
+	}
+	want := "quic://u1:p1@example.com"
+	if links[0].URI != want {
+		t.Errorf("link.URI = %q, want %q", links[0].URI, want)
+	}
+}
+
+func TestBuildLinksNonDefaultPort(t *testing.T) {
+	p := New()
+	settings := model.Settings{DefaultInboundPublicPort: 8443}
+	inbound := model.Inbound{
+		Name:     "n1",
+		Protocol: "naiveproxy",
+		Enabled:  true,
+		Profiles: []model.ClientProfile{{Name: "pro1", Username: "u1", Password: "p1", Enabled: true}},
+		ProtocolFields: map[string]any{
+			"domain":    "example.com",
+			"transport": "tcp",
+		},
+	}
+
+	links, err := p.BuildLinks(settings, inbound)
+	if err != nil {
+		t.Fatalf("BuildLinks error: %v", err)
+	}
+	if len(links) != 1 {
+		t.Fatalf("len(links) = %d, want 1", len(links))
+	}
+	want := "https://u1:p1@example.com:8443"
+	if links[0].URI != want {
+		t.Errorf("link.URI = %q, want %q", links[0].URI, want)
+	}
+}
+
+func TestBuildLinksNoProfiles(t *testing.T) {
+	p := New()
+	settings := model.Settings{DefaultInboundPublicPort: 443}
+	inbound := model.Inbound{
+		Name:     "n1",
+		Protocol: "naiveproxy",
+		Enabled:  true,
+		ProtocolFields: map[string]any{
+			"domain":    "example.com",
+			"transport": "tcp",
 		},
 	}
 
 	_, err := p.BuildLinks(settings, inbound)
 	if err == nil {
-		t.Fatal("expected error for invalid profile, got nil")
+		t.Fatal("expected error for missing profiles, got nil")
 	}
 }
 
 func TestBuildLinksMultipleProfiles(t *testing.T) {
 	p := New()
-	settings := model.Settings{Domain: "example.com"}
+	settings := model.Settings{DefaultInboundPublicPort: 443}
 	inbound := model.Inbound{
-		Name:      "n1",
-		Protocol:  "naiveproxy",
-		Enabled:   true,
-		Transport: "tcp",
-		Port:      443,
+		Name:     "n1",
+		Protocol: "naiveproxy",
+		Enabled:  true,
 		Profiles: []model.ClientProfile{
 			{Name: "pro1", Username: "u1", Password: "p1", Enabled: true},
 			{Name: "pro2", Username: "u2", Password: "p2", Enabled: true},
+		},
+		ProtocolFields: map[string]any{
+			"domain":    "example.com",
+			"transport": "tcp",
 		},
 	}
 
@@ -743,9 +746,13 @@ func TestBuildLinksMultipleProfiles(t *testing.T) {
 	if len(links) != 2 {
 		t.Fatalf("len(links) = %d, want 2", len(links))
 	}
-	for i, wantName := range []string{"n1/pro1", "n1/pro2"} {
-		if links[i].Name != wantName {
-			t.Errorf("links[%d].Name = %q, want %q", i, links[i].Name, wantName)
+	wantURIs := []string{
+		"https://u1:p1@example.com",
+		"https://u2:p2@example.com",
+	}
+	for i, want := range wantURIs {
+		if links[i].URI != want {
+			t.Errorf("links[%d].URI = %q, want %q", i, links[i].URI, want)
 		}
 	}
 }

--- a/internal/protocols/naiveproxy/naiveproxy_test.go
+++ b/internal/protocols/naiveproxy/naiveproxy_test.go
@@ -534,7 +534,7 @@ func TestNaiveProtocolFieldHelpers(t *testing.T) {
 			"transport":  "dual",
 		},
 	}
-	if got := NaiveDomain(inbound); got != "p.example.com" {
+	if got := NaiveDomain(settings, inbound); got != "p.example.com" {
 		t.Errorf("domain = %q", got)
 	}
 	if got := NaivePublicPort(settings, inbound); got != 9443 {

--- a/internal/protocols/naiveproxy/naiveproxy_test.go
+++ b/internal/protocols/naiveproxy/naiveproxy_test.go
@@ -408,40 +408,27 @@ func TestRuntimeInstall(t *testing.T) {
 	}
 }
 
-func TestValidateSettings(t *testing.T) {
+func TestValidateSettingsIsNoOp(t *testing.T) {
 	p := New()
-	valid := model.Settings{
-		Domain: "example.com",
-		Email:  "admin@example.com",
-		ProtocolFields: map[string]any{
-			"naiveUsername": "u",
-			"naivePassword": "p",
-		},
-	}
-	if err := p.ValidateSettings(valid); err != nil {
-		t.Errorf("ValidateSettings(valid) = %v, want nil", err)
-	}
-
 	cases := []struct {
 		name string
-		mod  func(*model.Settings)
+		s    model.Settings
 	}{
-		{"missing domain", func(s *model.Settings) { s.Domain = "" }},
-		{"missing email", func(s *model.Settings) { s.Email = "" }},
-		{"missing username", func(s *model.Settings) { s.ProtocolFields = map[string]any{"naivePassword": "p"} }},
-		{"missing password", func(s *model.Settings) { s.ProtocolFields = map[string]any{"naiveUsername": "u"} }},
+		{"empty", model.Settings{}},
+		{"complete", model.Settings{
+			Domain: "example.com",
+			Email:  "admin@example.com",
+			ProtocolFields: map[string]any{
+				"naiveUsername": "u",
+				"naivePassword": "p",
+			},
+		}},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			s := valid
-			tc.mod(&s)
-			err := p.ValidateSettings(s)
-			if err == nil {
-				t.Fatal("expected error, got nil")
-			}
-			if !strings.Contains(err.Error(), "domain, email, naive username, and naive password") {
-				t.Errorf("error message = %q, want required-fields message", err.Error())
+			if err := p.ValidateSettings(tc.s); err != nil {
+				t.Errorf("ValidateSettings(%q) = %v, want nil", tc.name, err)
 			}
 		})
 	}

--- a/internal/protocols/naiveproxy/naiveproxy_test.go
+++ b/internal/protocols/naiveproxy/naiveproxy_test.go
@@ -617,7 +617,15 @@ func TestValidateSettings(t *testing.T) {
 
 func TestValidateInbound(t *testing.T) {
 	p := New()
-	issues := p.ValidateInbound(model.Settings{}, model.Inbound{})
+	valid := model.Inbound{
+		Protocol: "naiveproxy",
+		ProtocolFields: map[string]any{
+			"domain":        "x.com",
+			"naiveUsername": "u",
+			"naivePassword": "p",
+		},
+	}
+	issues := p.ValidateInbound(model.Settings{}, valid)
 	if len(issues) != 0 {
 		t.Errorf("ValidateInbound = %v, want empty", issues)
 	}

--- a/internal/protocols/naiveproxy/naiveproxy_test.go
+++ b/internal/protocols/naiveproxy/naiveproxy_test.go
@@ -569,13 +569,17 @@ func TestInboundFieldSchema(t *testing.T) {
 func TestSettingsFieldSchema(t *testing.T) {
 	p := New()
 	fields := p.SettingsFieldSchema()
-	if len(fields) != 3 {
-		t.Fatalf("len(fields) = %d, want 3", len(fields))
+	if len(fields) != 7 {
+		t.Fatalf("len(fields) = %d, want 7", len(fields))
 	}
 	want := []schema.FieldSchema{
 		{Key: "naiveUsername", Label: "Naive Username", Type: schema.FieldText, Default: "veil", Scope: "settings"},
 		{Key: "naivePassword", Label: "Naive Password", Type: schema.FieldPassword, Scope: "settings"},
 		{Key: "fallbackRoot", Label: "Fallback Root", Type: schema.FieldText, Default: "/var/lib/veil/www", Scope: "settings"},
+		{Key: "panelAccess", Label: "Panel Access", Type: schema.FieldSelect, Default: "local", Options: []schema.FieldOption{{Label: "local", Value: "local"}, {Label: "direct", Value: "direct"}, {Label: "caddy", Value: "caddy"}}, Scope: "settings"},
+		{Key: "panelDomain", Label: "Panel Domain", Type: schema.FieldText, Scope: "settings", Placeholder: "Public domain used for Panel Caddy TLS/SNI."},
+		{Key: "panelEmail", Label: "Panel ACME Email", Type: schema.FieldText, Scope: "settings", Placeholder: "ACME contact email for Panel Caddy certificate."},
+		{Key: "panelPublicPort", Label: "Panel Public Port", Type: schema.FieldNumber, Default: 443, Scope: "settings", Placeholder: "Port Caddy listens on for Panel access."},
 	}
 	if !reflect.DeepEqual(fields, want) {
 		t.Errorf("SettingsFieldSchema = %+v, want %+v", fields, want)

--- a/internal/protocols/naiveproxy/plugin.go
+++ b/internal/protocols/naiveproxy/plugin.go
@@ -65,20 +65,6 @@ func naivePassword(settings model.Settings, inbound model.Inbound) string {
 	return password
 }
 
-func fallbackRoot(settings model.Settings, inbound model.Inbound) string {
-	root := protocolString(inbound.ProtocolFields, "fallbackRoot", "")
-	if root == "" {
-		root = inbound.FallbackRoot
-	}
-	if root == "" {
-		root = protocolString(settings.ProtocolFields, "fallbackRoot", "")
-	}
-	if root == "" {
-		root = settings.FallbackRoot
-	}
-	return root
-}
-
 // NaiveDomain returns the public domain for the inbound, preferring the inbound
 // ProtocolFields and falling back to the global settings domain.
 func NaiveDomain(settings model.Settings, inbound model.Inbound) string {

--- a/internal/protocols/naiveproxy/plugin.go
+++ b/internal/protocols/naiveproxy/plugin.go
@@ -88,19 +88,11 @@ func NaiveDomain(settings model.Settings, inbound model.Inbound) string {
 	return settings.Domain
 }
 
-// NaiveEmail returns the ACME contact email for the inbound, preferring the
-// inbound ProtocolFields and falling back through the domain-level resolver
-// chain: settings email, default ACME email, and panel email.
-func NaiveEmail(settings model.Settings, inbound model.Inbound) string {
-	if e := stringField(inbound.ProtocolFields, "email"); e != "" {
-		return e
-	}
-	for _, candidate := range []string{settings.Email, settings.DefaultAcmeEmail, settings.PanelEmail} {
-		if v := strings.TrimSpace(candidate); v != "" {
-			return v
-		}
-	}
-	return ""
+// NaiveEmail returns the ACME contact email explicitly set on the inbound.
+// It does not fall back to global settings; callers that need the effective
+// email should resolve the domain-level chain themselves.
+func NaiveEmail(_ model.Settings, inbound model.Inbound) string {
+	return stringField(inbound.ProtocolFields, "email")
 }
 
 // NaivePublicPort returns the public port for the inbound, falling back to the

--- a/internal/protocols/naiveproxy/plugin.go
+++ b/internal/protocols/naiveproxy/plugin.go
@@ -78,3 +78,71 @@ func fallbackRoot(settings model.Settings, inbound model.Inbound) string {
 	}
 	return root
 }
+
+// NaiveDomain returns the public domain stored on the inbound ProtocolFields.
+func NaiveDomain(inbound model.Inbound) string {
+	return stringField(inbound.ProtocolFields, "domain")
+}
+
+// NaiveEmail returns the explicit ACME contact email stored on the inbound ProtocolFields.
+func NaiveEmail(inbound model.Inbound) string {
+	return stringField(inbound.ProtocolFields, "email")
+}
+
+// NaivePublicPort returns the public port for the inbound, falling back to the
+// inbound listen port, the global default inbound public port, and finally 443.
+func NaivePublicPort(settings model.Settings, inbound model.Inbound) int {
+	if v, ok := inbound.ProtocolFields["publicPort"]; ok {
+		if n, ok := v.(float64); ok {
+			return int(n)
+		}
+		if n, ok := v.(int); ok {
+			return n
+		}
+	}
+	if inbound.Port != 0 {
+		return inbound.Port
+	}
+	if settings.DefaultInboundPublicPort != 0 {
+		return settings.DefaultInboundPublicPort
+	}
+	return 443
+}
+
+// NaiveTransport returns the transport from the inbound ProtocolFields,
+// defaulting to "tcp" when unset.
+func NaiveTransport(inbound model.Inbound) string {
+	t := stringField(inbound.ProtocolFields, "transport")
+	if t == "" {
+		return "tcp"
+	}
+	return t
+}
+
+// NaiveFallbackRoot returns the fallback web root for the inbound, falling back
+// to the inbound-level fallback root, the global fallback root, and finally the
+// built-in default.
+func NaiveFallbackRoot(settings model.Settings, inbound model.Inbound) string {
+	root := stringField(inbound.ProtocolFields, "fallbackRoot")
+	if root == "" {
+		root = inbound.FallbackRoot
+	}
+	if root == "" {
+		root = settings.FallbackRoot
+	}
+	if root == "" {
+		root = "/var/lib/veil/www"
+	}
+	return root
+}
+
+func stringField(m map[string]any, key string) string {
+	if m == nil {
+		return ""
+	}
+	v, ok := m[key].(string)
+	if !ok {
+		return ""
+	}
+	return v
+}

--- a/internal/protocols/naiveproxy/plugin.go
+++ b/internal/protocols/naiveproxy/plugin.go
@@ -79,14 +79,28 @@ func fallbackRoot(settings model.Settings, inbound model.Inbound) string {
 	return root
 }
 
-// NaiveDomain returns the public domain stored on the inbound ProtocolFields.
-func NaiveDomain(inbound model.Inbound) string {
-	return stringField(inbound.ProtocolFields, "domain")
+// NaiveDomain returns the public domain for the inbound, preferring the inbound
+// ProtocolFields and falling back to the global settings domain.
+func NaiveDomain(settings model.Settings, inbound model.Inbound) string {
+	if d := stringField(inbound.ProtocolFields, "domain"); d != "" {
+		return d
+	}
+	return settings.Domain
 }
 
-// NaiveEmail returns the explicit ACME contact email stored on the inbound ProtocolFields.
-func NaiveEmail(inbound model.Inbound) string {
-	return stringField(inbound.ProtocolFields, "email")
+// NaiveEmail returns the ACME contact email for the inbound, preferring the
+// inbound ProtocolFields and falling back through the domain-level resolver
+// chain: settings email, default ACME email, and panel email.
+func NaiveEmail(settings model.Settings, inbound model.Inbound) string {
+	if e := stringField(inbound.ProtocolFields, "email"); e != "" {
+		return e
+	}
+	for _, candidate := range []string{settings.Email, settings.DefaultAcmeEmail, settings.PanelEmail} {
+		if v := strings.TrimSpace(candidate); v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 // NaivePublicPort returns the public port for the inbound, falling back to the

--- a/internal/protocols/naiveproxy/renderer.go
+++ b/internal/protocols/naiveproxy/renderer.go
@@ -1,166 +1,46 @@
 package naiveproxy
 
 import (
-	"fmt"
-	"net"
-	"strconv"
-	"strings"
-
-	"github.com/mikkelchokolate/Veil/internal/clientaccess"
+	"github.com/mikkelchokolate/Veil/internal/caddyassembly"
+	"github.com/mikkelchokolate/Veil/internal/caddycapabilities"
 	"github.com/mikkelchokolate/Veil/internal/generatedconfig"
-	"github.com/mikkelchokolate/Veil/internal/model"
 	"github.com/mikkelchokolate/Veil/internal/renderer"
-	veilsettings "github.com/mikkelchokolate/Veil/internal/settings"
 )
 
-// RenderConfig generates per-inbound Caddyfiles and a standalone panel Caddyfile.
+// RenderConfig generates the consolidated Caddy JSON config for all naiveproxy
+// inbounds (and panel access when panelAccess is caddy). The inbound/Caddy
+// redesign moves from per-inbound Caddyfiles to a single JSON config used by
+// veil-caddy.service.
 func (Plugin) RenderConfig(input generatedconfig.ProtocolRenderInput) ([]generatedconfig.GeneratedConfigArtifact, bool, error) {
 	if len(input.Inbounds) == 0 {
-		if input.Settings.PanelAccess == "caddy" {
-			body, err := renderPanelStandalone(input.Settings)
-			if err != nil {
-				return nil, false, err
-			}
-			if body != "" {
-				return []generatedconfig.GeneratedConfigArtifact{{Path: input.Paths.Generated("caddy/panel.Caddyfile"), Body: body}}, true, nil
-			}
-		}
 		return nil, false, nil
 	}
 
-	hasInboundOn443 := false
-	for _, inbound := range input.Inbounds {
-		if inbound.Port == 443 {
-			hasInboundOn443 = true
-			break
-		}
+	plan, _, err := caddyassembly.BuildRenderPlan(input.Settings, input.Inbounds, nil)
+	if err != nil {
+		return nil, false, err
 	}
 
-	var artifacts []generatedconfig.GeneratedConfigArtifact
-	for i, inbound := range input.Inbounds {
-		includePanel := false
-		if input.Settings.PanelAccess == "caddy" {
-			if inbound.Port == 443 || (!hasInboundOn443 && i == 0) {
-				includePanel = true
-			}
-		}
-		body, err := renderNaive(input.Settings, inbound, input.Warp, includePanel)
-		if err != nil {
-			return nil, false, err
-		}
-		subpath := "caddy/" + inbound.Name + ".Caddyfile"
-		artifacts = append(artifacts, generatedconfig.GeneratedConfigArtifact{
-			Path: input.Paths.Generated(subpath),
-			Body: body,
-		})
+	caps, _ := caddycapabilities.Probe("")
+	data, err := renderer.RenderCaddyJSON(plan, caps)
+	if err != nil {
+		return nil, false, err
 	}
-	return artifacts, true, nil
+
+	return []generatedconfig.GeneratedConfigArtifact{{
+		Path: input.Paths.CaddyJSON(),
+		Body: string(data),
+	}}, true, nil
 }
 
-// ArtifactSpec returns the artifact metadata for naiveproxy configs.
+// ArtifactSpec returns the artifact metadata for the consolidated Caddy JSON
+// config.
 func (Plugin) ArtifactSpec() generatedconfig.ArtifactSpec {
 	return generatedconfig.ArtifactSpec{
-		Subpath:        generatedconfig.CaddyfileSubpath,
+		Subpath:        generatedconfig.CaddyJSONConfigSubpath,
 		ValidationName: "caddy",
 		ValidationCommand: func(path string) []string {
-			return []string{"caddy", "validate", "--config", path}
+			return []string{"caddy", "validate", "--config", path, "--adapter", "json"}
 		},
 	}
-}
-
-func renderNaive(settings model.Settings, inbound model.Inbound, warp model.WarpConfig, includePanel bool) (string, error) {
-	var buf strings.Builder
-	buf.WriteString("{\n  order forward_proxy before file_server\n  servers {\n    protocols h1 h2\n  }\n}\n\n")
-
-	password := naivePassword(settings, inbound)
-	access, err := clientaccess.BuildClientAccess(settings, inbound)
-	if err != nil {
-		return "", err
-	}
-	username := naiveUsername(settings, inbound)
-	root := fallbackRoot(settings, inbound)
-
-	naiveConfig := renderer.NaiveConfig{
-		Domain:       settings.Domain,
-		Email:        settings.Email,
-		ListenPort:   inbound.Port,
-		Username:     username,
-		Password:     password,
-		Users:        access.NaiveUsers(),
-		FallbackRoot: root,
-	}
-	if warp.Enabled {
-		socksPort := warp.SocksPort
-		if socksPort == 0 {
-			socksPort = 40000
-		}
-		naiveConfig.Upstream = fmt.Sprintf("socks5://127.0.0.1:%d", socksPort)
-	}
-	if includePanel && settings.PanelAccess == "caddy" {
-		if route, ok, err := panelCaddyRoute(settings); err == nil && ok {
-			naiveConfig.PanelPort = route.Port
-			naiveConfig.WebBasePath = route.WebBasePath
-		}
-	}
-	block, err := renderer.RenderNaiveCaddyfile(naiveConfig)
-	if err != nil {
-		return "", err
-	}
-	if idx := strings.Index(block, "\n:"); idx != -1 {
-		block = block[idx+1:]
-	} else if idx := strings.Index(block, "\n"+settings.Domain); idx != -1 {
-		block = block[idx+1:]
-	}
-	buf.WriteString(block)
-	buf.WriteString("\n")
-	return buf.String(), nil
-}
-
-func renderPanelStandalone(settings model.Settings) (string, error) {
-	if settings.PanelAccess != "caddy" {
-		return "", nil
-	}
-	route, ok, err := panelCaddyRoute(settings)
-	if err != nil || !ok {
-		return "", err
-	}
-	var buf strings.Builder
-	buf.WriteString("{\n  order forward_proxy before file_server\n  servers {\n    protocols h1 h2\n  }\n}\n\n")
-
-	panelBlock, err := renderer.RenderPanelCaddyfile(renderer.PanelCaddyConfig{
-		Domain:      settings.Domain,
-		Email:       settings.Email,
-		PanelPort:   route.Port,
-		WebBasePath: route.WebBasePath,
-	})
-	if err != nil {
-		return "", err
-	}
-	buf.WriteString(panelBlock)
-	buf.WriteString("\n")
-	return buf.String(), nil
-}
-
-type caddyRoute struct {
-	Port        int
-	WebBasePath string
-}
-
-func panelCaddyRoute(settings model.Settings) (caddyRoute, bool, error) {
-	if settings.PanelAccess != "caddy" {
-		return caddyRoute{}, false, nil
-	}
-	webBasePath := veilsettings.NormalizeWebBasePath(settings.WebBasePath)
-	if webBasePath == "" {
-		return caddyRoute{}, false, fmt.Errorf("webBasePath is required for caddy Panel access")
-	}
-	_, portText, err := net.SplitHostPort(settings.PanelListen)
-	if err != nil {
-		return caddyRoute{}, false, fmt.Errorf("panelListen must be host:port")
-	}
-	port, err := strconv.Atoi(portText)
-	if err != nil || port <= 0 || port > 65535 {
-		return caddyRoute{}, false, fmt.Errorf("panelListen must be host:port")
-	}
-	return caddyRoute{Port: port, WebBasePath: webBasePath}, true, nil
 }

--- a/internal/protocols/naiveproxy/renderer.go
+++ b/internal/protocols/naiveproxy/renderer.go
@@ -45,7 +45,7 @@ func (Plugin) ArtifactSpec() generatedconfig.ArtifactSpec {
 		Subpath:        generatedconfig.CaddyJSONConfigSubpath,
 		ValidationName: "caddy",
 		ValidationCommand: func(path string) []string {
-			return []string{"caddy", "validate", "--config", path, "--adapter", "json"}
+			return []string{"caddy", "validate", "--config", path}
 		},
 	}
 }

--- a/internal/protocols/naiveproxy/renderer.go
+++ b/internal/protocols/naiveproxy/renderer.go
@@ -1,6 +1,8 @@
 package naiveproxy
 
 import (
+	"fmt"
+
 	"github.com/mikkelchokolate/Veil/internal/caddyassembly"
 	"github.com/mikkelchokolate/Veil/internal/caddycapabilities"
 	"github.com/mikkelchokolate/Veil/internal/generatedconfig"
@@ -16,12 +18,15 @@ func (Plugin) RenderConfig(input generatedconfig.ProtocolRenderInput) ([]generat
 		return nil, false, nil
 	}
 
-	plan, _, err := caddyassembly.BuildRenderPlan(input.Settings, input.Inbounds, nil)
+	plan, _, _, err := caddyassembly.BuildFinalRenderPlan(input.Settings, input.Inbounds)
 	if err != nil {
 		return nil, false, err
 	}
 
-	caps, _ := caddycapabilities.Probe("")
+	caps, err := caddycapabilities.Probe("")
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to probe Caddy capabilities: %w", err)
+	}
 	data, err := renderer.RenderCaddyJSON(plan, caps)
 	if err != nil {
 		return nil, false, err

--- a/internal/protocols/naiveproxy/runtime.go
+++ b/internal/protocols/naiveproxy/runtime.go
@@ -1,50 +1,35 @@
 package naiveproxy
 
 import (
+	"github.com/mikkelchokolate/Veil/internal/generatedconfig"
 	"github.com/mikkelchokolate/Veil/internal/model"
 	"github.com/mikkelchokolate/Veil/internal/runtimeinstall"
 	"github.com/mikkelchokolate/Veil/internal/service"
 )
 
-const templateUnit = "veil-caddy@.service"
+const templateUnit = "veil-caddy.service"
 
-// RuntimeDescriptors returns per-inbound caddy units for naiveproxy.
+// RuntimeDescriptors returns the single veil-caddy.service runtime for all
+// naiveproxy inbounds. The inbound/Caddy redesign consolidates Caddy into one
+// process backed by a single JSON config.
 func (p Plugin) RuntimeDescriptors(enabledInbounds []model.Inbound) []service.ManagedRuntime {
-	var runtimes []service.ManagedRuntime
-	count := 0
-	for _, inbound := range enabledInbounds {
-		if inbound.Protocol != p.Protocol() {
-			continue
+	for _, inb := range enabledInbounds {
+		if inb.Protocol == "naiveproxy" {
+			return []service.ManagedRuntime{{
+				Name:             "veil-caddy.service",
+				ActionName:       "caddy",
+				Protocol:         p.Protocol(),
+				Transport:        "tcp",
+				Unit:             "veil-caddy.service",
+				TemplateUnit:     templateUnit,
+				PromotedSubpath:  generatedconfig.CaddyJSONConfigSubpath,
+				PromotedVerb:     "reload",
+				ManualRestart:    true,
+				HealthCheckAfter: true,
+			}}
 		}
-		count++
-		runtimes = append(runtimes, service.ManagedRuntime{
-			Name:             "caddy-" + inbound.Name,
-			ActionName:       "caddy-" + inbound.Name,
-			Protocol:         p.Protocol(),
-			Transport:        "tcp",
-			Unit:             "veil-caddy@" + inbound.Name + ".service",
-			TemplateUnit:     templateUnit,
-			PromotedSubpath:  "caddy/" + inbound.Name + ".Caddyfile",
-			PromotedVerb:     "restart",
-			ManualRestart:    true,
-			HealthCheckAfter: true,
-		})
 	}
-	if count == 0 {
-		runtimes = append(runtimes, service.ManagedRuntime{
-			Name:             "caddy-panel",
-			ActionName:       "caddy-panel",
-			Protocol:         p.Protocol(),
-			Transport:        "tcp",
-			Unit:             "veil-caddy@panel.service",
-			TemplateUnit:     templateUnit,
-			PromotedSubpath:  "caddy/panel.Caddyfile",
-			PromotedVerb:     "restart",
-			ManualRestart:    true,
-			HealthCheckAfter: true,
-		})
-	}
-	return runtimes
+	return nil
 }
 
 // RuntimeInstall returns the Caddy-with-naive runtime descriptor.

--- a/internal/protocols/naiveproxy/ui.go
+++ b/internal/protocols/naiveproxy/ui.go
@@ -8,6 +8,10 @@ import (
 // InboundFieldSchema returns the dynamic fields for an inbound naiveproxy form.
 func (Plugin) InboundFieldSchema() []schema.FieldSchema {
 	return []schema.FieldSchema{
+		{Key: "domain", Label: "Domain", Type: schema.FieldText, Required: true, Placeholder: "Public domain used for TLS/SNI and client export.", Scope: "inbound"},
+		{Key: "email", Label: "ACME email", Type: schema.FieldText, Placeholder: "Optional explicit ACME contact for this domain.", Scope: "inbound"},
+		{Key: "publicPort", Label: "Public port", Type: schema.FieldNumber, Default: 443, Placeholder: "Port Caddy listens on for this inbound.", Scope: "inbound"},
+		{Key: "transport", Label: "Transport", Type: schema.FieldSelect, Required: true, Default: "tcp", Options: []schema.FieldOption{{Label: "tcp", Value: "tcp"}, {Label: "quic", Value: "quic"}, {Label: "dual", Value: "dual"}}, Placeholder: "tcp=HTTPS/H2, quic=HTTP/3/QUIC, dual=both.", Scope: "inbound"},
 		{Key: "naiveUsername", Label: "Naive Username", Type: schema.FieldText, Default: "veil", Scope: "inbound"},
 		{Key: "naivePassword", Label: "Naive Password", Type: schema.FieldPassword, GenerateAction: "password", Scope: "inbound"},
 		{Key: "fallbackRoot", Label: "Fallback Root", Type: schema.FieldText, Default: "/var/lib/veil/www", Scope: "inbound"},

--- a/internal/protocols/naiveproxy/ui.go
+++ b/internal/protocols/naiveproxy/ui.go
@@ -24,6 +24,10 @@ func (Plugin) SettingsFieldSchema() []schema.FieldSchema {
 		{Key: "naiveUsername", Label: "Naive Username", Type: schema.FieldText, Default: "veil", Scope: "settings"},
 		{Key: "naivePassword", Label: "Naive Password", Type: schema.FieldPassword, Scope: "settings"},
 		{Key: "fallbackRoot", Label: "Fallback Root", Type: schema.FieldText, Default: "/var/lib/veil/www", Scope: "settings"},
+		{Key: "panelAccess", Label: "Panel Access", Type: schema.FieldSelect, Default: "local", Options: []schema.FieldOption{{Label: "local", Value: "local"}, {Label: "direct", Value: "direct"}, {Label: "caddy", Value: "caddy"}}, Scope: "settings"},
+		{Key: "panelDomain", Label: "Panel Domain", Type: schema.FieldText, Scope: "settings", Placeholder: "Public domain used for Panel Caddy TLS/SNI."},
+		{Key: "panelEmail", Label: "Panel ACME Email", Type: schema.FieldText, Scope: "settings", Placeholder: "ACME contact email for Panel Caddy certificate."},
+		{Key: "panelPublicPort", Label: "Panel Public Port", Type: schema.FieldNumber, Default: 443, Scope: "settings", Placeholder: "Port Caddy listens on for Panel access."},
 	}
 }
 

--- a/internal/protocols/naiveproxy/ui.go
+++ b/internal/protocols/naiveproxy/ui.go
@@ -11,7 +11,7 @@ func (Plugin) InboundFieldSchema() []schema.FieldSchema {
 		{Key: "domain", Label: "Domain", Type: schema.FieldText, Required: true, Placeholder: "Public domain used for TLS/SNI and client export.", Scope: "inbound"},
 		{Key: "email", Label: "ACME email", Type: schema.FieldText, Placeholder: "Optional explicit ACME contact for this domain.", Scope: "inbound"},
 		{Key: "publicPort", Label: "Public port", Type: schema.FieldNumber, Default: 443, Placeholder: "Port Caddy listens on for this inbound.", Scope: "inbound"},
-		{Key: "transport", Label: "Transport", Type: schema.FieldSelect, Required: true, Default: "tcp", Options: []schema.FieldOption{{Label: "tcp", Value: "tcp"}, {Label: "quic", Value: "quic"}, {Label: "dual", Value: "dual"}}, Placeholder: "tcp=HTTPS/H2, quic=HTTP/3/QUIC, dual=both.", Scope: "inbound"},
+		{Key: "transport", Label: "Transport", Type: schema.FieldSelect, Required: true, Default: "tcp", Options: []schema.FieldOption{{Label: "tcp", Value: "tcp"}}, Placeholder: "tcp=HTTPS/H2.", Scope: "inbound"},
 		{Key: "naiveUsername", Label: "Naive Username", Type: schema.FieldText, Default: "veil", Scope: "inbound"},
 		{Key: "naivePassword", Label: "Naive Password", Type: schema.FieldPassword, GenerateAction: "password", Scope: "inbound"},
 		{Key: "fallbackRoot", Label: "Fallback Root", Type: schema.FieldText, Default: "/var/lib/veil/www", Scope: "inbound"},

--- a/internal/protocols/naiveproxy/validator.go
+++ b/internal/protocols/naiveproxy/validator.go
@@ -10,13 +10,9 @@ import (
 // dedicated receiver type while keeping the existing plugin interface intact.
 type Validator = Plugin
 
-// ValidateSettings ensures the global settings needed by naiveproxy are present.
-func (Plugin) ValidateSettings(settings model.Settings) error {
-	username := protocolString(settings.ProtocolFields, "naiveUsername", settings.NaiveUsername)
-	password := protocolString(settings.ProtocolFields, "naivePassword", settings.NaivePassword)
-	if strings.TrimSpace(settings.Domain) == "" || strings.TrimSpace(settings.Email) == "" || strings.TrimSpace(username) == "" || strings.TrimSpace(password) == "" {
-		return errNaiveCaddySettingsRequired{}
-	}
+// ValidateSettings is a no-op for naiveproxy. Per-inbound domain, email, and
+// credential validation are handled by ValidateInbound and the apply-plan builder.
+func (Plugin) ValidateSettings(model.Settings) error {
 	return nil
 }
 
@@ -86,8 +82,3 @@ func (p Plugin) HasCredential(settings model.Settings, inbound model.Inbound) bo
 	return username != "" && password != ""
 }
 
-type errNaiveCaddySettingsRequired struct{}
-
-func (errNaiveCaddySettingsRequired) Error() string {
-	return "domain, email, naive username, and naive password are required for NaiveProxy/Caddy"
-}

--- a/internal/protocols/naiveproxy/validator.go
+++ b/internal/protocols/naiveproxy/validator.go
@@ -23,7 +23,7 @@ func (Plugin) ValidateSettings(settings model.Settings) error {
 // ValidateInbound checks one inbound for naiveproxy-specific problems.
 func (p Plugin) ValidateInbound(settings model.Settings, inbound model.Inbound) []model.ValidationIssue {
 	var issues []model.ValidationIssue
-	domain := NaiveDomain(inbound)
+	domain := NaiveDomain(settings, inbound)
 	if domain == "" {
 		issues = append(issues, model.ValidationIssue{
 			Code:     "naive_domain_required",

--- a/internal/protocols/naiveproxy/validator.go
+++ b/internal/protocols/naiveproxy/validator.go
@@ -66,8 +66,15 @@ func (Plugin) NeedsDomain(model.Settings, model.Inbound) bool { return true }
 func (Plugin) NeedsEmail(model.Settings, model.Inbound) bool  { return true }
 
 func (p Plugin) HasCredential(settings model.Settings, inbound model.Inbound) bool {
+	hasExplicitlyEnabledProfile := false
 	for _, profile := range inbound.Profiles {
-		if !profile.Enabled || strings.TrimSpace(profile.Password) == "" {
+		if profile.Enabled {
+			hasExplicitlyEnabledProfile = true
+			break
+		}
+	}
+	for _, profile := range inbound.Profiles {
+		if (hasExplicitlyEnabledProfile && !profile.Enabled) || strings.TrimSpace(profile.Password) == "" {
 			continue
 		}
 		if strings.TrimSpace(profile.Username) != "" || strings.TrimSpace(profile.Name) != "" {

--- a/internal/protocols/naiveproxy/validator.go
+++ b/internal/protocols/naiveproxy/validator.go
@@ -6,6 +6,10 @@ import (
 	"github.com/mikkelchokolate/Veil/internal/model"
 )
 
+// Validator is an alias for Plugin so inbound validation can be invoked with a
+// dedicated receiver type while keeping the existing plugin interface intact.
+type Validator = Plugin
+
 // ValidateSettings ensures the global settings needed by naiveproxy are present.
 func (Plugin) ValidateSettings(settings model.Settings) error {
 	username := protocolString(settings.ProtocolFields, "naiveUsername", settings.NaiveUsername)
@@ -17,8 +21,51 @@ func (Plugin) ValidateSettings(settings model.Settings) error {
 }
 
 // ValidateInbound checks one inbound for naiveproxy-specific problems.
-func (Plugin) ValidateInbound(settings model.Settings, inbound model.Inbound) []model.ValidationIssue {
-	return nil
+func (p Plugin) ValidateInbound(settings model.Settings, inbound model.Inbound) []model.ValidationIssue {
+	var issues []model.ValidationIssue
+	domain := NaiveDomain(inbound)
+	if domain == "" {
+		issues = append(issues, model.ValidationIssue{
+			Code:     "naive_domain_required",
+			Severity: "error",
+			Field:    "domain",
+			Message:  "Naive inbound requires a public domain.",
+			Source:   "naiveproxy",
+		})
+	}
+	transport := NaiveTransport(inbound)
+	switch transport {
+	case "tcp", "quic", "dual":
+	default:
+		issues = append(issues, model.ValidationIssue{
+			Code:     "naive_transport_invalid",
+			Severity: "error",
+			Field:    "transport",
+			Message:  "transport must be tcp, quic, or dual",
+			Source:   "naiveproxy",
+		})
+	}
+	port := NaivePublicPort(settings, inbound)
+	if port < 1 || port > 65535 {
+		issues = append(issues, model.ValidationIssue{
+			Code:     "naive_public_port_invalid",
+			Severity: "error",
+			Field:    "publicPort",
+			Message:  "publicPort must be between 1 and 65535",
+			Source:   "naiveproxy",
+		})
+	}
+	// credential presence preserved from existing validator
+	if !p.HasCredential(settings, inbound) {
+		issues = append(issues, model.ValidationIssue{
+			Code:     "naive_credential_required",
+			Severity: "error",
+			Field:    "profiles",
+			Message:  "At least one username/password profile is required.",
+			Source:   "naiveproxy",
+		})
+	}
+	return issues
 }
 
 // NeedsDomain reports that naiveproxy needs a public domain.

--- a/internal/protocols/naiveproxy/validator.go
+++ b/internal/protocols/naiveproxy/validator.go
@@ -35,13 +35,13 @@ func (p Plugin) ValidateInbound(settings model.Settings, inbound model.Inbound) 
 	}
 	transport := NaiveTransport(inbound)
 	switch transport {
-	case "tcp", "quic", "dual":
+	case "tcp":
 	default:
 		issues = append(issues, model.ValidationIssue{
 			Code:     "naive_transport_invalid",
 			Severity: "error",
 			Field:    "transport",
-			Message:  "transport must be tcp, quic, or dual",
+			Message:  "NaiveProxy supports only the tcp transport in this release",
 			Source:   "naiveproxy",
 		})
 	}

--- a/internal/protocols/naiveproxy/validator_test.go
+++ b/internal/protocols/naiveproxy/validator_test.go
@@ -1,0 +1,36 @@
+package naiveproxy
+
+import (
+	"testing"
+
+	"github.com/mikkelchokolate/Veil/internal/model"
+)
+
+func TestValidateInboundMissingDomain(t *testing.T) {
+	v := Validator{}
+	issues := v.ValidateInbound(model.Settings{}, model.Inbound{Protocol: "naiveproxy", ProtocolFields: map[string]any{}})
+	if len(issues) == 0 {
+		t.Fatal("expected missing domain issue")
+	}
+}
+
+func TestValidateInboundInvalidTransport(t *testing.T) {
+	v := Validator{}
+	inbound := model.Inbound{
+		Protocol: "naiveproxy",
+		ProtocolFields: map[string]any{
+			"domain":    "x.com",
+			"transport": "udp",
+		},
+	}
+	issues := v.ValidateInbound(model.Settings{}, inbound)
+	found := false
+	for _, i := range issues {
+		if i.Field == "transport" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected invalid transport issue")
+	}
+}

--- a/internal/protocols/protocols_test.go
+++ b/internal/protocols/protocols_test.go
@@ -633,7 +633,7 @@ func TestGeneratedConfigRegistryFromMockRenderers(t *testing.T) {
 }
 
 func TestGeneratedConfigRegistryConstants(t *testing.T) {
-	if UnitCaddy != "veil-caddy@.service" {
+	if UnitCaddy != "veil-caddy.service" {
 		t.Fatalf("UnitCaddy = %q", UnitCaddy)
 	}
 	if UnitHysteria2 != "veil-hysteria2@.service" {

--- a/internal/renderer/caddy.go
+++ b/internal/renderer/caddy.go
@@ -3,9 +3,6 @@ package renderer
 import (
 	"bytes"
 	"errors"
-	"fmt"
-	"path/filepath"
-	"strings"
 	"text/template"
 )
 
@@ -45,19 +42,11 @@ func RenderNaiveCaddyfile(cfg NaiveConfig) (string, error) {
 			return "", errors.New("naive username and password are required")
 		}
 	}
-	if cfg.FallbackRoot == "" {
-		cfg.FallbackRoot = "/var/lib/veil/www"
+	fallbackRoot, err := resolveNaiveFallbackRoot(cfg.FallbackRoot)
+	if err != nil {
+		return "", err
 	}
-	// Validate FallbackRoot is within /var/lib/veil to prevent path traversal.
-	cfg.FallbackRoot = filepath.Clean(cfg.FallbackRoot)
-	// Use ToSlash for platform-independent path manipulation.
-	if !strings.HasPrefix(filepath.ToSlash(cfg.FallbackRoot), "/var/lib/veil") {
-		cfg.FallbackRoot = filepath.Clean("/var/lib/veil/" + cfg.FallbackRoot)
-	}
-	if !strings.HasPrefix(filepath.ToSlash(cfg.FallbackRoot), "/var/lib/veil") {
-		return "", fmt.Errorf("fallback root must be within /var/lib/veil: %s", cfg.FallbackRoot)
-	}
-	cfg.FallbackRoot = filepath.ToSlash(cfg.FallbackRoot)
+	cfg.FallbackRoot = fallbackRoot
 	const tpl = `{
   order forward_proxy before file_server
   servers {

--- a/internal/renderer/caddy_test.go
+++ b/internal/renderer/caddy_test.go
@@ -152,10 +152,14 @@ func TestRenderNaiveCaddyfileNormalizesPaths(t *testing.T) {
 		fallbackRoot string
 		wantOk       bool
 	}{
-		{"FallbackRoot=/etc/passwd normalizes into /var/lib/veil", "/etc/passwd", true},
-		{"FallbackRoot=/var/lib/veil/../../../etc/passwd normalizes into /var/lib/veil", "/var/lib/veil/../../../etc/passwd", true},
+		{"FallbackRoot=/etc/passwd rejects outside /var/lib/veil", "/etc/passwd", false},
+		{"FallbackRoot=/var/lib/veil2 rejects boundary prefix", "/var/lib/veil2", false},
+		{"FallbackRoot=/var/lib/veil-evil rejects boundary prefix", "/var/lib/veil-evil", false},
+		{"FallbackRoot=/var/lib/veil/../../../etc/passwd rejects escape", "/var/lib/veil/../../../etc/passwd", false},
 		{"FallbackRoot=/var/lib/veil/www unchanged", "/var/lib/veil/www", true},
+		{"FallbackRoot=/var/lib/veil accepted exactly", "/var/lib/veil", true},
 		{"FallbackRoot empty uses default", "", true},
+		{"FallbackRoot relative resolves under /var/lib/veil", "custom", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/renderer/caddyjson.go
+++ b/internal/renderer/caddyjson.go
@@ -99,6 +99,9 @@ func renderServer(key bindregistry.BindKey, owner caddyassembly.CaddyBindOwner, 
 		"listen":     []string{listenString(key)},
 		"auto_https": map[string]any{"disable_redirects": true},
 	}
+	if owner.Kind == caddyassembly.CaddyOwnerNaive {
+		server["protocols"] = protocolsForTransport(owner.Transport)
+	}
 	switch owner.Kind {
 	case caddyassembly.CaddyOwnerPanel:
 		server["routes"] = panelRoutes(owner.Domain, owner.BackendPort, owner.WebBasePath)
@@ -106,6 +109,10 @@ func renderServer(key bindregistry.BindKey, owner caddyassembly.CaddyBindOwner, 
 		basicAuth := make([]map[string]any, 0, len(owner.NaiveUsers))
 		for _, u := range owner.NaiveUsers {
 			basicAuth = append(basicAuth, map[string]any{"username": u.Username, "password": u.Password})
+		}
+		fallbackRoot := owner.FallbackRoot
+		if fallbackRoot == "" {
+			fallbackRoot = "/var/lib/veil/www"
 		}
 		handlers := []map[string]any{
 			{
@@ -117,12 +124,25 @@ func renderServer(key bindregistry.BindKey, owner caddyassembly.CaddyBindOwner, 
 			},
 			{
 				"handler": "file_server",
-				"root":    "/var/lib/veil/www",
+				"root":    fallbackRoot,
 			},
 		}
 		server["routes"] = []map[string]any{{"handle": handlers}}
 	}
 	return server
+}
+
+func protocolsForTransport(transport string) []string {
+	switch transport {
+	case "tcp":
+		return []string{"h1", "h2"}
+	case "quic":
+		return []string{"h3"}
+	case "dual":
+		return []string{"h1", "h2", "h3"}
+	default:
+		return []string{"h1", "h2"}
+	}
 }
 
 func renderAcmeChallengeServer(key bindregistry.BindKey, owner caddyassembly.AcmeChallengeOwner) map[string]any {

--- a/internal/renderer/caddyjson.go
+++ b/internal/renderer/caddyjson.go
@@ -1,0 +1,88 @@
+package renderer
+
+import (
+	"encoding/json"
+	"strconv"
+
+	"github.com/mikkelchokolate/Veil/internal/bindregistry"
+	"github.com/mikkelchokolate/Veil/internal/caddyassembly"
+	"github.com/mikkelchokolate/Veil/internal/caddycapabilities"
+)
+
+func RenderCaddyJSON(plan caddyassembly.CaddyRenderPlan, caps caddycapabilities.CaddyCapabilities) ([]byte, error) {
+	cfg := caddyConfig{Apps: map[string]any{}}
+	cfg.Apps["http"] = renderHTTPApp(plan, caps)
+	cfg.Apps["tls"] = renderTLSApp(plan)
+	return json.MarshalIndent(cfg, "", "  ")
+}
+
+type caddyConfig struct {
+	Apps map[string]any `json:"apps"`
+}
+
+func renderHTTPApp(plan caddyassembly.CaddyRenderPlan, caps caddycapabilities.CaddyCapabilities) map[string]any {
+	servers := make(map[string]any)
+	for key, owner := range plan.Servers {
+		serverName := serverNameFor(key)
+		servers[serverName] = renderServer(key, owner, caps)
+	}
+	for key, owner := range plan.ACMEChallenges {
+		serverName := serverNameFor(key) + "-acme"
+		servers[serverName] = renderAcmeChallengeServer(key, owner)
+	}
+	return map[string]any{"servers": servers}
+}
+
+func renderTLSApp(plan caddyassembly.CaddyRenderPlan) map[string]any {
+	byIssuer := make(map[string][]string)
+	for _, spec := range plan.Domains {
+		issuerKey := spec.Email + "/" + challengeForDomain(plan, spec.Domain)
+		byIssuer[issuerKey] = append(byIssuer[issuerKey], spec.Domain)
+	}
+	var policies []map[string]any
+	for _, domains := range byIssuer {
+		policies = append(policies, map[string]any{
+			"subjects": domains,
+			"issuer":   map[string]any{"email": domains[0], "module": "acme"},
+		})
+	}
+	return map[string]any{"automation": map[string]any{"policies": policies}}
+}
+
+func renderServer(key bindregistry.BindKey, owner caddyassembly.CaddyBindOwner, caps caddycapabilities.CaddyCapabilities) map[string]any {
+	// Naive server: no host matcher, forward_proxy first, file_server fallback.
+	// Panel server: host matcher, reverse_proxy to panel loopback.
+	// Implementation expanded in Task 11.
+	return map[string]any{
+		"listen": []string{listenString(key)},
+		"routes": []map[string]any{},
+	}
+}
+
+func renderAcmeChallengeServer(key bindregistry.BindKey, owner caddyassembly.AcmeChallengeOwner) map[string]any {
+	return map[string]any{
+		"listen": []string{listenString(key)},
+		"routes": []map[string]any{},
+	}
+}
+
+func serverNameFor(key bindregistry.BindKey) string {
+	return string(key.Network) + "-" + key.Address + "-" + portString(key.Port)
+}
+
+func listenString(key bindregistry.BindKey) string {
+	return ":" + portString(key.Port)
+}
+
+func portString(p int) string { return strconv.Itoa(p) }
+
+func challengeForDomain(plan caddyassembly.CaddyRenderPlan, domain string) string {
+	for _, owner := range plan.ACMEChallenges {
+		for _, d := range owner.Domains {
+			if d == domain {
+				return owner.ChallengeMode
+			}
+		}
+	}
+	return "tls-alpn-01"
+}

--- a/internal/renderer/caddyjson.go
+++ b/internal/renderer/caddyjson.go
@@ -35,9 +35,6 @@ func validateCaddyCapabilities(plan caddyassembly.CaddyRenderPlan, caps caddycap
 				return fmt.Errorf("Caddy binary does not support HTTP/3/QUIC transport required for NaiveProxy transport %s", owner.Transport)
 			}
 		}
-		if owner.Transport == "quic" && !caps.H3Only {
-			return fmt.Errorf("Caddy binary does not support HTTP/3/QUIC transport required for NaiveProxy transport %s", owner.Transport)
-		}
 	}
 	return nil
 }

--- a/internal/renderer/caddyjson.go
+++ b/internal/renderer/caddyjson.go
@@ -1,6 +1,7 @@
 package renderer
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -21,7 +22,7 @@ func RenderCaddyJSON(plan caddyassembly.CaddyRenderPlan, caps caddycapabilities.
 	if err != nil {
 		return nil, err
 	}
-	cfg := caddyConfig{Apps: map[string]any{}}
+	cfg := caddyConfig{Admin: map[string]any{"listen": "127.0.0.1:2019"}, Apps: map[string]any{}}
 	cfg.Apps["http"] = httpApp
 	cfg.Apps["tls"] = renderTLSApp(plan)
 	return json.MarshalIndent(cfg, "", "  ")
@@ -40,7 +41,8 @@ func validateCaddyCapabilities(plan caddyassembly.CaddyRenderPlan, caps caddycap
 }
 
 type caddyConfig struct {
-	Apps map[string]any `json:"apps"`
+	Admin map[string]any `json:"admin"`
+	Apps  map[string]any `json:"apps"`
 }
 
 func renderHTTPApp(plan caddyassembly.CaddyRenderPlan, caps caddycapabilities.CaddyCapabilities) (map[string]any, error) {
@@ -100,8 +102,8 @@ func renderACMEIssuer(email, mode string) map[string]any {
 
 func renderServer(key bindregistry.BindKey, owner caddyassembly.CaddyBindOwner, caps caddycapabilities.CaddyCapabilities) (map[string]any, error) {
 	server := map[string]any{
-		"listen":     []string{listenString(key)},
-		"auto_https": map[string]any{"disable_redirects": true},
+		"listen":          []string{listenString(key)},
+		"automatic_https": map[string]any{"disable_redirects": true},
 	}
 	if owner.Kind == caddyassembly.CaddyOwnerNaive {
 		protocols, err := protocolsForTransport(owner.Transport)
@@ -114,9 +116,9 @@ func renderServer(key bindregistry.BindKey, owner caddyassembly.CaddyBindOwner, 
 	case caddyassembly.CaddyOwnerPanel:
 		server["routes"] = panelRoutes(owner.Domain, owner.BackendPort, owner.WebBasePath)
 	case caddyassembly.CaddyOwnerNaive:
-		basicAuth := make([]map[string]any, 0, len(owner.NaiveUsers))
+		authCreds := make([]string, 0, len(owner.NaiveUsers))
 		for _, u := range owner.NaiveUsers {
-			basicAuth = append(basicAuth, map[string]any{"username": u.Username, "password": u.Password})
+			authCreds = append(authCreds, base64.StdEncoding.EncodeToString([]byte(u.Username+":"+u.Password)))
 		}
 		fallbackRoot, err := resolveNaiveFallbackRoot(owner.FallbackRoot)
 		if err != nil {
@@ -125,7 +127,7 @@ func renderServer(key bindregistry.BindKey, owner caddyassembly.CaddyBindOwner, 
 		handlers := []map[string]any{
 			{
 				"handler":          "forward_proxy",
-				"basic_auth":       basicAuth,
+				"auth_credentials": authCreds,
 				"hide_ip":          true,
 				"hide_via":         true,
 				"probe_resistance": map[string]any{},
@@ -168,9 +170,9 @@ func resolveNaiveFallbackRoot(input string) (string, error) {
 
 func renderAcmeChallengeServer(key bindregistry.BindKey, owner caddyassembly.AcmeChallengeOwner) map[string]any {
 	return map[string]any{
-		"listen":     []string{listenString(key)},
-		"auto_https": map[string]any{"disable_redirects": true},
-		"routes":     []map[string]any{},
+		"listen":          []string{listenString(key)},
+		"automatic_https": map[string]any{"disable_redirects": true},
+		"routes":          []map[string]any{},
 	}
 }
 
@@ -191,13 +193,13 @@ func panelRoutes(domain string, backendPort int, webBasePath string) []map[strin
 		{
 			"match": []map[string]any{{"host": []string{domain}, "path": []string{webBasePath}}},
 			"handle": []map[string]any{{
-				"handler": "static_response",
-				"headers": map[string]any{"Location": []string{webBasePathSlash}},
+				"handler":     "static_response",
+				"headers":     map[string]any{"Location": []string{webBasePathSlash}},
 				"status_code": 308,
 			}},
 		},
 		{
-			"match": []map[string]any{{"host": []string{domain}, "path": []string{webBasePathSlash + "*"}}},
+			"match":  []map[string]any{{"host": []string{domain}, "path": []string{webBasePathSlash + "*"}}},
 			"handle": []map[string]any{proxy},
 		},
 		{

--- a/internal/renderer/caddyjson.go
+++ b/internal/renderer/caddyjson.go
@@ -118,19 +118,10 @@ func renderServer(key bindregistry.BindKey, owner caddyassembly.CaddyBindOwner, 
 		for _, u := range owner.NaiveUsers {
 			basicAuth = append(basicAuth, map[string]any{"username": u.Username, "password": u.Password})
 		}
-		fallbackRoot := owner.FallbackRoot
-		if fallbackRoot == "" {
-			fallbackRoot = "/var/lib/veil/www"
+		fallbackRoot, err := resolveNaiveFallbackRoot(owner.FallbackRoot)
+		if err != nil {
+			return nil, err
 		}
-		// Validate FallbackRoot is within /var/lib/veil to prevent path traversal.
-		fallbackRoot = filepath.Clean(fallbackRoot)
-		if !strings.HasPrefix(filepath.ToSlash(fallbackRoot), "/var/lib/veil") {
-			fallbackRoot = filepath.Clean("/var/lib/veil/" + fallbackRoot)
-		}
-		if !strings.HasPrefix(filepath.ToSlash(fallbackRoot), "/var/lib/veil") {
-			return nil, fmt.Errorf("fallback root must be within /var/lib/veil: %s", fallbackRoot)
-		}
-		fallbackRoot = filepath.ToSlash(fallbackRoot)
 		handlers := []map[string]any{
 			{
 				"handler":          "forward_proxy",
@@ -156,6 +147,23 @@ func protocolsForTransport(transport string) ([]string, error) {
 	default:
 		return nil, fmt.Errorf("unsupported naive transport %q", transport)
 	}
+}
+
+// resolveNaiveFallbackRoot validates and normalizes the naive fallback root.
+// It must be either exactly /var/lib/veil or a subdirectory of it.
+// Relative paths are resolved against /var/lib/veil.
+func resolveNaiveFallbackRoot(input string) (string, error) {
+	if input == "" {
+		return "/var/lib/veil/www", nil
+	}
+	root := filepath.ToSlash(filepath.Clean(input))
+	if !strings.HasPrefix(root, "/") {
+		root = filepath.ToSlash(filepath.Clean("/var/lib/veil/" + root))
+	}
+	if root != "/var/lib/veil" && !strings.HasPrefix(root, "/var/lib/veil/") {
+		return "", fmt.Errorf("fallback root must be within /var/lib/veil: %s", root)
+	}
+	return root, nil
 }
 
 func renderAcmeChallengeServer(key bindregistry.BindKey, owner caddyassembly.AcmeChallengeOwner) map[string]any {

--- a/internal/renderer/caddyjson.go
+++ b/internal/renderer/caddyjson.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -121,6 +122,15 @@ func renderServer(key bindregistry.BindKey, owner caddyassembly.CaddyBindOwner, 
 		if fallbackRoot == "" {
 			fallbackRoot = "/var/lib/veil/www"
 		}
+		// Validate FallbackRoot is within /var/lib/veil to prevent path traversal.
+		fallbackRoot = filepath.Clean(fallbackRoot)
+		if !strings.HasPrefix(filepath.ToSlash(fallbackRoot), "/var/lib/veil") {
+			fallbackRoot = filepath.Clean("/var/lib/veil/" + fallbackRoot)
+		}
+		if !strings.HasPrefix(filepath.ToSlash(fallbackRoot), "/var/lib/veil") {
+			return nil, fmt.Errorf("fallback root must be within /var/lib/veil: %s", fallbackRoot)
+		}
+		fallbackRoot = filepath.ToSlash(fallbackRoot)
 		handlers := []map[string]any{
 			{
 				"handler":          "forward_proxy",

--- a/internal/renderer/caddyjson.go
+++ b/internal/renderer/caddyjson.go
@@ -2,6 +2,7 @@ package renderer
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
 	"strconv"
 	"strings"
@@ -12,10 +13,33 @@ import (
 )
 
 func RenderCaddyJSON(plan caddyassembly.CaddyRenderPlan, caps caddycapabilities.CaddyCapabilities) ([]byte, error) {
+	if err := validateCaddyCapabilities(plan, caps); err != nil {
+		return nil, err
+	}
 	cfg := caddyConfig{Apps: map[string]any{}}
 	cfg.Apps["http"] = renderHTTPApp(plan, caps)
 	cfg.Apps["tls"] = renderTLSApp(plan)
 	return json.MarshalIndent(cfg, "", "  ")
+}
+
+func validateCaddyCapabilities(plan caddyassembly.CaddyRenderPlan, caps caddycapabilities.CaddyCapabilities) error {
+	for _, owner := range plan.Servers {
+		if owner.Kind != caddyassembly.CaddyOwnerNaive {
+			continue
+		}
+		if !caps.ForwardProxy {
+			return fmt.Errorf("Caddy binary does not include the forward_proxy module required for NaiveProxy")
+		}
+		if owner.Transport == "quic" || owner.Transport == "dual" {
+			if !caps.H3Only || !caps.HTTP3 {
+				return fmt.Errorf("Caddy binary does not support HTTP/3/QUIC transport required for NaiveProxy transport %s", owner.Transport)
+			}
+		}
+		if owner.Transport == "quic" && !caps.H3Only {
+			return fmt.Errorf("Caddy binary does not support HTTP/3/QUIC transport required for NaiveProxy transport %s", owner.Transport)
+		}
+	}
+	return nil
 }
 
 type caddyConfig struct {

--- a/internal/renderer/caddyjson.go
+++ b/internal/renderer/caddyjson.go
@@ -34,7 +34,7 @@ func validateCaddyCapabilities(plan caddyassembly.CaddyRenderPlan, caps caddycap
 			continue
 		}
 		if !caps.ForwardProxy {
-			return fmt.Errorf("Caddy binary does not include the forward_proxy module required for NaiveProxy")
+			return fmt.Errorf("caddy binary does not include the forward_proxy module required for NaiveProxy")
 		}
 	}
 	return nil

--- a/internal/renderer/caddyjson.go
+++ b/internal/renderer/caddyjson.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net"
 	"strconv"
+	"strings"
 
 	"github.com/mikkelchokolate/Veil/internal/bindregistry"
 	"github.com/mikkelchokolate/Veil/internal/caddyassembly"
@@ -79,18 +80,7 @@ func renderServer(key bindregistry.BindKey, owner caddyassembly.CaddyBindOwner, 
 	}
 	switch owner.Kind {
 	case caddyassembly.CaddyOwnerPanel:
-		server["routes"] = []map[string]any{
-			{
-				"match": []map[string]any{{"host": []string{owner.Domain}}},
-				"handle": []map[string]any{{
-					"handler":   "reverse_proxy",
-					"upstreams": []map[string]any{{"dial": "127.0.0.1:8080"}},
-				}},
-			},
-			{
-				"handle": []map[string]any{{"handler": "static_response", "status_code": 404}},
-			},
-		}
+		server["routes"] = panelRoutes(owner.Domain, owner.BackendPort, owner.WebBasePath)
 	case caddyassembly.CaddyOwnerNaive:
 		handlers := []map[string]any{
 			{
@@ -115,6 +105,38 @@ func renderAcmeChallengeServer(key bindregistry.BindKey, owner caddyassembly.Acm
 		"listen":     []string{listenString(key)},
 		"auto_https": map[string]any{"disable_redirects": true},
 		"routes":     []map[string]any{},
+	}
+}
+
+func panelRoutes(domain string, backendPort int, webBasePath string) []map[string]any {
+	proxy := map[string]any{
+		"handler":   "reverse_proxy",
+		"upstreams": []map[string]any{{"dial": "127.0.0.1:" + portString(backendPort)}},
+	}
+	if webBasePath == "" || webBasePath == "/" {
+		return []map[string]any{
+			{"match": []map[string]any{{"host": []string{domain}}}, "handle": []map[string]any{proxy}},
+			{"handle": []map[string]any{{"handler": "static_response", "status_code": 404}}},
+		}
+	}
+	webBasePath = strings.TrimRight(webBasePath, "/")
+	webBasePathSlash := webBasePath + "/"
+	return []map[string]any{
+		{
+			"match": []map[string]any{{"host": []string{domain}, "path": []string{webBasePath}}},
+			"handle": []map[string]any{{
+				"handler": "static_response",
+				"headers": map[string]any{"Location": []string{webBasePathSlash}},
+				"status_code": 308,
+			}},
+		},
+		{
+			"match": []map[string]any{{"host": []string{domain}, "path": []string{webBasePathSlash + "*"}}},
+			"handle": []map[string]any{proxy},
+		},
+		{
+			"handle": []map[string]any{{"handler": "static_response", "status_code": 404}},
+		},
 	}
 }
 

--- a/internal/renderer/caddyjson.go
+++ b/internal/renderer/caddyjson.go
@@ -55,7 +55,7 @@ func renderTLSApp(plan caddyassembly.CaddyRenderPlan) map[string]any {
 	for _, g := range groups {
 		policies = append(policies, map[string]any{
 			"subjects": g.domains,
-			"issuer":   renderACMEIssuer(g.email, g.mode),
+			"issuers":  []map[string]any{renderACMEIssuer(g.email, g.mode)},
 		})
 	}
 	return map[string]any{"automation": map[string]any{"policies": policies}}
@@ -66,8 +66,8 @@ func renderACMEIssuer(email, mode string) map[string]any {
 		"module": "acme",
 		"email":  email,
 		"challenges": map[string]any{
-			"http-01":     map[string]any{"disabled": mode != "http-01"},
-			"tls-alpn-01": map[string]any{"disabled": mode != "tls-alpn-01"},
+			"http":     map[string]any{"disabled": mode != "http-01"},
+			"tls-alpn": map[string]any{"disabled": mode != "tls-alpn-01"},
 		},
 	}
 }

--- a/internal/renderer/caddyjson.go
+++ b/internal/renderer/caddyjson.go
@@ -82,10 +82,14 @@ func renderServer(key bindregistry.BindKey, owner caddyassembly.CaddyBindOwner, 
 	case caddyassembly.CaddyOwnerPanel:
 		server["routes"] = panelRoutes(owner.Domain, owner.BackendPort, owner.WebBasePath)
 	case caddyassembly.CaddyOwnerNaive:
+		basicAuth := make([]map[string]any, 0, len(owner.NaiveUsers))
+		for _, u := range owner.NaiveUsers {
+			basicAuth = append(basicAuth, map[string]any{"username": u.Username, "password": u.Password})
+		}
 		handlers := []map[string]any{
 			{
 				"handler":          "forward_proxy",
-				"basic_auth":       []map[string]any{}, // populated from inbound profiles in Task 15
+				"basic_auth":       basicAuth,
 				"hide_ip":          true,
 				"hide_via":         true,
 				"probe_resistance": map[string]any{},
@@ -160,6 +164,9 @@ func challengeForDomain(plan caddyassembly.CaddyRenderPlan, domain string) strin
 				return owner.ChallengeMode
 			}
 		}
+	}
+	if plan.DefaultChallengeMode != "" {
+		return plan.DefaultChallengeMode
 	}
 	return "tls-alpn-01"
 }

--- a/internal/renderer/caddyjson.go
+++ b/internal/renderer/caddyjson.go
@@ -2,6 +2,7 @@ package renderer
 
 import (
 	"encoding/json"
+	"net"
 	"strconv"
 
 	"github.com/mikkelchokolate/Veil/internal/bindregistry"
@@ -34,35 +35,86 @@ func renderHTTPApp(plan caddyassembly.CaddyRenderPlan, caps caddycapabilities.Ca
 }
 
 func renderTLSApp(plan caddyassembly.CaddyRenderPlan) map[string]any {
-	byIssuer := make(map[string][]string)
+	type issuerGroup struct {
+		email   string
+		mode    string
+		domains []string
+	}
+	groups := make(map[string]*issuerGroup)
 	for _, spec := range plan.Domains {
-		issuerKey := spec.Email + "/" + challengeForDomain(plan, spec.Domain)
-		byIssuer[issuerKey] = append(byIssuer[issuerKey], spec.Domain)
+		mode := challengeForDomain(plan, spec.Domain)
+		issuerKey := spec.Email + "/" + mode
+		g := groups[issuerKey]
+		if g == nil {
+			g = &issuerGroup{email: spec.Email, mode: mode}
+			groups[issuerKey] = g
+		}
+		g.domains = append(g.domains, spec.Domain)
 	}
 	var policies []map[string]any
-	for _, domains := range byIssuer {
+	for _, g := range groups {
 		policies = append(policies, map[string]any{
-			"subjects": domains,
-			"issuer":   map[string]any{"email": domains[0], "module": "acme"},
+			"subjects": g.domains,
+			"issuer":   renderACMEIssuer(g.email, g.mode),
 		})
 	}
 	return map[string]any{"automation": map[string]any{"policies": policies}}
 }
 
-func renderServer(key bindregistry.BindKey, owner caddyassembly.CaddyBindOwner, caps caddycapabilities.CaddyCapabilities) map[string]any {
-	// Naive server: no host matcher, forward_proxy first, file_server fallback.
-	// Panel server: host matcher, reverse_proxy to panel loopback.
-	// Implementation expanded in Task 11.
+func renderACMEIssuer(email, mode string) map[string]any {
 	return map[string]any{
-		"listen": []string{listenString(key)},
-		"routes": []map[string]any{},
+		"module": "acme",
+		"email":  email,
+		"challenges": map[string]any{
+			"http-01":     map[string]any{"disabled": mode != "http-01"},
+			"tls-alpn-01": map[string]any{"disabled": mode != "tls-alpn-01"},
+		},
 	}
+}
+
+func renderServer(key bindregistry.BindKey, owner caddyassembly.CaddyBindOwner, caps caddycapabilities.CaddyCapabilities) map[string]any {
+	server := map[string]any{
+		"listen":     []string{listenString(key)},
+		"auto_https": map[string]any{"disable_redirects": true},
+	}
+	switch owner.Kind {
+	case caddyassembly.CaddyOwnerPanel:
+		server["routes"] = []map[string]any{
+			{
+				"match": []map[string]any{{"host": []string{owner.Domain}}},
+				"handle": []map[string]any{{
+					"handler":   "reverse_proxy",
+					"upstreams": []map[string]any{{"dial": "127.0.0.1:8080"}},
+				}},
+			},
+			{
+				"handle": []map[string]any{{"handler": "static_response", "status_code": 404}},
+			},
+		}
+	case caddyassembly.CaddyOwnerNaive:
+		handlers := []map[string]any{
+			{
+				"handler":          "forward_proxy",
+				"basic_auth":       []map[string]any{}, // populated from inbound profiles in Task 15
+				"hide_ip":          true,
+				"hide_via":         true,
+				"probe_resistance": map[string]any{},
+			},
+			{
+				"handler": "file_server",
+				"root":    "/var/lib/veil/www",
+			},
+		}
+		server["routes"] = []map[string]any{{"handle": handlers}}
+	}
+	return server
 }
 
 func renderAcmeChallengeServer(key bindregistry.BindKey, owner caddyassembly.AcmeChallengeOwner) map[string]any {
 	return map[string]any{
-		"listen": []string{listenString(key)},
-		"routes": []map[string]any{},
+		"listen":     []string{listenString(key)},
+		"auto_https": map[string]any{"disable_redirects": true},
+		"routes":     []map[string]any{},
 	}
 }
 
@@ -71,7 +123,10 @@ func serverNameFor(key bindregistry.BindKey) string {
 }
 
 func listenString(key bindregistry.BindKey) string {
-	return ":" + portString(key.Port)
+	if bindregistry.IsWildcard(key.Address) {
+		return ":" + portString(key.Port)
+	}
+	return net.JoinHostPort(key.Address, portString(key.Port))
 }
 
 func portString(p int) string { return strconv.Itoa(p) }

--- a/internal/renderer/caddyjson.go
+++ b/internal/renderer/caddyjson.go
@@ -16,8 +16,12 @@ func RenderCaddyJSON(plan caddyassembly.CaddyRenderPlan, caps caddycapabilities.
 	if err := validateCaddyCapabilities(plan, caps); err != nil {
 		return nil, err
 	}
+	httpApp, err := renderHTTPApp(plan, caps)
+	if err != nil {
+		return nil, err
+	}
 	cfg := caddyConfig{Apps: map[string]any{}}
-	cfg.Apps["http"] = renderHTTPApp(plan, caps)
+	cfg.Apps["http"] = httpApp
 	cfg.Apps["tls"] = renderTLSApp(plan)
 	return json.MarshalIndent(cfg, "", "  ")
 }
@@ -30,11 +34,6 @@ func validateCaddyCapabilities(plan caddyassembly.CaddyRenderPlan, caps caddycap
 		if !caps.ForwardProxy {
 			return fmt.Errorf("Caddy binary does not include the forward_proxy module required for NaiveProxy")
 		}
-		if owner.Transport == "quic" || owner.Transport == "dual" {
-			if !caps.H3Only || !caps.HTTP3 {
-				return fmt.Errorf("Caddy binary does not support HTTP/3/QUIC transport required for NaiveProxy transport %s", owner.Transport)
-			}
-		}
 	}
 	return nil
 }
@@ -43,17 +42,21 @@ type caddyConfig struct {
 	Apps map[string]any `json:"apps"`
 }
 
-func renderHTTPApp(plan caddyassembly.CaddyRenderPlan, caps caddycapabilities.CaddyCapabilities) map[string]any {
+func renderHTTPApp(plan caddyassembly.CaddyRenderPlan, caps caddycapabilities.CaddyCapabilities) (map[string]any, error) {
 	servers := make(map[string]any)
 	for key, owner := range plan.Servers {
 		serverName := serverNameFor(key)
-		servers[serverName] = renderServer(key, owner, caps)
+		server, err := renderServer(key, owner, caps)
+		if err != nil {
+			return nil, err
+		}
+		servers[serverName] = server
 	}
 	for key, owner := range plan.ACMEChallenges {
 		serverName := serverNameFor(key) + "-acme"
 		servers[serverName] = renderAcmeChallengeServer(key, owner)
 	}
-	return map[string]any{"servers": servers}
+	return map[string]any{"servers": servers}, nil
 }
 
 func renderTLSApp(plan caddyassembly.CaddyRenderPlan) map[string]any {
@@ -94,13 +97,17 @@ func renderACMEIssuer(email, mode string) map[string]any {
 	}
 }
 
-func renderServer(key bindregistry.BindKey, owner caddyassembly.CaddyBindOwner, caps caddycapabilities.CaddyCapabilities) map[string]any {
+func renderServer(key bindregistry.BindKey, owner caddyassembly.CaddyBindOwner, caps caddycapabilities.CaddyCapabilities) (map[string]any, error) {
 	server := map[string]any{
 		"listen":     []string{listenString(key)},
 		"auto_https": map[string]any{"disable_redirects": true},
 	}
 	if owner.Kind == caddyassembly.CaddyOwnerNaive {
-		server["protocols"] = protocolsForTransport(owner.Transport)
+		protocols, err := protocolsForTransport(owner.Transport)
+		if err != nil {
+			return nil, err
+		}
+		server["protocols"] = protocols
 	}
 	switch owner.Kind {
 	case caddyassembly.CaddyOwnerPanel:
@@ -129,19 +136,15 @@ func renderServer(key bindregistry.BindKey, owner caddyassembly.CaddyBindOwner, 
 		}
 		server["routes"] = []map[string]any{{"handle": handlers}}
 	}
-	return server
+	return server, nil
 }
 
-func protocolsForTransport(transport string) []string {
+func protocolsForTransport(transport string) ([]string, error) {
 	switch transport {
 	case "tcp":
-		return []string{"h1", "h2"}
-	case "quic":
-		return []string{"h3"}
-	case "dual":
-		return []string{"h1", "h2", "h3"}
+		return []string{"h1", "h2"}, nil
 	default:
-		return []string{"h1", "h2"}
+		return nil, fmt.Errorf("unsupported naive transport %q", transport)
 	}
 }
 

--- a/internal/renderer/caddyjson_test.go
+++ b/internal/renderer/caddyjson_test.go
@@ -121,3 +121,72 @@ func TestRenderCaddyJSONAcmeChallengeKeys(t *testing.T) {
 		})
 	}
 }
+
+
+func TestRenderCaddyJSONRejectsNaiveWithoutForwardProxy(t *testing.T) {
+	plan := caddyassembly.CaddyRenderPlan{
+		Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
+			{Address: "0.0.0.0", Port: 8443, Network: bindregistry.ListenTCP}: {
+				Kind:        caddyassembly.CaddyOwnerNaive,
+				Domain:      "p.example.com",
+				InboundName: "naive-1",
+				Transport:   "tcp",
+			},
+		},
+		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
+			"p.example.com": {Domain: "p.example.com", Email: "a@example.com"},
+		},
+	}
+	_, err := RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{ForwardProxy: false})
+	if err == nil {
+		t.Fatal("expected error for missing forward_proxy module")
+	}
+	want := "Caddy binary does not include the forward_proxy module required for NaiveProxy"
+	if err.Error() != want {
+		t.Fatalf("error = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestRenderCaddyJSONRejectsNaiveQuicWithoutH3Only(t *testing.T) {
+	plan := caddyassembly.CaddyRenderPlan{
+		Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
+			{Address: "0.0.0.0", Port: 8443, Network: bindregistry.ListenUDP}: {
+				Kind:        caddyassembly.CaddyOwnerNaive,
+				Domain:      "p.example.com",
+				InboundName: "naive-1",
+				Transport:   "quic",
+			},
+		},
+		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
+			"p.example.com": {Domain: "p.example.com", Email: "a@example.com"},
+		},
+	}
+	_, err := RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{ForwardProxy: true, HTTP3: true, H3Only: false})
+	if err == nil {
+		t.Fatal("expected error for missing H3Only support")
+	}
+	want := "Caddy binary does not support HTTP/3/QUIC transport required for NaiveProxy transport quic"
+	if err.Error() != want {
+		t.Fatalf("error = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestRenderCaddyJSONAllowsNaiveHTTPSWithForwardProxy(t *testing.T) {
+	plan := caddyassembly.CaddyRenderPlan{
+		Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
+			{Address: "0.0.0.0", Port: 8443, Network: bindregistry.ListenTCP}: {
+				Kind:        caddyassembly.CaddyOwnerNaive,
+				Domain:      "p.example.com",
+				InboundName: "naive-1",
+				Transport:   "https",
+			},
+		},
+		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
+			"p.example.com": {Domain: "p.example.com", Email: "a@example.com"},
+		},
+	}
+	_, err := RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{ForwardProxy: true})
+	if err != nil {
+		t.Fatalf("expected success for https transport with forward_proxy, got %v", err)
+	}
+}

--- a/internal/renderer/caddyjson_test.go
+++ b/internal/renderer/caddyjson_test.go
@@ -1,0 +1,36 @@
+package renderer
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/mikkelchokolate/Veil/internal/bindregistry"
+	"github.com/mikkelchokolate/Veil/internal/caddyassembly"
+	"github.com/mikkelchokolate/Veil/internal/caddycapabilities"
+)
+
+func TestRenderCaddyJSONPanelOnly(t *testing.T) {
+	plan := caddyassembly.CaddyRenderPlan{
+		Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
+			{Address: "0.0.0.0", Port: 443, Network: bindregistry.ListenTCP}: {
+				Kind:   caddyassembly.CaddyOwnerPanel,
+				Domain: "panel.example.com",
+			},
+		},
+		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
+			"panel.example.com": {Domain: "panel.example.com", Email: "admin@example.com"},
+		},
+	}
+	data, err := RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	apps := cfg["apps"].(map[string]any)
+	if _, ok := apps["http"]; !ok {
+		t.Error("expected http app")
+	}
+}

--- a/internal/renderer/caddyjson_test.go
+++ b/internal/renderer/caddyjson_test.go
@@ -1,8 +1,12 @@
 package renderer
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -123,7 +127,6 @@ func TestRenderCaddyJSONAcmeChallengeKeys(t *testing.T) {
 		})
 	}
 }
-
 
 func TestRenderCaddyJSONRejectsNaiveWithoutForwardProxy(t *testing.T) {
 	plan := caddyassembly.CaddyRenderPlan{
@@ -304,5 +307,138 @@ func TestRenderCaddyJSONNaiveFallbackRootResolvesRelativePath(t *testing.T) {
 	}
 	if !strings.Contains(string(data), `"root": "/var/lib/veil/custom"`) {
 		t.Errorf("expected resolved fallback root, got %s", string(data))
+	}
+}
+
+func TestRenderCaddyJSONUsesAutomaticHTTPS(t *testing.T) {
+	plan := caddyassembly.CaddyRenderPlan{
+		Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
+			{Address: "0.0.0.0", Port: 443, Network: bindregistry.ListenTCP}: {
+				Kind:        caddyassembly.CaddyOwnerPanel,
+				Domain:      "panel.example.com",
+				BackendPort: 2096,
+			},
+		},
+		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
+			"panel.example.com": {Domain: "panel.example.com", Email: "admin@example.com"},
+		},
+	}
+	data, err := RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(data)
+	if strings.Contains(s, `"auto_https"`) {
+		t.Error("rendered JSON must not contain the Caddyfile field auto_https")
+	}
+	if !strings.Contains(s, `"automatic_https"`) {
+		t.Error("rendered JSON must contain the JSON field automatic_https")
+	}
+}
+
+func TestRenderCaddyJSONNaiveForwardProxyAuthCredentials(t *testing.T) {
+	plan := caddyassembly.CaddyRenderPlan{
+		Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
+			{Address: "0.0.0.0", Port: 8443, Network: bindregistry.ListenTCP}: {
+				Kind:        caddyassembly.CaddyOwnerNaive,
+				Domain:      "p.example.com",
+				InboundName: "naive-1",
+				Transport:   "tcp",
+				NaiveUsers: []caddyassembly.CaddyNaiveUser{
+					{Username: "alice", Password: "secret-a"},
+					{Username: "bob", Password: "secret-b"},
+				},
+			},
+		},
+		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
+			"p.example.com": {Domain: "p.example.com", Email: "a@example.com"},
+		},
+	}
+	data, err := RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{ForwardProxy: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(data)
+	if strings.Contains(s, `"basic_auth"`) {
+		t.Error("rendered JSON must not contain the Caddyfile field basic_auth")
+	}
+	if !strings.Contains(s, `"auth_credentials"`) {
+		t.Error("rendered JSON must contain the JSON field auth_credentials")
+	}
+	for _, u := range []struct{ user, pass string }{
+		{"alice", "secret-a"},
+		{"bob", "secret-b"},
+	} {
+		want := base64.StdEncoding.EncodeToString([]byte(u.user + ":" + u.pass))
+		if !strings.Contains(s, fmt.Sprintf("%q", want)) {
+			t.Errorf("expected base64 credential %q for %s", want, u.user)
+		}
+	}
+}
+
+func TestRenderCaddyJSONAdminEndpoint(t *testing.T) {
+	plan := caddyassembly.CaddyRenderPlan{
+		Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
+			{Address: "0.0.0.0", Port: 443, Network: bindregistry.ListenTCP}: {
+				Kind:        caddyassembly.CaddyOwnerPanel,
+				Domain:      "panel.example.com",
+				BackendPort: 2096,
+			},
+		},
+		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
+			"panel.example.com": {Domain: "panel.example.com", Email: "admin@example.com"},
+		},
+	}
+	data, err := RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	admin, ok := cfg["admin"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected top-level admin block, got %T", cfg["admin"])
+	}
+	if admin["listen"] != "127.0.0.1:2019" {
+		t.Errorf("admin.listen = %v, want 127.0.0.1:2019", admin["listen"])
+	}
+}
+
+func TestRenderCaddyJSONValidatesWithCaddy(t *testing.T) {
+	if _, err := exec.LookPath("caddy"); err != nil {
+		t.Skip("caddy binary not available in PATH:", err)
+	}
+
+	plan := caddyassembly.CaddyRenderPlan{
+		Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
+			{Address: "0.0.0.0", Port: 443, Network: bindregistry.ListenTCP}: {
+				Kind:        caddyassembly.CaddyOwnerPanel,
+				Domain:      "panel.example.com",
+				BackendPort: 2096,
+			},
+		},
+		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
+			"panel.example.com": {Domain: "panel.example.com", Email: "admin@example.com"},
+		},
+	}
+	data, err := RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.json")
+	if err := os.WriteFile(cfgPath, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := exec.Command("caddy", "validate", "--config", cfgPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("caddy validate failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "Valid configuration") {
+		t.Errorf("caddy validate did not report valid configuration:\n%s", out)
 	}
 }

--- a/internal/renderer/caddyjson_test.go
+++ b/internal/renderer/caddyjson_test.go
@@ -2,6 +2,7 @@ package renderer
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -212,27 +213,73 @@ func TestRenderCaddyJSONNaiveFallbackRootRejectsParentTraversal(t *testing.T) {
 	}
 }
 
-func TestRenderCaddyJSONNaiveFallbackRootNormalizesAbsolutePath(t *testing.T) {
-	plan := caddyassembly.CaddyRenderPlan{
-		Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
-			{Address: "0.0.0.0", Port: 8443, Network: bindregistry.ListenTCP}: {
-				Kind:         caddyassembly.CaddyOwnerNaive,
-				Domain:       "p.example.com",
-				InboundName:  "naive-1",
-				Transport:    "tcp",
-				FallbackRoot: "/etc/passwd",
-			},
-		},
-		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
-			"p.example.com": {Domain: "p.example.com", Email: "a@example.com"},
-		},
+func TestRenderCaddyJSONNaiveFallbackRootRejectsOutsideVeil(t *testing.T) {
+	cases := []string{
+		"/etc/passwd",
+		"/var/lib/veil2",
+		"/var/lib/veil-evil",
+		"/var/lib/veil2/sub",
+		"/var/lib",
 	}
-	data, err := RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{ForwardProxy: true})
-	if err != nil {
-		t.Fatal(err)
+	for _, root := range cases {
+		t.Run(root, func(t *testing.T) {
+			plan := caddyassembly.CaddyRenderPlan{
+				Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
+					{Address: "0.0.0.0", Port: 8443, Network: bindregistry.ListenTCP}: {
+						Kind:         caddyassembly.CaddyOwnerNaive,
+						Domain:       "p.example.com",
+						InboundName:  "naive-1",
+						Transport:    "tcp",
+						FallbackRoot: root,
+					},
+				},
+				Domains: map[string]caddyassembly.CaddyDomainCertSpec{
+					"p.example.com": {Domain: "p.example.com", Email: "a@example.com"},
+				},
+			}
+			_, err := RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{ForwardProxy: true})
+			if err == nil {
+				t.Fatalf("expected error for fallback root %q outside /var/lib/veil", root)
+			}
+		})
 	}
-	if !strings.Contains(string(data), `"root": "/var/lib/veil/etc/passwd"`) {
-		t.Errorf("expected normalized fallback root, got %s", string(data))
+}
+
+func TestRenderCaddyJSONNaiveFallbackRootAcceptsWithinVeil(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"/var/lib/veil", "/var/lib/veil"},
+		{"/var/lib/veil/", "/var/lib/veil"},
+		{"/var/lib/veil/custom", "/var/lib/veil/custom"},
+		{"/var/lib/veil/www", "/var/lib/veil/www"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			plan := caddyassembly.CaddyRenderPlan{
+				Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
+					{Address: "0.0.0.0", Port: 8443, Network: bindregistry.ListenTCP}: {
+						Kind:         caddyassembly.CaddyOwnerNaive,
+						Domain:       "p.example.com",
+						InboundName:  "naive-1",
+						Transport:    "tcp",
+						FallbackRoot: tc.input,
+					},
+				},
+				Domains: map[string]caddyassembly.CaddyDomainCertSpec{
+					"p.example.com": {Domain: "p.example.com", Email: "a@example.com"},
+				},
+			}
+			data, err := RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{ForwardProxy: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantRoot := fmt.Sprintf(`"root": %q`, tc.want)
+			if !strings.Contains(string(data), wantRoot) {
+				t.Errorf("expected %s in rendered JSON, got %s", wantRoot, string(data))
+			}
+		})
 	}
 }
 

--- a/internal/renderer/caddyjson_test.go
+++ b/internal/renderer/caddyjson_test.go
@@ -64,3 +64,58 @@ func TestRenderCaddyJSONPanelOnly(t *testing.T) {
 		t.Error("expected http app")
 	}
 }
+
+func TestRenderCaddyJSONAcmeChallengeKeys(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     bindregistry.BindKey
+		mode    string
+		wantKey string
+	}{
+		{
+			name:    "http-01",
+			key:     bindregistry.BindKey{Address: "0.0.0.0", Port: 80, Network: bindregistry.ListenTCP},
+			mode:    "http-01",
+			wantKey: `"http"`,
+		},
+		{
+			name:    "tls-alpn-01",
+			key:     bindregistry.BindKey{Address: "0.0.0.0", Port: 443, Network: bindregistry.ListenTCP},
+			mode:    "tls-alpn-01",
+			wantKey: `"tls-alpn"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plan := caddyassembly.CaddyRenderPlan{
+				Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
+					{Address: "0.0.0.0", Port: 443, Network: bindregistry.ListenTCP}: {
+						Kind:   caddyassembly.CaddyOwnerPanel,
+						Domain: "panel.example.com",
+					},
+				},
+				Domains: map[string]caddyassembly.CaddyDomainCertSpec{
+					"panel.example.com": {Domain: "panel.example.com", Email: "admin@example.com"},
+				},
+				ACMEChallenges: map[bindregistry.BindKey]caddyassembly.AcmeChallengeOwner{
+					tt.key: {ChallengeMode: tt.mode, Domains: []string{"panel.example.com"}},
+				},
+			}
+			data, err := RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			s := string(data)
+			if !strings.Contains(s, `"issuers"`) {
+				t.Error("expected automation policy to contain issuers array")
+			}
+			if !strings.Contains(s, tt.wantKey) {
+				t.Errorf("expected challenge key %s in rendered JSON", tt.wantKey)
+			}
+			if strings.Contains(s, `"http-01"`) || strings.Contains(s, `"tls-alpn-01"`) {
+				t.Error("old challenge keys http-01/tls-alpn-01 must not appear in rendered JSON")
+			}
+		})
+	}
+}

--- a/internal/renderer/caddyjson_test.go
+++ b/internal/renderer/caddyjson_test.go
@@ -53,6 +53,7 @@ func TestRenderCaddyJSONPanelOnly(t *testing.T) {
 				Kind:        caddyassembly.CaddyOwnerPanel,
 				Domain:      "panel.example.com",
 				BackendPort: 2096,
+				WebBasePath: "/panel/",
 			},
 		},
 		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
@@ -102,6 +103,7 @@ func TestRenderCaddyJSONAcmeChallengeKeys(t *testing.T) {
 						Kind:        caddyassembly.CaddyOwnerPanel,
 						Domain:      "panel.example.com",
 						BackendPort: 2096,
+						WebBasePath: "/panel/",
 					},
 				},
 				Domains: map[string]caddyassembly.CaddyDomainCertSpec{
@@ -147,7 +149,7 @@ func TestRenderCaddyJSONRejectsNaiveWithoutForwardProxy(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for missing forward_proxy module")
 	}
-	want := "Caddy binary does not include the forward_proxy module required for NaiveProxy"
+	want := "caddy binary does not include the forward_proxy module required for NaiveProxy"
 	if err.Error() != want {
 		t.Fatalf("error = %q, want %q", err.Error(), want)
 	}
@@ -318,6 +320,7 @@ func TestRenderCaddyJSONUsesAutomaticHTTPS(t *testing.T) {
 				Kind:        caddyassembly.CaddyOwnerPanel,
 				Domain:      "panel.example.com",
 				BackendPort: 2096,
+				WebBasePath: "/panel/",
 			},
 		},
 		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
@@ -384,6 +387,7 @@ func TestRenderCaddyJSONAdminEndpoint(t *testing.T) {
 				Kind:        caddyassembly.CaddyOwnerPanel,
 				Domain:      "panel.example.com",
 				BackendPort: 2096,
+				WebBasePath: "/panel/",
 			},
 		},
 		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
@@ -533,6 +537,7 @@ func TestRenderCaddyJSONValidatesWithCaddy(t *testing.T) {
 				Kind:        caddyassembly.CaddyOwnerPanel,
 				Domain:      "panel.example.com",
 				BackendPort: 2096,
+				WebBasePath: "/panel/",
 			},
 		},
 		Domains: map[string]caddyassembly.CaddyDomainCertSpec{

--- a/internal/renderer/caddyjson_test.go
+++ b/internal/renderer/caddyjson_test.go
@@ -167,3 +167,95 @@ func TestRenderCaddyJSONAllowsNaiveTCPWithForwardProxy(t *testing.T) {
 		t.Fatalf("expected success for tcp transport with forward_proxy, got %v", err)
 	}
 }
+
+func TestRenderCaddyJSONNaiveFallbackRootDefaults(t *testing.T) {
+	plan := caddyassembly.CaddyRenderPlan{
+		Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
+			{Address: "0.0.0.0", Port: 8443, Network: bindregistry.ListenTCP}: {
+				Kind:        caddyassembly.CaddyOwnerNaive,
+				Domain:      "p.example.com",
+				InboundName: "naive-1",
+				Transport:   "tcp",
+			},
+		},
+		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
+			"p.example.com": {Domain: "p.example.com", Email: "a@example.com"},
+		},
+	}
+	data, err := RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{ForwardProxy: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"root": "/var/lib/veil/www"`) {
+		t.Errorf("expected default fallback root, got %s", string(data))
+	}
+}
+
+func TestRenderCaddyJSONNaiveFallbackRootRejectsParentTraversal(t *testing.T) {
+	plan := caddyassembly.CaddyRenderPlan{
+		Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
+			{Address: "0.0.0.0", Port: 8443, Network: bindregistry.ListenTCP}: {
+				Kind:         caddyassembly.CaddyOwnerNaive,
+				Domain:       "p.example.com",
+				InboundName:  "naive-1",
+				Transport:    "tcp",
+				FallbackRoot: "..",
+			},
+		},
+		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
+			"p.example.com": {Domain: "p.example.com", Email: "a@example.com"},
+		},
+	}
+	_, err := RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{ForwardProxy: true})
+	if err == nil {
+		t.Fatal("expected error for fallback root outside /var/lib/veil")
+	}
+}
+
+func TestRenderCaddyJSONNaiveFallbackRootNormalizesAbsolutePath(t *testing.T) {
+	plan := caddyassembly.CaddyRenderPlan{
+		Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
+			{Address: "0.0.0.0", Port: 8443, Network: bindregistry.ListenTCP}: {
+				Kind:         caddyassembly.CaddyOwnerNaive,
+				Domain:       "p.example.com",
+				InboundName:  "naive-1",
+				Transport:    "tcp",
+				FallbackRoot: "/etc/passwd",
+			},
+		},
+		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
+			"p.example.com": {Domain: "p.example.com", Email: "a@example.com"},
+		},
+	}
+	data, err := RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{ForwardProxy: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"root": "/var/lib/veil/etc/passwd"`) {
+		t.Errorf("expected normalized fallback root, got %s", string(data))
+	}
+}
+
+func TestRenderCaddyJSONNaiveFallbackRootResolvesRelativePath(t *testing.T) {
+	plan := caddyassembly.CaddyRenderPlan{
+		Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
+			{Address: "0.0.0.0", Port: 8443, Network: bindregistry.ListenTCP}: {
+				Kind:         caddyassembly.CaddyOwnerNaive,
+				Domain:       "p.example.com",
+				InboundName:  "naive-1",
+				Transport:    "tcp",
+				FallbackRoot: "custom",
+			},
+		},
+		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
+			"p.example.com": {Domain: "p.example.com", Email: "a@example.com"},
+		},
+	}
+	data, err := RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{ForwardProxy: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"root": "/var/lib/veil/custom"`) {
+		t.Errorf("expected resolved fallback root, got %s", string(data))
+	}
+}

--- a/internal/renderer/caddyjson_test.go
+++ b/internal/renderer/caddyjson_test.go
@@ -2,12 +2,42 @@ package renderer
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/mikkelchokolate/Veil/internal/bindregistry"
 	"github.com/mikkelchokolate/Veil/internal/caddyassembly"
 	"github.com/mikkelchokolate/Veil/internal/caddycapabilities"
 )
+
+func TestRenderCaddyJSONNaiveForwardProxyOrder(t *testing.T) {
+	plan := caddyassembly.CaddyRenderPlan{
+		Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
+			{Address: "0.0.0.0", Port: 8443, Network: bindregistry.ListenTCP}: {
+				Kind:        caddyassembly.CaddyOwnerNaive,
+				Domain:      "p.example.com",
+				InboundName: "naive-1",
+			},
+		},
+		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
+			"p.example.com": {Domain: "p.example.com", Email: "a@example.com"},
+		},
+	}
+	data, err := RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{ForwardProxy: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(data)
+	if !containsInOrder(s, `"forward_proxy"`, `"file_server"`) {
+		t.Error("forward_proxy must appear before file_server")
+	}
+}
+
+func containsInOrder(s, a, b string) bool {
+	ia := strings.Index(s, a)
+	ib := strings.Index(s, b)
+	return ia >= 0 && ib > ia
+}
 
 func TestRenderCaddyJSONPanelOnly(t *testing.T) {
 	plan := caddyassembly.CaddyRenderPlan{

--- a/internal/renderer/caddyjson_test.go
+++ b/internal/renderer/caddyjson_test.go
@@ -43,8 +43,9 @@ func TestRenderCaddyJSONPanelOnly(t *testing.T) {
 	plan := caddyassembly.CaddyRenderPlan{
 		Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
 			{Address: "0.0.0.0", Port: 443, Network: bindregistry.ListenTCP}: {
-				Kind:   caddyassembly.CaddyOwnerPanel,
-				Domain: "panel.example.com",
+				Kind:        caddyassembly.CaddyOwnerPanel,
+				Domain:      "panel.example.com",
+				BackendPort: 2096,
 			},
 		},
 		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
@@ -91,8 +92,9 @@ func TestRenderCaddyJSONAcmeChallengeKeys(t *testing.T) {
 			plan := caddyassembly.CaddyRenderPlan{
 				Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
 					{Address: "0.0.0.0", Port: 443, Network: bindregistry.ListenTCP}: {
-						Kind:   caddyassembly.CaddyOwnerPanel,
-						Domain: "panel.example.com",
+						Kind:        caddyassembly.CaddyOwnerPanel,
+						Domain:      "panel.example.com",
+						BackendPort: 2096,
 					},
 				},
 				Domains: map[string]caddyassembly.CaddyDomainCertSpec{

--- a/internal/renderer/caddyjson_test.go
+++ b/internal/renderer/caddyjson_test.go
@@ -17,6 +17,7 @@ func TestRenderCaddyJSONNaiveForwardProxyOrder(t *testing.T) {
 				Kind:        caddyassembly.CaddyOwnerNaive,
 				Domain:      "p.example.com",
 				InboundName: "naive-1",
+				Transport:   "tcp",
 			},
 		},
 		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
@@ -147,38 +148,14 @@ func TestRenderCaddyJSONRejectsNaiveWithoutForwardProxy(t *testing.T) {
 	}
 }
 
-func TestRenderCaddyJSONRejectsNaiveQuicWithoutH3Only(t *testing.T) {
-	plan := caddyassembly.CaddyRenderPlan{
-		Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
-			{Address: "0.0.0.0", Port: 8443, Network: bindregistry.ListenUDP}: {
-				Kind:        caddyassembly.CaddyOwnerNaive,
-				Domain:      "p.example.com",
-				InboundName: "naive-1",
-				Transport:   "quic",
-			},
-		},
-		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
-			"p.example.com": {Domain: "p.example.com", Email: "a@example.com"},
-		},
-	}
-	_, err := RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{ForwardProxy: true, HTTP3: true, H3Only: false})
-	if err == nil {
-		t.Fatal("expected error for missing H3Only support")
-	}
-	want := "Caddy binary does not support HTTP/3/QUIC transport required for NaiveProxy transport quic"
-	if err.Error() != want {
-		t.Fatalf("error = %q, want %q", err.Error(), want)
-	}
-}
-
-func TestRenderCaddyJSONAllowsNaiveHTTPSWithForwardProxy(t *testing.T) {
+func TestRenderCaddyJSONAllowsNaiveTCPWithForwardProxy(t *testing.T) {
 	plan := caddyassembly.CaddyRenderPlan{
 		Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
 			{Address: "0.0.0.0", Port: 8443, Network: bindregistry.ListenTCP}: {
 				Kind:        caddyassembly.CaddyOwnerNaive,
 				Domain:      "p.example.com",
 				InboundName: "naive-1",
-				Transport:   "https",
+				Transport:   "tcp",
 			},
 		},
 		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
@@ -187,6 +164,6 @@ func TestRenderCaddyJSONAllowsNaiveHTTPSWithForwardProxy(t *testing.T) {
 	}
 	_, err := RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{ForwardProxy: true})
 	if err != nil {
-		t.Fatalf("expected success for https transport with forward_proxy, got %v", err)
+		t.Fatalf("expected success for tcp transport with forward_proxy, got %v", err)
 	}
 }

--- a/internal/renderer/caddyjson_test.go
+++ b/internal/renderer/caddyjson_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mikkelchokolate/Veil/internal/bindregistry"
 	"github.com/mikkelchokolate/Veil/internal/caddyassembly"
 	"github.com/mikkelchokolate/Veil/internal/caddycapabilities"
+	"github.com/mikkelchokolate/Veil/internal/model"
 )
 
 func TestRenderCaddyJSONNaiveForwardProxyOrder(t *testing.T) {
@@ -406,6 +407,121 @@ func TestRenderCaddyJSONAdminEndpoint(t *testing.T) {
 	}
 }
 
+func TestRenderCaddyJSONHttp01ChallengeServer(t *testing.T) {
+	plan := caddyassembly.CaddyRenderPlan{
+		Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
+			{Address: "0.0.0.0", Port: 443, Network: bindregistry.ListenTCP}: {
+				Kind:        caddyassembly.CaddyOwnerNaive,
+				Domain:      "proxy.example.com",
+				InboundName: "naive-1",
+				Transport:   "tcp",
+				NaiveUsers:  []caddyassembly.CaddyNaiveUser{{Username: "u", Password: "p"}},
+			},
+		},
+		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
+			"proxy.example.com": {Domain: "proxy.example.com", Email: "admin@example.com"},
+		},
+		ACMEChallenges: map[bindregistry.BindKey]caddyassembly.AcmeChallengeOwner{
+			{Address: "0.0.0.0", Port: 80, Network: bindregistry.ListenTCP}: {
+				ChallengeMode: "http-01",
+				Domains:       []string{"proxy.example.com"},
+			},
+		},
+		DefaultChallengeMode: "http-01",
+	}
+	data, err := RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{ForwardProxy: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	apps := cfg["apps"].(map[string]any)
+	httpApp := apps["http"].(map[string]any)
+	servers := httpApp["servers"].(map[string]any)
+	challengeServer, ok := servers["tcp-0.0.0.0-80-acme"]
+	if !ok {
+		t.Fatalf("expected HTTP-01 challenge server tcp-0.0.0.0-80-acme, got servers: %v", servers)
+	}
+	challengeServerMap := challengeServer.(map[string]any)
+	listen := challengeServerMap["listen"].([]any)
+	if len(listen) != 1 || listen[0] != ":80" {
+		t.Fatalf("expected challenge server to listen on :80, got %v", listen)
+	}
+	routes := challengeServerMap["routes"].([]any)
+	if len(routes) != 0 {
+		// Caddy handles ACME HTTP-01 challenges at the server level (before route matching),
+		// so the challenge server intentionally has no routes.
+		t.Fatalf("expected HTTP-01 challenge server to have empty routes (Caddy handles challenges at server level), got %v", routes)
+	}
+
+	tlsApp := apps["tls"].(map[string]any)
+	policies := tlsApp["automation"].(map[string]any)["policies"].([]any)
+	if len(policies) != 1 {
+		t.Fatalf("expected 1 automation policy, got %d", len(policies))
+	}
+	issuer := policies[0].(map[string]any)["issuers"].([]any)[0].(map[string]any)
+	challenges := issuer["challenges"].(map[string]any)
+	if challenges["http"].(map[string]any)["disabled"] != false {
+		t.Error("expected http challenge to be enabled for http-01 mode")
+	}
+	if challenges["tls-alpn"].(map[string]any)["disabled"] != true {
+		t.Error("expected tls-alpn challenge to be disabled for http-01 mode")
+	}
+}
+
+func TestRenderCaddyJSONHttp01ChallengeHandlerEndToEnd(t *testing.T) {
+	settings := model.Settings{
+		PanelAccess:       "direct",
+		AcmeChallengeMode: "http-01",
+		DefaultAcmeEmail:  "admin@example.com",
+	}
+	inbounds := []model.Inbound{
+		{
+			Name:     "naive-1",
+			Protocol: "naiveproxy",
+			Enabled:  true,
+			ProtocolFields: map[string]any{
+				"domain":     "proxy.example.com",
+				"transport":  "tcp",
+				"publicPort": 443,
+			},
+			Profiles: []model.ClientProfile{
+				{Name: "p1", Username: "u", Password: "p", Enabled: true},
+			},
+		},
+	}
+	plan, _, issues, err := caddyassembly.BuildFinalRenderPlan(settings, inbounds)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(issues) > 0 {
+		t.Fatalf("unexpected validation issues: %v", issues)
+	}
+
+	challengeKey := bindregistry.BindKey{Address: "0.0.0.0", Port: 80, Network: bindregistry.ListenTCP}
+	if _, ok := plan.ACMEChallenges[challengeKey]; !ok {
+		t.Fatalf("expected TCP :80 ACME challenge bind in plan, got %v", plan.ACMEChallenges)
+	}
+
+	data, err := RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{ForwardProxy: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	apps := cfg["apps"].(map[string]any)
+	servers := apps["http"].(map[string]any)["servers"].(map[string]any)
+	challengeServer := servers["tcp-0.0.0.0-80-acme"].(map[string]any)
+	routes := challengeServer["routes"].([]any)
+	if len(routes) != 0 {
+		t.Fatalf("expected HTTP-01 challenge server to have empty routes (Caddy handles challenges at server level), got %v", routes)
+	}
+}
+
 func TestRenderCaddyJSONValidatesWithCaddy(t *testing.T) {
 	if _, err := exec.LookPath("caddy"); err != nil {
 		t.Skip("caddy binary not available in PATH:", err)
@@ -437,6 +553,52 @@ func TestRenderCaddyJSONValidatesWithCaddy(t *testing.T) {
 	out, err := exec.Command("caddy", "validate", "--config", cfgPath).CombinedOutput()
 	if err != nil {
 		t.Fatalf("caddy validate failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "Valid configuration") {
+		t.Errorf("caddy validate did not report valid configuration:\n%s", out)
+	}
+}
+
+func TestRenderCaddyJSONHttp01ValidatesWithCaddy(t *testing.T) {
+	if _, err := exec.LookPath("caddy"); err != nil {
+		t.Skip("caddy binary not available in PATH:", err)
+	}
+
+	plan := caddyassembly.CaddyRenderPlan{
+		Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
+			{Address: "0.0.0.0", Port: 443, Network: bindregistry.ListenTCP}: {
+				Kind:        caddyassembly.CaddyOwnerNaive,
+				Domain:      "proxy.example.com",
+				InboundName: "naive-1",
+				Transport:   "tcp",
+				NaiveUsers:  []caddyassembly.CaddyNaiveUser{{Username: "u", Password: "p"}},
+			},
+		},
+		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
+			"proxy.example.com": {Domain: "proxy.example.com", Email: "admin@example.com"},
+		},
+		ACMEChallenges: map[bindregistry.BindKey]caddyassembly.AcmeChallengeOwner{
+			{Address: "0.0.0.0", Port: 80, Network: bindregistry.ListenTCP}: {
+				ChallengeMode: "http-01",
+				Domains:       []string{"proxy.example.com"},
+			},
+		},
+		DefaultChallengeMode: "http-01",
+	}
+	data, err := RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{ForwardProxy: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.json")
+	if err := os.WriteFile(cfgPath, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := exec.Command("caddy", "validate", "--config", cfgPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("caddy validate failed for http-01 config: %v\n%s", err, out)
 	}
 	if !strings.Contains(string(out), "Valid configuration") {
 		t.Errorf("caddy validate did not report valid configuration:\n%s", out)

--- a/internal/renderer/hdd_happy_path_test.go
+++ b/internal/renderer/hdd_happy_path_test.go
@@ -1,0 +1,181 @@
+package renderer_test
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/mikkelchokolate/Veil/internal/bindregistry"
+	"github.com/mikkelchokolate/Veil/internal/caddyassembly"
+	"github.com/mikkelchokolate/Veil/internal/caddycapabilities"
+	"github.com/mikkelchokolate/Veil/internal/renderer"
+)
+
+func TestRenderCaddyJSON_NaiveTCP443HappyPath(t *testing.T) {
+	plan := caddyassembly.CaddyRenderPlan{
+		Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
+			{Address: "0.0.0.0", Port: 443, Network: bindregistry.ListenTCP}: {
+				Kind:         caddyassembly.CaddyOwnerNaive,
+				Domain:       "hy.flow2go.ru",
+				InboundName:  "test",
+				Transport:    "tcp",
+				NaiveUsers:   []caddyassembly.CaddyNaiveUser{{Username: "user", Password: "pass"}},
+				FallbackRoot: "/var/lib/veil/www",
+			},
+		},
+		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
+			"hy.flow2go.ru": {
+				Domain: "hy.flow2go.ru",
+				Email:  "admin@hy.flow2go.ru",
+			},
+		},
+		DefaultChallengeMode: "tls-alpn-01",
+	}
+
+	data, err := renderer.RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{ForwardProxy: true})
+	if err != nil {
+		t.Fatalf("RenderCaddyJSON error: %v", err)
+	}
+	t.Logf("rendered Caddy JSON:\n%s", string(data))
+
+	var cfg map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("rendered JSON is invalid: %v\n%s", err, string(data))
+	}
+
+	apps := cfg["apps"].(map[string]any)
+	httpApp := apps["http"].(map[string]any)
+	servers := httpApp["servers"].(map[string]any)
+
+	serverName := "tcp-0.0.0.0-443"
+	server, ok := servers[serverName].(map[string]any)
+	if !ok {
+		t.Fatalf("expected server %s in %v", serverName, servers)
+	}
+
+	listen := server["listen"].([]any)
+	if len(listen) != 1 || listen[0] != ":443" {
+		t.Errorf("server.listen = %v, want [:443]", listen)
+	}
+
+	routes := server["routes"].([]any)
+	if len(routes) != 1 {
+		t.Fatalf("expected exactly one route, got %d", len(routes))
+	}
+	route := routes[0].(map[string]any)
+	if _, hasMatch := route["match"]; hasMatch {
+		t.Error("naive server route must not contain a host matcher")
+	}
+
+	handlers := route["handle"].([]any)
+	if len(handlers) != 2 {
+		t.Fatalf("expected 2 handlers, got %d", len(handlers))
+	}
+	first := handlers[0].(map[string]any)
+	second := handlers[1].(map[string]any)
+	if first["handler"] != "forward_proxy" {
+		t.Errorf("first handler = %v, want forward_proxy", first["handler"])
+	}
+	if second["handler"] != "file_server" {
+		t.Errorf("second handler = %v, want file_server", second["handler"])
+	}
+	if second["root"] != "/var/lib/veil/www" {
+		t.Errorf("file_server root = %v, want /var/lib/veil/www", second["root"])
+	}
+
+	authCreds := first["auth_credentials"].([]any)
+	wantCred := base64.StdEncoding.EncodeToString([]byte("user:pass"))
+	if len(authCreds) != 1 || authCreds[0] != wantCred {
+		t.Errorf("auth_credentials = %v, want [%s]", authCreds, wantCred)
+	}
+
+	tlsApp := apps["tls"].(map[string]any)
+	automation := tlsApp["automation"].(map[string]any)
+	policies := automation["policies"].([]any)
+	if len(policies) != 1 {
+		t.Fatalf("expected 1 automation policy, got %d", len(policies))
+	}
+	policy := policies[0].(map[string]any)
+	subjects := policy["subjects"].([]any)
+	if len(subjects) != 1 || subjects[0] != "hy.flow2go.ru" {
+		t.Errorf("policy.subjects = %v, want [hy.flow2go.ru]", subjects)
+	}
+	issuers := policy["issuers"].([]any)
+	if len(issuers) != 1 {
+		t.Fatalf("expected 1 issuer, got %d", len(issuers))
+	}
+	issuer := issuers[0].(map[string]any)
+	if issuer["module"] != "acme" {
+		t.Errorf("issuer.module = %v, want acme", issuer["module"])
+	}
+	if issuer["email"] != "admin@hy.flow2go.ru" {
+		t.Errorf("issuer.email = %v, want admin@hy.flow2go.ru", issuer["email"])
+	}
+	challenges := issuer["challenges"].(map[string]any)
+	httpChallenge := challenges["http"].(map[string]any)
+	tlsAlpnChallenge := challenges["tls-alpn"].(map[string]any)
+	if httpChallenge["disabled"] != true {
+		t.Error("http challenge must be disabled for tls-alpn-01 mode")
+	}
+	if tlsAlpnChallenge["disabled"] != false {
+		t.Error("tls-alpn challenge must be enabled for tls-alpn-01 mode")
+	}
+}
+
+// TestRenderCaddyJSON_SameDomainTwoServersSharesCert verifies that two naive
+// inbounds using the same domain on different ports render distinct servers
+// while sharing a single TLS automation policy.
+func TestRenderCaddyJSON_SameDomainTwoServersSharesCert(t *testing.T) {
+	plan := caddyassembly.CaddyRenderPlan{
+		Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
+			{Address: "0.0.0.0", Port: 443, Network: bindregistry.ListenTCP}: {
+				Kind:        caddyassembly.CaddyOwnerNaive,
+				Domain:      "hy.flow2go.ru",
+				InboundName: "test-a",
+				Transport:   "tcp",
+				NaiveUsers:  []caddyassembly.CaddyNaiveUser{{Username: "user-a", Password: "pass-a"}},
+			},
+			{Address: "0.0.0.0", Port: 8443, Network: bindregistry.ListenTCP}: {
+				Kind:        caddyassembly.CaddyOwnerNaive,
+				Domain:      "hy.flow2go.ru",
+				InboundName: "test-b",
+				Transport:   "tcp",
+				NaiveUsers:  []caddyassembly.CaddyNaiveUser{{Username: "user-b", Password: "pass-b"}},
+			},
+		},
+		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
+			"hy.flow2go.ru": {
+				Domain: "hy.flow2go.ru",
+				Email:  "admin@hy.flow2go.ru",
+			},
+		},
+		DefaultChallengeMode: "tls-alpn-01",
+	}
+
+	data, err := renderer.RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{ForwardProxy: true})
+	if err != nil {
+		t.Fatalf("RenderCaddyJSON error: %v", err)
+	}
+
+	var cfg map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("rendered JSON is invalid: %v\n%s", err, string(data))
+	}
+
+	apps := cfg["apps"].(map[string]any)
+	servers := apps["http"].(map[string]any)["servers"].(map[string]any)
+	if len(servers) != 2 {
+		t.Fatalf("expected 2 servers, got %d", len(servers))
+	}
+
+	tlsApp := apps["tls"].(map[string]any)
+	policies := tlsApp["automation"].(map[string]any)["policies"].([]any)
+	if len(policies) != 1 {
+		t.Fatalf("expected 1 shared automation policy, got %d", len(policies))
+	}
+	policy := policies[0].(map[string]any)
+	subjects := policy["subjects"].([]any)
+	if len(subjects) != 1 || subjects[0] != "hy.flow2go.ru" {
+		t.Errorf("policy.subjects = %v, want [hy.flow2go.ru]", subjects)
+	}
+}

--- a/internal/renderer/panel_caddy.go
+++ b/internal/renderer/panel_caddy.go
@@ -11,6 +11,7 @@ type PanelCaddyConfig struct {
 	Domain           string
 	Email            string
 	PanelPort        int
+	PublicPort       int
 	WebBasePath      string
 	WebBasePathSlash string
 }
@@ -25,6 +26,9 @@ func RenderPanelCaddyfile(cfg PanelCaddyConfig) (string, error) {
 	if cfg.WebBasePath == "" || cfg.WebBasePath == "/" {
 		return "", errors.New("web base path is required")
 	}
+	if cfg.PublicPort == 0 {
+		cfg.PublicPort = 443
+	}
 	// Preserve trailing slash semantics used by the Panel router while also
 	// providing a no-slash variant for the exact-path redirect.
 	cfg.WebBasePathSlash = cfg.WebBasePath
@@ -37,7 +41,7 @@ func RenderPanelCaddyfile(cfg PanelCaddyConfig) (string, error) {
 	// if ACME can't issue (no public DNS, ports unreachable, rate limits). So
 	// the operator just enters a domain and it always works, using a trusted
 	// cert whenever possible.
-	const tpl = `{{ .Domain }} {
+	const tpl = `{{ .Domain }}{{ if ne .PublicPort 443 }}:{{ .PublicPort }}{{ end }} {
   tls {
     issuer acme{{ if .Email }} {
       email {{ .Email }}

--- a/internal/renderer/systemd.go
+++ b/internal/renderer/systemd.go
@@ -4,7 +4,7 @@ import "path"
 
 const (
 	UnitVeil          = "veil.service"
-	UnitCaddy         = "veil-caddy@.service"
+	UnitCaddy         = "veil-caddy.service"
 	UnitHysteria2     = "veil-hysteria2@.service"
 	UnitOlcrtc        = "veil-olcrtc@.service"
 	UnitWarp          = "veil-warp.service"
@@ -68,7 +68,7 @@ func RenderSystemdUnits(cfg SystemdConfig) map[string]string {
 	if cfg.EtcDir == "" {
 		cfg.EtcDir = "/etc/veil"
 	}
-	caddyfile := path.Join(cfg.EtcDir, "generated", "caddy", "%i.Caddyfile")
+	caddyConfig := path.Join(cfg.EtcDir, "generated", "caddy", "config.json")
 	hysteriaConfig := path.Join(cfg.EtcDir, "generated", "hysteria2", "%i.yaml")
 	olcrtcConfig := path.Join(cfg.EtcDir, "generated", "olcrtc", "%i.yaml")
 	warpConfig := path.Join(cfg.EtcDir, "generated", "sing-box", "warp.json")
@@ -171,7 +171,7 @@ RemoveOnStop=true
 WantedBy=sockets.target
 `,
 		UnitCaddy: `[Unit]
-Description=Veil managed NaiveProxy/Caddy (%i)
+Description=Veil managed NaiveProxy/Caddy
 After=network-online.target
 Wants=network-online.target
 
@@ -184,8 +184,8 @@ Type=simple
 # internal-CA fallback.
 StateDirectory=caddy
 Environment=HOME=/var/lib/caddy XDG_DATA_HOME=/var/lib/caddy XDG_CONFIG_HOME=/var/lib/caddy
-ExecStart=` + cfg.CaddyBinary + ` run --config ` + caddyfile + ` --adapter caddyfile
-ExecReload=` + cfg.CaddyBinary + ` reload --config ` + caddyfile + ` --adapter caddyfile
+ExecStart=` + cfg.CaddyBinary + ` run --config ` + caddyConfig + ` --adapter json
+ExecReload=` + cfg.CaddyBinary + ` reload --config ` + caddyConfig + ` --adapter json
 Restart=on-failure
 RestartSec=3
 NoNewPrivileges=true

--- a/internal/renderer/systemd.go
+++ b/internal/renderer/systemd.go
@@ -184,8 +184,8 @@ Type=simple
 # internal-CA fallback.
 StateDirectory=caddy
 Environment=HOME=/var/lib/caddy XDG_DATA_HOME=/var/lib/caddy XDG_CONFIG_HOME=/var/lib/caddy
-ExecStart=` + cfg.CaddyBinary + ` run --config ` + caddyConfig + ` --adapter json
-ExecReload=` + cfg.CaddyBinary + ` reload --config ` + caddyConfig + ` --adapter json
+ExecStart=` + cfg.CaddyBinary + ` run --config ` + caddyConfig + `
+ExecReload=` + cfg.CaddyBinary + ` reload --config ` + caddyConfig + `
 Restart=on-failure
 RestartSec=3
 NoNewPrivileges=true

--- a/internal/renderer/systemd_test.go
+++ b/internal/renderer/systemd_test.go
@@ -57,8 +57,8 @@ func TestRenderSystemdUnits(t *testing.T) {
 	if !strings.Contains(units["veil.service"], "EnvironmentFile=-/etc/veil/veil.env") {
 		t.Fatalf("expected veil env file in unit:\n%s", units["veil.service"])
 	}
-	if !strings.Contains(units["veil-caddy@.service"], "/etc/veil/generated/caddy/%i.Caddyfile") {
-		t.Fatalf("bad caddy unit:\n%s", units["veil-caddy@.service"])
+	if !strings.Contains(units["veil-caddy.service"], "/etc/veil/generated/caddy/config.json") {
+		t.Fatalf("bad caddy unit:\n%s", units["veil-caddy.service"])
 	}
 	if !strings.Contains(units["veil-hysteria2@.service"], "/etc/veil/generated/hysteria2/%i.yaml") {
 		t.Fatalf("bad hysteria2 unit:\n%s", units["veil-hysteria2@.service"])
@@ -93,13 +93,13 @@ func TestRenderSystemdUnitsDefaults(t *testing.T) {
 		t.Fatalf("veil.service: expected default EtcDir env file, got:\n%s", veilUnit)
 	}
 
-	// veil-caddy@.service: default CaddyBinary and EtcDir config path
-	naiveUnit := units["veil-caddy@.service"]
-	if !strings.Contains(naiveUnit, "ExecStart=/usr/local/bin/caddy run --config /etc/veil/generated/caddy/%i.Caddyfile") {
-		t.Fatalf("veil-caddy@.service: expected default CaddyBinary and EtcDir, got:\n%s", naiveUnit)
+	// veil-caddy.service: default CaddyBinary and EtcDir config path
+	naiveUnit := units["veil-caddy.service"]
+	if !strings.Contains(naiveUnit, "ExecStart=/usr/local/bin/caddy run --config /etc/veil/generated/caddy/config.json") {
+		t.Fatalf("veil-caddy.service: expected default CaddyBinary and EtcDir, got:\n%s", naiveUnit)
 	}
-	if !strings.Contains(naiveUnit, "ExecReload=/usr/local/bin/caddy reload --config /etc/veil/generated/caddy/%i.Caddyfile") {
-		t.Fatalf("veil-caddy@.service: expected default CaddyBinary reload, got:\n%s", naiveUnit)
+	if !strings.Contains(naiveUnit, "ExecReload=/usr/local/bin/caddy reload --config /etc/veil/generated/caddy/config.json") {
+		t.Fatalf("veil-caddy.service: expected default CaddyBinary reload, got:\n%s", naiveUnit)
 	}
 
 	// veil-hysteria2@.service: default HysteriaBinary and EtcDir config path

--- a/internal/service/managed_runtime_catalog.go
+++ b/internal/service/managed_runtime_catalog.go
@@ -84,7 +84,7 @@ func (c ManagedRuntimeCatalog) AllowsPromotedAction(command []string) bool {
 	}
 	if command[1] == "stop" || command[1] == "disable" || command[1] == "start" || command[1] == "enable" {
 		unit := command[2]
-		for _, prefix := range []string{"veil-caddy@", "veil-hysteria2@", "veil-olcrtc@"} {
+		for _, prefix := range []string{"veil-caddy.service", "veil-hysteria2@", "veil-olcrtc@"} {
 			if strings.HasPrefix(unit, prefix) && strings.HasSuffix(unit, ".service") {
 				return true
 			}

--- a/internal/service/managed_runtime_catalog_more_test.go
+++ b/internal/service/managed_runtime_catalog_more_test.go
@@ -80,14 +80,14 @@ func TestAllowsPromotedActionStandardVerbs(t *testing.T) {
 		command []string
 		want    bool
 	}{
-		{[]string{"systemctl", "start", "veil-caddy@x.service"}, true},
+		{[]string{"systemctl", "start", "veil-caddy.service"}, true},
 		{[]string{"systemctl", "stop", "veil-hysteria2@y.service"}, true},
 		{[]string{"systemctl", "enable", "veil-olcrtc@z.service"}, true},
-		{[]string{"systemctl", "disable", "veil-caddy@x.service"}, true},
-		{[]string{"systemctl", "restart", "veil-caddy@x.service"}, false},
+		{[]string{"systemctl", "disable", "veil-caddy.service"}, true},
+		{[]string{"systemctl", "restart", "veil-caddy.service"}, false},
 		{[]string{"systemctl", "start", "veil-unknown@x.service"}, false},
-		{[]string{"systemctl", "start", "veil-caddy@x"}, false},
-		{[]string{"systemctl", "kill", "veil-caddy@x.service"}, false},
+		{[]string{"systemctl", "start", "veil-caddy"}, false},
+		{[]string{"systemctl", "kill", "veil-caddy.service"}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.command[1]+"_"+tt.command[2], func(t *testing.T) {
@@ -100,15 +100,15 @@ func TestAllowsPromotedActionStandardVerbs(t *testing.T) {
 
 func TestMatchUnitTemplateSuffix(t *testing.T) {
 	catalog := NewManagedRuntimeCatalog([]ManagedRuntime{
-		{Unit: "veil-caddy@.service", HealthCheckAfter: true},
+		{Unit: "veil-hysteria2@.service", HealthCheckAfter: true},
 	})
-	if !catalog.AllowsHealthUnit("veil-caddy@x.service") {
+	if !catalog.AllowsHealthUnit("veil-hysteria2@x.service") {
 		t.Fatal("expected template unit to match instantiated unit")
 	}
-	if catalog.AllowsHealthUnit("veil-caddy@x.servic") {
+	if catalog.AllowsHealthUnit("veil-hysteria2@x.servic") {
 		t.Fatal("expected suffix mismatch to be rejected")
 	}
-	if catalog.AllowsHealthUnit("veil-hysteria2@x.service") {
+	if catalog.AllowsHealthUnit("veil-caddy@x.service") {
 		t.Fatal("expected prefix mismatch to be rejected")
 	}
 }

--- a/internal/settings/settings_validation.go
+++ b/internal/settings/settings_validation.go
@@ -119,14 +119,13 @@ func (SettingsValidation) NormalizeAndValidate(settings *Settings, current Setti
 	settings.Hysteria2Password = disclosure.PreserveRedacted(settings.Hysteria2Password, current.Hysteria2Password)
 	settings.OlcrtcAuth = disclosure.PreserveRedacted(settings.OlcrtcAuth, current.OlcrtcAuth)
 	if settings.FallbackRoot != "" {
-		settings.FallbackRoot = filepath.Clean(settings.FallbackRoot)
-		if !strings.HasPrefix(filepath.ToSlash(settings.FallbackRoot), "/var/lib/veil") {
-			settings.FallbackRoot = filepath.Clean("/var/lib/veil/" + settings.FallbackRoot)
+		settings.FallbackRoot = filepath.ToSlash(filepath.Clean(settings.FallbackRoot))
+		if !strings.HasPrefix(settings.FallbackRoot, "/") {
+			settings.FallbackRoot = filepath.ToSlash(filepath.Clean("/var/lib/veil/" + settings.FallbackRoot))
 		}
-		if !strings.HasPrefix(filepath.ToSlash(settings.FallbackRoot), "/var/lib/veil") {
+		if settings.FallbackRoot != "/var/lib/veil" && !strings.HasPrefix(settings.FallbackRoot, "/var/lib/veil/") {
 			return errors.New("fallbackRoot must be within /var/lib/veil")
 		}
-		settings.FallbackRoot = filepath.ToSlash(settings.FallbackRoot)
 	}
 	return nil
 }

--- a/internal/settings/settings_validation.go
+++ b/internal/settings/settings_validation.go
@@ -45,8 +45,18 @@ func (SettingsValidation) NormalizeAndValidate(settings *Settings, current Setti
 	if settings.OlcrtcRoomID == "" {
 		settings.OlcrtcRoomID = current.OlcrtcRoomID
 	}
-	if settings.PanelAccess == "caddy" && (strings.TrimSpace(settings.Domain) == "" || strings.TrimSpace(settings.Email) == "") {
-		return errors.New("--domain and --email are required for caddy Panel access")
+	if settings.PanelAccess == "caddy" {
+		domain := strings.TrimSpace(settings.PanelDomain)
+		if domain == "" {
+			domain = strings.TrimSpace(settings.Domain)
+		}
+		email := strings.TrimSpace(settings.PanelEmail)
+		if email == "" {
+			email = strings.TrimSpace(settings.Email)
+		}
+		if domain == "" || email == "" {
+			return errors.New("--domain and --email are required for caddy Panel access")
+		}
 	}
 	if settings.PanelPublicPort == 0 {
 		settings.PanelPublicPort = current.PanelPublicPort

--- a/internal/settings/settings_validation.go
+++ b/internal/settings/settings_validation.go
@@ -48,6 +48,40 @@ func (SettingsValidation) NormalizeAndValidate(settings *Settings, current Setti
 	if settings.PanelAccess == "caddy" && (strings.TrimSpace(settings.Domain) == "" || strings.TrimSpace(settings.Email) == "") {
 		return errors.New("--domain and --email are required for caddy Panel access")
 	}
+	if settings.PanelPublicPort == 0 {
+		settings.PanelPublicPort = current.PanelPublicPort
+	}
+	if settings.PanelPublicPort == 0 {
+		settings.PanelPublicPort = 443
+	}
+	if settings.DefaultInboundPublicPort == 0 {
+		settings.DefaultInboundPublicPort = current.DefaultInboundPublicPort
+	}
+	if settings.DefaultInboundPublicPort == 0 {
+		settings.DefaultInboundPublicPort = 443
+	}
+	if settings.AcmeChallengeMode == "" {
+		settings.AcmeChallengeMode = current.AcmeChallengeMode
+	}
+	if settings.AcmeChallengeMode == "" {
+		settings.AcmeChallengeMode = "tls-alpn-01"
+	}
+	switch settings.AcmeChallengeMode {
+	case "http-01", "tls-alpn-01", "dns-01":
+	default:
+		return errors.New("acmeChallengeMode must be http-01, tls-alpn-01, or dns-01")
+	}
+	if settings.PanelPublicPort < 1 || settings.PanelPublicPort > 65535 {
+		return errors.New("panelPublicPort must be between 1 and 65535")
+	}
+	if settings.DefaultInboundPublicPort < 1 || settings.DefaultInboundPublicPort > 65535 {
+		return errors.New("defaultInboundPublicPort must be between 1 and 65535")
+	}
+	if settings.DefaultAcmeEmail != "" {
+		if err := hostenv.ValidateEmail(settings.DefaultAcmeEmail); err != nil {
+			return errors.New("defaultAcmeEmail: " + err.Error())
+		}
+	}
 	if settings.Domain != "" {
 		if err := hostenv.ValidateDomain(settings.Domain); err != nil {
 			return errors.New("domain: " + err.Error())

--- a/internal/settings/settings_validation.go
+++ b/internal/settings/settings_validation.go
@@ -77,7 +77,9 @@ func (SettingsValidation) NormalizeAndValidate(settings *Settings, current Setti
 		settings.AcmeChallengeMode = "tls-alpn-01"
 	}
 	switch settings.AcmeChallengeMode {
-	case "http-01", "tls-alpn-01", "dns-01":
+	case "http-01", "tls-alpn-01":
+	case "dns-01":
+		return errors.New("dns-01 ACME challenge requires DNS provider credentials, which are not yet configured")
 	default:
 		return errors.New("acmeChallengeMode must be http-01, tls-alpn-01, or dns-01")
 	}

--- a/internal/settings/settings_validation.go
+++ b/internal/settings/settings_validation.go
@@ -257,14 +257,29 @@ func StructFieldName(key string) string {
 }
 
 func normalizeFallbackRoot(root *string) error {
-	*root = filepath.Clean(*root)
-	if !strings.HasPrefix(filepath.ToSlash(*root), "/var/lib/veil") {
-		*root = filepath.Clean("/var/lib/veil/" + *root)
+	const base = "/var/lib/veil"
+
+	raw := strings.TrimSpace(*root)
+	if raw == "" {
+		*root = ""
+		return nil
 	}
-	if !strings.HasPrefix(filepath.ToSlash(*root), "/var/lib/veil") {
+	for _, part := range strings.FieldsFunc(filepath.ToSlash(raw), func(r rune) bool { return r == '/' }) {
+		if part == ".." {
+			return errors.New("fallbackRoot must not contain parent-directory traversal")
+		}
+	}
+
+	candidate := raw
+	if !filepath.IsAbs(candidate) {
+		candidate = filepath.Join(base, candidate)
+	}
+	candidate = filepath.Clean(candidate)
+	relative, err := filepath.Rel(base, candidate)
+	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) || filepath.IsAbs(relative) {
 		return errors.New("fallbackRoot must be within /var/lib/veil")
 	}
-	*root = filepath.ToSlash(*root)
+	*root = filepath.ToSlash(candidate)
 	return nil
 }
 

--- a/internal/settings/settings_validation_more_test.go
+++ b/internal/settings/settings_validation_more_test.go
@@ -113,10 +113,22 @@ func TestSettingsValidationPanelListenErrors(t *testing.T) {
 }
 
 func TestSettingsValidationFallbackRootEscapesVarLibVeil(t *testing.T) {
-	settings := Settings{PanelListen: "127.0.0.1:2096", Mode: "server", FallbackRoot: "../../etc/passwd"}
-	err := NewSettingsValidation().NormalizeAndValidate(&settings, Settings{})
-	if err == nil || err.Error() != "fallbackRoot must be within /var/lib/veil" {
-		t.Fatalf("err = %v", err)
+	cases := []string{
+		"../../etc/passwd",
+		"/etc/passwd",
+		"/var/lib/veil2",
+		"/var/lib/veil-evil",
+		"/var/lib/veil2/sub",
+		"/var/lib",
+	}
+	for _, root := range cases {
+		t.Run(root, func(t *testing.T) {
+			settings := Settings{PanelListen: "127.0.0.1:2096", Mode: "server", FallbackRoot: root}
+			err := NewSettingsValidation().NormalizeAndValidate(&settings, Settings{})
+			if err == nil || err.Error() != "fallbackRoot must be within /var/lib/veil" {
+				t.Fatalf("err = %v", err)
+			}
+		})
 	}
 }
 

--- a/internal/settings/settings_validation_test.go
+++ b/internal/settings/settings_validation_test.go
@@ -1,6 +1,49 @@
 package settings
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/mikkelchokolate/Veil/internal/model"
+)
+
+func TestNormalizeAndValidateNewFields(t *testing.T) {
+	current := model.Settings{PanelListen: "0.0.0.0:8080", Mode: "server"}
+	s := model.Settings{
+		PanelListen:              "0.0.0.0:8080",
+		Mode:                     "server",
+		PanelAccess:              "caddy",
+		WebBasePath:              "/panel/",
+		Domain:                   "panel.example.com",
+		Email:                    "admin@example.com",
+		PanelEmail:               "admin@example.com",
+		PanelPublicPort:          8443,
+		DefaultAcmeEmail:         "acme@example.com",
+		DefaultInboundPublicPort: 443,
+		AcmeChallengeMode:        "tls-alpn-01",
+	}
+	if err := NewSettingsValidation().NormalizeAndValidate(&s, current); err != nil {
+		t.Fatal(err)
+	}
+	if s.PanelPublicPort != 8443 {
+		t.Errorf("PanelPublicPort = %d", s.PanelPublicPort)
+	}
+	if s.DefaultInboundPublicPort != 443 {
+		t.Errorf("DefaultInboundPublicPort = %d", s.DefaultInboundPublicPort)
+	}
+}
+
+func TestNormalizeAndValidateInvalidChallengeMode(t *testing.T) {
+	current := model.Settings{PanelListen: "0.0.0.0:8080", Mode: "server"}
+	s := model.Settings{
+		PanelListen:       "0.0.0.0:8080",
+		Mode:              "server",
+		PanelAccess:       "direct",
+		AcmeChallengeMode: "ftp-01",
+	}
+	if err := NewSettingsValidation().NormalizeAndValidate(&s, current); err == nil {
+		t.Fatal("expected invalid challenge mode error")
+	}
+}
 
 func TestSettingsValidationPreservesRedactedSecretsAndNormalizesFallbackRoot(t *testing.T) {
 	settings := Settings{PanelListen: "127.0.0.1:2096", Mode: "server", NaivePassword: "[REDACTED]", Hysteria2Password: "[REDACTED]", OlcrtcAuth: "[REDACTED]", FallbackRoot: "www"}

--- a/packaging/nfpm.yaml
+++ b/packaging/nfpm.yaml
@@ -45,8 +45,8 @@ contents:
   - src: packaging/systemd/veil-backup.timer
     dst: /lib/systemd/system/veil-backup.timer
     type: config
-  - src: packaging/systemd/veil-caddy@.service
-    dst: /lib/systemd/system/veil-caddy@.service
+  - src: packaging/systemd/veil-caddy.service
+    dst: /lib/systemd/system/veil-caddy.service
     type: config
   - src: packaging/systemd/veil-hysteria2@.service
     dst: /lib/systemd/system/veil-hysteria2@.service

--- a/packaging/systemd/veil-caddy.service
+++ b/packaging/systemd/veil-caddy.service
@@ -12,8 +12,8 @@ Type=simple
 # internal-CA fallback.
 StateDirectory=caddy
 Environment=HOME=/var/lib/caddy XDG_DATA_HOME=/var/lib/caddy XDG_CONFIG_HOME=/var/lib/caddy
-ExecStart=/usr/local/bin/caddy run --config /etc/veil/generated/caddy/config.json --adapter json
-ExecReload=/usr/local/bin/caddy reload --config /etc/veil/generated/caddy/config.json --adapter json
+ExecStart=/usr/local/bin/caddy run --config /etc/veil/generated/caddy/config.json
+ExecReload=/usr/local/bin/caddy reload --config /etc/veil/generated/caddy/config.json
 Restart=on-failure
 RestartSec=3
 NoNewPrivileges=true

--- a/packaging/systemd/veil-caddy.service
+++ b/packaging/systemd/veil-caddy.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Veil managed NaiveProxy/Caddy (%i)
+Description=Veil managed NaiveProxy/Caddy
 After=network-online.target
 Wants=network-online.target
 
@@ -12,8 +12,8 @@ Type=simple
 # internal-CA fallback.
 StateDirectory=caddy
 Environment=HOME=/var/lib/caddy XDG_DATA_HOME=/var/lib/caddy XDG_CONFIG_HOME=/var/lib/caddy
-ExecStart=/usr/local/bin/caddy run --config /etc/veil/generated/caddy/%i.Caddyfile --adapter caddyfile
-ExecReload=/usr/local/bin/caddy reload --config /etc/veil/generated/caddy/%i.Caddyfile --adapter caddyfile
+ExecStart=/usr/local/bin/caddy run --config /etc/veil/generated/caddy/config.json --adapter json
+ExecReload=/usr/local/bin/caddy reload --config /etc/veil/generated/caddy/config.json --adapter json
 Restart=on-failure
 RestartSec=3
 NoNewPrivileges=true

--- a/scripts/package-smoke.sh
+++ b/scripts/package-smoke.sh
@@ -49,7 +49,7 @@ run_deb_smoke() {
       apt-get install -y ca-certificates
       dpkg -i /packages/old/*.deb
       test -x /usr/local/bin/veil
-      for unit in veil.service veil-helper.service veil-helper.socket veil-backup.service veil-backup.timer veil-caddy@.service veil-hysteria2@.service veil-mieru.service veil-olcrtc@.service veil-warp.service; do
+      for unit in veil.service veil-helper.service veil-helper.socket veil-backup.service veil-backup.timer veil-caddy.service veil-hysteria2@.service veil-mieru.service veil-olcrtc@.service veil-warp.service; do
         test -f "/lib/systemd/system/$unit"
       done
       id veil

--- a/sdk/go/veilclient.gen.go
+++ b/sdk/go/veilclient.gen.go
@@ -646,7 +646,7 @@ type RURecommendedPreviewRequestPanelAccess string
 
 // RURecommendedPreviewResponse defines model for RURecommendedPreviewResponse.
 type RURecommendedPreviewResponse struct {
-	Caddyfile   *string                                 `json:"caddyfile,omitempty"`
+	CaddyJSON   *string                                 `json:"caddyJSON,omitempty"`
 	Domain      string                                  `json:"domain"`
 	Email       openapi_types.Email                     `json:"email"`
 	PanelAccess RURecommendedPreviewResponsePanelAccess `json:"panelAccess"`

--- a/test/e2e/management_flow_test.go
+++ b/test/e2e/management_flow_test.go
@@ -231,19 +231,9 @@ func TestNaiveInboundCaddyJSON(t *testing.T) {
 	}
 	drain(resp)
 
-	data, err = os.ReadFile(caddyJSON)
-	if err != nil {
-		if !os.IsNotExist(err) {
-			t.Fatalf("unexpected error reading regenerated Caddy JSON at %s: %v", caddyJSON, err)
-		}
-	} else {
-		s = string(data)
-		if strings.Contains(s, "forward_proxy") {
-			t.Error("Caddy JSON still contains forward_proxy handler after delete")
-		}
-		if strings.Contains(s, "proxy.example.com") {
-			t.Error("Caddy JSON still contains naive domain after delete")
-		}
+	_, err = os.ReadFile(caddyJSON)
+	if !os.IsNotExist(err) {
+		t.Fatalf("expected Caddy JSON to be removed after inbound deletion, got err=%v", err)
 	}
 }
 

--- a/test/e2e/management_flow_test.go
+++ b/test/e2e/management_flow_test.go
@@ -156,6 +156,57 @@ func TestVersionAndDoctorCLI(t *testing.T) {
 	}
 }
 
+// TestNaiveInboundCaddyJSON creates a naiveproxy inbound, stages an apply, and
+// verifies the generated Caddy JSON config contains the forward_proxy handler
+// and the inbound's domain.
+func TestNaiveInboundCaddyJSON(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
+	srv := startServer(t, serverOptions{token: "e2e-secret-token"})
+
+	resp := srv.do(http.MethodPut, "/api/settings", `{"panelListen":"127.0.0.1:2096","mode":"dev","panelAccess":"direct","domain":"vpn.example.com","email":"admin@example.com","naiveUsername":"sysadmin","naivePassword":"syspassword","defaultInboundPublicPort":443}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("settings expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp))
+	}
+	drain(resp)
+
+	resp = srv.do(http.MethodPost, "/api/inbounds", `{"name":"naive-tcp","protocol":"naiveproxy","transport":"tcp","port":8443,"enabled":true,"naiveUsername":"alice","naivePassword":"alice-pass","protocolFields":{"domain":"proxy.example.com","transport":"tcp","publicPort":8443}}`)
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("inbound expected 201, got %d: %v", resp.StatusCode, readJSON(t, resp))
+	}
+	drain(resp)
+
+	resp = srv.do(http.MethodPost, "/api/apply/plan", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("apply plan expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp))
+	}
+	planBody := readJSON(t, resp)
+	if valid, ok := planBody["valid"].(bool); !ok || !valid {
+		t.Fatalf("expected valid plan, got %v", planBody)
+	}
+	drain(resp)
+
+	resp = srv.do(http.MethodPost, "/api/apply", `{"confirm":true}`)
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusConflict {
+		t.Fatalf("apply expected 200/409, got %d: %v", resp.StatusCode, readJSON(t, resp))
+	}
+	drain(resp)
+
+	caddyJSON := filepath.Join(srv.applyRoot, "generated", "caddy", "config.json")
+	data, err := os.ReadFile(caddyJSON)
+	if err != nil {
+		t.Fatalf("expected Caddy JSON at %s: %v", caddyJSON, err)
+	}
+	s := string(data)
+	if !strings.Contains(s, "forward_proxy") {
+		t.Error("Caddy JSON missing forward_proxy handler")
+	}
+	if !strings.Contains(s, "proxy.example.com") {
+		t.Error("Caddy JSON missing naive domain")
+	}
+}
+
 // TestRejectsDuplicatePortsEndToEnd confirms the safeguard against
 // multiple inbounds trying to listen on the same port surfaces as
 // an apply/plan error over the HTTP surface.

--- a/test/e2e/management_flow_test.go
+++ b/test/e2e/management_flow_test.go
@@ -158,7 +158,8 @@ func TestVersionAndDoctorCLI(t *testing.T) {
 
 // TestNaiveInboundCaddyJSON creates a naiveproxy inbound, stages an apply, and
 // verifies the generated Caddy JSON config contains the forward_proxy handler
-// and the inbound's domain.
+// and the inbound's domain. It then deletes the inbound, re-applies, and
+// asserts the generated config no longer references the deleted inbound.
 func TestNaiveInboundCaddyJSON(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping e2e test in short mode")
@@ -204,6 +205,45 @@ func TestNaiveInboundCaddyJSON(t *testing.T) {
 	}
 	if !strings.Contains(s, "proxy.example.com") {
 		t.Error("Caddy JSON missing naive domain")
+	}
+
+	// Delete the naive inbound and re-apply so the config is regenerated
+	// without it.
+	resp = srv.do(http.MethodDelete, "/api/inbounds/naive-tcp", "")
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("delete inbound expected 204, got %d: %v", resp.StatusCode, readJSON(t, resp))
+	}
+	drain(resp)
+
+	resp = srv.do(http.MethodPost, "/api/apply/plan", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("apply plan after delete expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp))
+	}
+	planBody = readJSON(t, resp)
+	if valid, ok := planBody["valid"].(bool); !ok || !valid {
+		t.Fatalf("expected valid plan after delete, got %v", planBody)
+	}
+	drain(resp)
+
+	resp = srv.do(http.MethodPost, "/api/apply", `{"confirm":true}`)
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusConflict {
+		t.Fatalf("apply after delete expected 200/409, got %d: %v", resp.StatusCode, readJSON(t, resp))
+	}
+	drain(resp)
+
+	data, err = os.ReadFile(caddyJSON)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			t.Fatalf("unexpected error reading regenerated Caddy JSON at %s: %v", caddyJSON, err)
+		}
+	} else {
+		s = string(data)
+		if strings.Contains(s, "forward_proxy") {
+			t.Error("Caddy JSON still contains forward_proxy handler after delete")
+		}
+		if strings.Contains(s, "proxy.example.com") {
+			t.Error("Caddy JSON still contains naive domain after delete")
+		}
 	}
 }
 

--- a/test/e2e/management_flow_test.go
+++ b/test/e2e/management_flow_test.go
@@ -156,17 +156,21 @@ func TestVersionAndDoctorCLI(t *testing.T) {
 	}
 }
 
-// TestNaiveInboundCaddyJSON creates a naiveproxy inbound, stages an apply, and
-// verifies the generated Caddy JSON config contains the forward_proxy handler
-// and the inbound's domain. It then deletes the inbound, re-applies, and
-// asserts the generated config no longer references the deleted inbound.
-func TestNaiveInboundCaddyJSON(t *testing.T) {
+// TestNaiveInboundCreateDeleteCaddyJSON creates a naiveproxy inbound, stages
+// an apply, and verifies the generated Caddy JSON config contains the
+// forward_proxy handler and the inbound's domain. It then deletes the inbound,
+// re-applies, and asserts the generated config is cleaned up.
+//
+// The settings payload includes domain/email/naiveUsername/naivePassword in
+// addition to defaultAcmeEmail because the current naiveproxy settings
+// validator requires the legacy fallback fields to be present.
+func TestNaiveInboundCreateDeleteCaddyJSON(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping e2e test in short mode")
 	}
 	srv := startServer(t, serverOptions{token: "e2e-secret-token"})
 
-	resp := srv.do(http.MethodPut, "/api/settings", `{"panelListen":"127.0.0.1:2096","mode":"dev","panelAccess":"direct","domain":"vpn.example.com","email":"admin@example.com","naiveUsername":"sysadmin","naivePassword":"syspassword","defaultInboundPublicPort":443}`)
+	resp := srv.do(http.MethodPut, "/api/settings", `{"panelListen":"127.0.0.1:2096","mode":"dev","panelAccess":"direct","domain":"vpn.example.com","email":"admin@example.com","defaultAcmeEmail":"admin@example.com","naiveUsername":"sysadmin","naivePassword":"syspassword","defaultInboundPublicPort":443}`)
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("settings expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp))
 	}

--- a/test/e2e/management_flow_test.go
+++ b/test/e2e/management_flow_test.go
@@ -247,7 +247,7 @@ func TestNaiveInboundCreateDeleteCaddyJSON(t *testing.T) {
 func TestRejectsDuplicatePortsEndToEnd(t *testing.T) {
 	srv := startServer(t, serverOptions{token: "tok"})
 
-	resp := srv.do(http.MethodPut, "/api/settings", `{"panelListen":"127.0.0.1:2096","mode":"dev","domain":"vpn.example.com","email":"admin@example.com","naiveUsername":"sysadmin","naivePassword":"syspassword"}`)
+	resp := srv.do(http.MethodPut, "/api/settings", `{"panelListen":"127.0.0.1:2096","mode":"dev","domain":"vpn.example.com","defaultAcmeEmail":"admin@example.com","naiveUsername":"sysadmin","naivePassword":"syspassword"}`)
 	drain(resp)
 
 	// First NaiveProxy inbound on port 20001

--- a/test/e2e/proxy_binary_data_path_test.go
+++ b/test/e2e/proxy_binary_data_path_test.go
@@ -22,7 +22,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
-	"strings"
 	"testing"
 	"time"
 

--- a/test/e2e/proxy_binary_data_path_test.go
+++ b/test/e2e/proxy_binary_data_path_test.go
@@ -489,29 +489,84 @@ func TestNaiveProxyDataPath(t *testing.T) {
 	}
 	drain(resp)
 
-	// 3. Modify generated Caddyfile to run over HTTP (remove domain name and tls directives)
-	serverConfig := filepath.Join(srv.applyRoot, "generated", "caddy", "naive-tcp.Caddyfile")
-	caddyfileContent, err := os.ReadFile(serverConfig)
+	// 3. Modify generated Caddy JSON to run over HTTP on loopback.
+	serverConfig := filepath.Join(srv.applyRoot, "generated", "caddy", "config.json")
+	configBytes, err := os.ReadFile(serverConfig)
 	if err != nil {
-		t.Fatalf("read caddyfile: %v", err)
+		t.Fatalf("read caddy config: %v", err)
 	}
 
-	// Change format: ":port, vpn.example.com {" -> "127.0.0.1:port {"
-	caddyfile := string(caddyfileContent)
-	caddyfile = strings.Replace(caddyfile, fmt.Sprintf(":%d, vpn.example.com", inboundPort), fmt.Sprintf("127.0.0.1:%d", inboundPort), 1)
+	var fullCfg map[string]any
+	if err := json.Unmarshal(configBytes, &fullCfg); err != nil {
+		t.Fatalf("parse caddy config: %v", err)
+	}
+	apps, ok := fullCfg["apps"].(map[string]any)
+	if !ok {
+		t.Fatal("caddy config missing apps")
+	}
+	httpApp, ok := apps["http"].(map[string]any)
+	if !ok {
+		t.Fatal("caddy config missing http app")
+	}
+	servers, ok := httpApp["servers"].(map[string]any)
+	if !ok {
+		t.Fatal("caddy config missing servers")
+	}
 
-	// Remove tls directive
-	reTls := regexp.MustCompile(`(?m)^\s*tls\s+\S+\s*$`)
-	caddyfile = reTls.ReplaceAllString(caddyfile, "")
+	var naiveServer map[string]any
+	for _, srvRaw := range servers {
+		srvMap, ok := srvRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+		routes, ok := srvMap["routes"].([]any)
+		if !ok || len(routes) == 0 {
+			continue
+		}
+		route, ok := routes[0].(map[string]any)
+		if !ok {
+			continue
+		}
+		handlers, ok := route["handle"].([]any)
+		if !ok || len(handlers) == 0 {
+			continue
+		}
+		handler, ok := handlers[0].(map[string]any)
+		if !ok {
+			continue
+		}
+		if handler["handler"] == "forward_proxy" {
+			naiveServer = srvMap
+			break
+		}
+	}
+	if naiveServer == nil {
+		t.Fatal("caddy config missing naive server")
+	}
+	naiveServer["listen"] = []any{fmt.Sprintf("127.0.0.1:%d", inboundPort)}
+	naiveServer["auto_https"] = "off"
 
 	tempDir := t.TempDir()
-	tempCaddyfile := filepath.Join(tempDir, "Caddyfile")
-	if err := os.WriteFile(tempCaddyfile, []byte(caddyfile), 0o600); err != nil {
-		t.Fatalf("write modified caddyfile: %v", err)
+	tempConfig := filepath.Join(tempDir, "config.json")
+	minimalCfg := map[string]any{
+		"apps": map[string]any{
+			"http": map[string]any{
+				"servers": map[string]any{
+					"naive": naiveServer,
+				},
+			},
+		},
+	}
+	minimalBytes, err := json.MarshalIndent(minimalCfg, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal minimal caddy config: %v", err)
+	}
+	if err := os.WriteFile(tempConfig, minimalBytes, 0o600); err != nil {
+		t.Fatalf("write minimal caddy config: %v", err)
 	}
 
 	// 4. Start Caddy server
-	cmdServer := exec.Command(caddyPath, "run", "--config", tempCaddyfile, "--adapter", "caddyfile")
+	cmdServer := exec.Command(caddyPath, "run", "--config", tempConfig)
 	if err := cmdServer.Start(); err != nil {
 		t.Fatalf("start caddy server: %v", err)
 	}

--- a/test/e2e/proxy_binary_data_path_test.go
+++ b/test/e2e/proxy_binary_data_path_test.go
@@ -463,7 +463,7 @@ func TestNaiveProxyDataPath(t *testing.T) {
 
 	// Configure settings and inbound
 	inboundPort := freePort(t)
-	resp := srv.do(http.MethodPut, "/api/settings", `{"panelListen":"127.0.0.1:2096","mode":"dev","domain":"vpn.example.com","email":"test@example.com","naiveUsername":"test-user","naivePassword":"test-pass"}`)
+	resp := srv.do(http.MethodPut, "/api/settings", `{"panelListen":"127.0.0.1:2096","mode":"dev","domain":"vpn.example.com","defaultAcmeEmail":"test@example.com","naiveUsername":"test-user","naivePassword":"test-pass"}`)
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("settings expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp))
 	}
@@ -543,7 +543,7 @@ func TestNaiveProxyDataPath(t *testing.T) {
 		t.Fatal("caddy config missing naive server")
 	}
 	naiveServer["listen"] = []any{fmt.Sprintf("127.0.0.1:%d", inboundPort)}
-	naiveServer["auto_https"] = "off"
+	naiveServer["automatic_https"] = map[string]any{"disable": true}
 
 	tempDir := t.TempDir()
 	tempConfig := filepath.Join(tempDir, "config.json")

--- a/test/e2e/proxy_binary_data_path_test.go
+++ b/test/e2e/proxy_binary_data_path_test.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 

--- a/test/linuxintegration/permissions_test.go
+++ b/test/linuxintegration/permissions_test.go
@@ -44,7 +44,7 @@ func TestIntegrationPanelPermissionMatrix(t *testing.T) {
 	writeFixture(t, filepath.Join(etcDir, "state.key"), "key")
 	writeFixture(t, filepath.Join(etcDir, "veil.env"), "token")
 	writeFixture(t, filepath.Join(etcDir, "backup.passphrase"), "passphrase")
-	writeFixture(t, filepath.Join(etcDir, "generated", "caddy", "panel.Caddyfile"), "config")
+	writeFixture(t, filepath.Join(etcDir, "generated", "caddy", "config.json"), "config")
 	writeFixture(t, filepath.Join(varDir, "state.json"), "state")
 	writeFixture(t, filepath.Join(varDir, "sessions.json"), "sessions")
 	writeFixture(t, filepath.Join(varDir, "backups", "daily.enc"), "backup")


### PR DESCRIPTION
Rebuilds the inbound/Caddy redesign cleanly on top of the current `main` instead of merging the stale divergent implementation.

Initial scope:
- validated TCP/UDP bind-key model;
- canonical IP address handling;
- conservative dual-stack overlap detection;
- deterministic conflict reporting with owner context;
- focused unit tests.

The previous implementation remains only as a reference in `backup/inbound-caddy-redesign-pre-main-sync-20260715`. No encoded patch/chunk artifacts are part of this PR.