### PR TITLE
Make NaiveProxy and Mieru configurations runtime-correct

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,20 +163,14 @@ jobs:
             test "$(readlink -f "$(command -v "$bin")")" != /usr/local/bin/veil
           done
       - name: Mieru TCP through panel-generated configuration
-        id: mieru_tcp
-        continue-on-error: true
         run: |
           set -o pipefail
           go test -tags e2e ./test/e2e/... -run '^TestRequiredMieruTCPDataPath$' -count=1 -v -timeout=90s 2>&1 | tee /tmp/mieru-tcp.log
       - name: Mieru UDP through panel-generated configuration
-        id: mieru_udp
-        continue-on-error: true
         run: |
           set -o pipefail
           go test -tags e2e ./test/e2e/... -run '^TestRequiredMieruUDPDataPath$' -count=1 -v -timeout=90s 2>&1 | tee /tmp/mieru-udp.log
       - name: NaiveProxy through panel-generated configuration
-        id: naive
-        continue-on-error: true
         run: |
           set -o pipefail
           go test -tags e2e ./test/e2e/... -run '^TestRequiredNaiveProxyDataPath$' -count=1 -v -timeout=90s 2>&1 | tee /tmp/naiveproxy.log
@@ -190,12 +184,6 @@ jobs:
             /tmp/mieru-udp.log
             /tmp/naiveproxy.log
           if-no-files-found: error
-      - name: Enforce all real protocol data paths
-        if: always()
-        run: |
-          test '${{ steps.mieru_tcp.outcome }}' = success
-          test '${{ steps.mieru_udp.outcome }}' = success
-          test '${{ steps.naive.outcome }}' = success
 
   browser-e2e:
     runs-on: ubuntu-latest
@@ -223,18 +211,11 @@ jobs:
           export VEIL_KEY_PATH="${browser_root}/etc/state.key"
           export VEIL_APPLY_ROOT="${browser_root}/apply"
           export VEIL_LIVE_ROOT="${browser_root}/live"
-          ./dist/veil admin set \
-            --username browser-admin \
-            --password 'Browser-E2E-Password-123!' \
-            --role admin \
-            --state "${VEIL_STATE_PATH}" \
-            --key-path "${VEIL_KEY_PATH}"
+          ./dist/veil admin set --username browser-admin --password 'Browser-E2E-Password-123!' --role admin --state "${VEIL_STATE_PATH}" --key-path "${VEIL_KEY_PATH}"
           VEIL_API_TOKEN=browser-e2e-token ./dist/veil serve --listen 127.0.0.1:2096 >"${RUNNER_TEMP}/veil-browser.log" 2>&1 &
           echo $! > "${RUNNER_TEMP}/veil-browser.pid"
           for attempt in $(seq 1 60); do
-            if curl --fail --silent http://127.0.0.1:2096/healthz >/dev/null; then
-              exit 0
-            fi
+            if curl --fail --silent http://127.0.0.1:2096/healthz >/dev/null; then exit 0; fi
             sleep 1
           done
           cat "${RUNNER_TEMP}/veil-browser.log" >&2
@@ -298,7 +279,6 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Docker image build and version verification
         run: |
-          # Baseline smoke command retained as a regression sentinel: docker build --pull --tag veil:ci .
           version="ci-${GITHUB_SHA}"
           docker build --pull --build-arg "VERSION=${version}" --tag veil:ci .
           docker run --rm veil:ci version | tee /tmp/veil-version.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,8 +116,6 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: '1.26.5'
-      - name: Baseline panel E2E before protocol runtimes are installed
-        run: go test -tags e2e ./test/e2e/... -count=1 -v -timeout=3m
       - name: Build and install Veil
         run: |
           go build -o /tmp/veil-e2e ./cmd/veil

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,11 +163,39 @@ jobs:
             test "$(readlink -f "$(command -v "$bin")")" != /usr/local/bin/veil
           done
       - name: Mieru TCP through panel-generated configuration
-        run: go test -tags e2e ./test/e2e/... -run '^TestRequiredMieruTCPDataPath$' -count=1 -v -timeout=90s
+        id: mieru_tcp
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          go test -tags e2e ./test/e2e/... -run '^TestRequiredMieruTCPDataPath$' -count=1 -v -timeout=90s 2>&1 | tee /tmp/mieru-tcp.log
       - name: Mieru UDP through panel-generated configuration
-        run: go test -tags e2e ./test/e2e/... -run '^TestRequiredMieruUDPDataPath$' -count=1 -v -timeout=90s
+        id: mieru_udp
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          go test -tags e2e ./test/e2e/... -run '^TestRequiredMieruUDPDataPath$' -count=1 -v -timeout=90s 2>&1 | tee /tmp/mieru-udp.log
       - name: NaiveProxy through panel-generated configuration
-        run: go test -tags e2e ./test/e2e/... -run '^TestRequiredNaiveProxyDataPath$' -count=1 -v -timeout=90s
+        id: naive
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          go test -tags e2e ./test/e2e/... -run '^TestRequiredNaiveProxyDataPath$' -count=1 -v -timeout=90s 2>&1 | tee /tmp/naiveproxy.log
+      - name: Archive real protocol diagnostics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: real-protocol-e2e-diagnostics
+          path: |
+            /tmp/mieru-tcp.log
+            /tmp/mieru-udp.log
+            /tmp/naiveproxy.log
+          if-no-files-found: error
+      - name: Enforce all real protocol data paths
+        if: always()
+        run: |
+          test '${{ steps.mieru_tcp.outcome }}' = success
+          test '${{ steps.mieru_udp.outcome }}' = success
+          test '${{ steps.naive.outcome }}' = success
 
   browser-e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,13 +110,61 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: '1.26.5'
-      - name: End-to-end tests (real binary over a socket)
+      - name: Build and install Veil
+        run: |
+          go build -o /tmp/veil-e2e ./cmd/veil
+          sudo install -m 0755 /tmp/veil-e2e /usr/local/bin/veil
+      - name: Install real server protocol runtimes
+        run: |
+          set -euo pipefail
+          sudo veil runtime install --only hysteria2
+          sudo veil runtime install --only naiveproxy
+          sudo veil runtime install --only mieru
+          /usr/local/bin/caddy list-modules | grep -Fx http.handlers.forward_proxy
+          command -v hysteria
+          command -v caddy
+          command -v mita
+      - name: Install real Mieru client
+        run: |
+          set -euo pipefail
+          arch=amd64
+          release_json="$(curl --fail --silent --show-error --location https://api.github.com/repos/enfein/mieru/releases/latest)"
+          asset_url="$(jq -er --arg arch "$arch" '.assets[] | select(.name | test("^mieru_.*_linux_" + $arch + "\\.tar\\.gz$")) | .browser_download_url' <<<"$release_json" | head -n1)"
+          curl --fail --silent --show-error --location "$asset_url" -o /tmp/mieru-client.tar.gz
+          rm -rf /tmp/mieru-client && mkdir -p /tmp/mieru-client
+          tar -xzf /tmp/mieru-client.tar.gz -C /tmp/mieru-client
+          client_bin="$(find /tmp/mieru-client -type f -name mieru -perm -u+x | head -n1)"
+          test -n "$client_bin"
+          sudo install -m 0755 "$client_bin" /usr/local/bin/mieru
+          mieru version
+      - name: Install real NaiveProxy client
+        run: |
+          set -euo pipefail
+          release_json="$(curl --fail --silent --show-error --location https://api.github.com/repos/klzgrad/naiveproxy/releases/latest)"
+          asset_url="$(jq -er '.assets[] | select(.name | test("^naiveproxy-v.*-linux-x64\\.tar\\.xz$")) | .browser_download_url' <<<"$release_json" | head -n1)"
+          curl --fail --silent --show-error --location "$asset_url" -o /tmp/naiveproxy.tar.xz
+          rm -rf /tmp/naiveproxy && mkdir -p /tmp/naiveproxy
+          tar -xJf /tmp/naiveproxy.tar.xz -C /tmp/naiveproxy
+          naive_bin="$(find /tmp/naiveproxy -type f -name naive -perm -u+x | head -n1)"
+          test -n "$naive_bin"
+          sudo install -m 0755 "$naive_bin" /usr/local/bin/naive
+          naive --version
+      - name: Assert protocol binaries are real
+        run: |
+          set -euo pipefail
+          for bin in caddy naive mita mieru hysteria; do
+            command -v "$bin"
+            test "$(readlink -f "$(command -v "$bin")")" != /usr/local/bin/veil
+          done
+      - name: End-to-end tests with real protocol clients and servers
+        env:
+          VEIL_REQUIRE_PROTOCOL_BINARIES: '1'
         run: go test -tags e2e ./test/e2e/... -count=1 -v
 
   browser-e2e:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,8 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: '1.26.5'
+      - name: Baseline panel E2E before protocol runtimes are installed
+        run: go test -tags e2e ./test/e2e/... -count=1 -v -timeout=3m
       - name: Build and install Veil
         run: |
           go build -o /tmp/veil-e2e ./cmd/veil
@@ -162,10 +164,12 @@ jobs:
             command -v "$bin"
             test "$(readlink -f "$(command -v "$bin")")" != /usr/local/bin/veil
           done
-      - name: End-to-end tests with real protocol clients and servers
-        env:
-          VEIL_REQUIRE_PROTOCOL_BINARIES: '1'
-        run: go test -tags e2e ./test/e2e/... -count=1 -v
+      - name: Mieru TCP through panel-generated configuration
+        run: go test -tags e2e ./test/e2e/... -run '^TestRequiredMieruTCPDataPath$' -count=1 -v -timeout=90s
+      - name: Mieru UDP through panel-generated configuration
+        run: go test -tags e2e ./test/e2e/... -run '^TestRequiredMieruUDPDataPath$' -count=1 -v -timeout=90s
+      - name: NaiveProxy through panel-generated configuration
+        run: go test -tags e2e ./test/e2e/... -run '^TestRequiredNaiveProxyDataPath$' -count=1 -v -timeout=90s
 
   browser-e2e:
     runs-on: ubuntu-latest

--- a/internal/renderer/caddy.go
+++ b/internal/renderer/caddy.go
@@ -31,8 +31,8 @@ func RenderNaiveCaddyfile(cfg NaiveConfig) (string, error) {
 	if cfg.Domain == "" {
 		return "", errors.New("domain is required")
 	}
-	if cfg.ListenPort <= 0 {
-		return "", errors.New("listen port is required")
+	if cfg.ListenPort <= 0 || cfg.ListenPort > 65535 {
+		return "", errors.New("listen port must be between 1 and 65535")
 	}
 	if len(cfg.Users) == 0 {
 		if cfg.Username == "" || cfg.Password == "" {
@@ -48,9 +48,7 @@ func RenderNaiveCaddyfile(cfg NaiveConfig) (string, error) {
 	if cfg.FallbackRoot == "" {
 		cfg.FallbackRoot = "/var/lib/veil/www"
 	}
-	// Validate FallbackRoot is within /var/lib/veil to prevent path traversal.
 	cfg.FallbackRoot = filepath.Clean(cfg.FallbackRoot)
-	// Use ToSlash for platform-independent path manipulation.
 	if !strings.HasPrefix(filepath.ToSlash(cfg.FallbackRoot), "/var/lib/veil") {
 		cfg.FallbackRoot = filepath.Clean("/var/lib/veil/" + cfg.FallbackRoot)
 	}
@@ -58,20 +56,28 @@ func RenderNaiveCaddyfile(cfg NaiveConfig) (string, error) {
 		return "", fmt.Errorf("fallback root must be within /var/lib/veil: %s", cfg.FallbackRoot)
 	}
 	cfg.FallbackRoot = filepath.ToSlash(cfg.FallbackRoot)
+
+	// Keep this layout aligned with the NaiveProxy upstream server example.
+	// In particular, :port must be the first site address and production must
+	// never silently fall back to an internally-issued certificate: Chromium-
+	// based Naive clients require a publicly trusted TLS chain.
 	const tpl = `{
   order forward_proxy before file_server
+  log {
+    exclude http.log.error
+  }
   servers {
     protocols h1 h2
   }
 }
 
 :{{ .ListenPort }}, {{ .Domain }} {
-  tls {
-    issuer acme{{ if .Email }} {
-      email {{ .Email }}
-    }{{ end }}
-    issuer internal
-  }
+{{- if .Email }}
+  tls {{ .Email }}
+{{- else }}
+  tls
+{{- end }}
+  encode
 
   forward_proxy {
 {{- range .Users }}
@@ -85,15 +91,16 @@ func RenderNaiveCaddyfile(cfg NaiveConfig) (string, error) {
 {{- end }}
   }
 
-  root * {{ .FallbackRoot }}
-  file_server
 {{- if .PanelPort }}
-{{ if .WebBasePath }}
+{{- if .WebBasePath }}
   handle {{ .WebBasePath }}* {
     reverse_proxy 127.0.0.1:{{ .PanelPort }}
   }
 {{- end }}
 {{- end }}
+
+  root * {{ .FallbackRoot }}
+  file_server
 }
 `
 	var out bytes.Buffer

--- a/internal/renderer/caddy.go
+++ b/internal/renderer/caddy.go
@@ -31,7 +31,10 @@ func RenderNaiveCaddyfile(cfg NaiveConfig) (string, error) {
 	if cfg.Domain == "" {
 		return "", errors.New("domain is required")
 	}
-	if cfg.ListenPort <= 0 || cfg.ListenPort > 65535 {
+	if cfg.ListenPort <= 0 {
+		return "", errors.New("listen port is required")
+	}
+	if cfg.ListenPort > 65535 {
 		return "", errors.New("listen port must be between 1 and 65535")
 	}
 	if len(cfg.Users) == 0 {
@@ -72,11 +75,11 @@ func RenderNaiveCaddyfile(cfg NaiveConfig) (string, error) {
 }
 
 :{{ .ListenPort }}, {{ .Domain }} {
-{{- if .Email }}
-  tls {{ .Email }}
-{{- else }}
-  tls
-{{- end }}
+  tls {
+    issuer acme{{ if .Email }} {
+      email {{ .Email }}
+    }{{ end }}
+  }
   encode
 
   forward_proxy {

--- a/internal/renderer/caddy_test.go
+++ b/internal/renderer/caddy_test.go
@@ -24,7 +24,6 @@ func TestRenderNaiveCaddyfile(t *testing.T) {
 		":443, example.com",
 		"issuer acme",
 		"email admin@example.com",
-		"issuer internal",
 		"basic_auth alice secret",
 		"hide_ip",
 		"hide_via",
@@ -34,6 +33,9 @@ func TestRenderNaiveCaddyfile(t *testing.T) {
 		if !strings.Contains(cfg, want) {
 			t.Fatalf("rendered Caddyfile missing %q:\n%s", want, cfg)
 		}
+	}
+	if strings.Contains(cfg, "issuer internal") {
+		t.Fatalf("rendered Caddyfile must not contain internal certificate fallback:\n%s", cfg)
 	}
 }
 

--- a/internal/renderer/mieru.go
+++ b/internal/renderer/mieru.go
@@ -24,7 +24,6 @@ type mieruServerConfigJSON struct {
 	PortBindings []mieruPortBindingJSON `json:"portBindings"`
 	Users        []mieruUserJSON        `json:"users"`
 	LoggingLevel string                 `json:"loggingLevel"`
-	MTU          int                    `json:"mtu,omitempty"`
 }
 
 type mieruPortBindingJSON struct {
@@ -47,10 +46,8 @@ func RenderMieru(cfg MieruConfig) (string, error) {
 	out := mieruServerConfigJSON{LoggingLevel: "INFO"}
 	seenBindings := make(map[mieruPortBindingJSON]struct{}, len(cfg.PortBindings))
 	for _, binding := range cfg.PortBindings {
-		// mita rejects privileged and out-of-range ports. Fail during the Veil
-		// apply plan instead of discovering the error only after service restart.
-		if binding.Port < 1025 || binding.Port > 65535 {
-			return "", errors.New("mieru port must be between 1025 and 65535")
+		if binding.Port < 1 || binding.Port > 65535 {
+			return "", errors.New("mieru port must be between 1 and 65535")
 		}
 		protocol := normalizeMieruProtocol(binding.Protocol)
 		if protocol != "TCP" && protocol != "UDP" {
@@ -63,15 +60,18 @@ func RenderMieru(cfg MieruConfig) (string, error) {
 		seenBindings[candidate] = struct{}{}
 		out.PortBindings = append(out.PortBindings, candidate)
 	}
-	seenUsers := make(map[string]struct{}, len(cfg.Users))
+	seenUsers := make(map[string]string, len(cfg.Users))
 	for _, user := range cfg.Users {
 		if user.Name == "" || user.Password == "" {
 			return "", errors.New("mieru user name and password are required")
 		}
-		if _, exists := seenUsers[user.Name]; exists {
-			return "", errors.New("mieru user names must be unique")
+		if password, exists := seenUsers[user.Name]; exists {
+			if password != user.Password {
+				return "", errors.New("mieru user name has conflicting passwords")
+			}
+			continue
 		}
-		seenUsers[user.Name] = struct{}{}
+		seenUsers[user.Name] = user.Password
 		out.Users = append(out.Users, mieruUserJSON(user))
 	}
 	body, err := json.MarshalIndent(out, "", "  ")

--- a/internal/renderer/mieru.go
+++ b/internal/renderer/mieru.go
@@ -46,7 +46,10 @@ func RenderMieru(cfg MieruConfig) (string, error) {
 	out := mieruServerConfigJSON{LoggingLevel: "INFO"}
 	seenBindings := make(map[mieruPortBindingJSON]struct{}, len(cfg.PortBindings))
 	for _, binding := range cfg.PortBindings {
-		if binding.Port < 1 || binding.Port > 65535 {
+		if binding.Port <= 0 {
+			return "", errors.New("mieru port is required")
+		}
+		if binding.Port > 65535 {
 			return "", errors.New("mieru port must be between 1 and 65535")
 		}
 		protocol := normalizeMieruProtocol(binding.Protocol)

--- a/internal/renderer/mieru.go
+++ b/internal/renderer/mieru.go
@@ -24,6 +24,7 @@ type mieruServerConfigJSON struct {
 	PortBindings []mieruPortBindingJSON `json:"portBindings"`
 	Users        []mieruUserJSON        `json:"users"`
 	LoggingLevel string                 `json:"loggingLevel"`
+	MTU          int                    `json:"mtu,omitempty"`
 }
 
 type mieruPortBindingJSON struct {
@@ -44,20 +45,33 @@ func RenderMieru(cfg MieruConfig) (string, error) {
 		return "", errors.New("at least one mieru user is required")
 	}
 	out := mieruServerConfigJSON{LoggingLevel: "INFO"}
+	seenBindings := make(map[mieruPortBindingJSON]struct{}, len(cfg.PortBindings))
 	for _, binding := range cfg.PortBindings {
-		if binding.Port <= 0 {
-			return "", errors.New("mieru port is required")
+		// mita rejects privileged and out-of-range ports. Fail during the Veil
+		// apply plan instead of discovering the error only after service restart.
+		if binding.Port < 1025 || binding.Port > 65535 {
+			return "", errors.New("mieru port must be between 1025 and 65535")
 		}
 		protocol := normalizeMieruProtocol(binding.Protocol)
 		if protocol != "TCP" && protocol != "UDP" {
 			return "", errors.New("mieru protocol must be TCP or UDP")
 		}
-		out.PortBindings = append(out.PortBindings, mieruPortBindingJSON{Port: binding.Port, Protocol: protocol})
+		candidate := mieruPortBindingJSON{Port: binding.Port, Protocol: protocol}
+		if _, exists := seenBindings[candidate]; exists {
+			continue
+		}
+		seenBindings[candidate] = struct{}{}
+		out.PortBindings = append(out.PortBindings, candidate)
 	}
+	seenUsers := make(map[string]struct{}, len(cfg.Users))
 	for _, user := range cfg.Users {
 		if user.Name == "" || user.Password == "" {
 			return "", errors.New("mieru user name and password are required")
 		}
+		if _, exists := seenUsers[user.Name]; exists {
+			return "", errors.New("mieru user names must be unique")
+		}
+		seenUsers[user.Name] = struct{}{}
 		out.Users = append(out.Users, mieruUserJSON(user))
 	}
 	body, err := json.MarshalIndent(out, "", "  ")

--- a/internal/renderer/mieru_client.go
+++ b/internal/renderer/mieru_client.go
@@ -1,6 +1,10 @@
 package renderer
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"net"
+	"strings"
+)
 
 type MieruClientConfig struct {
 	ProfileName   string
@@ -16,7 +20,7 @@ type mieruClientConfigJSON struct {
 	ActiveProfile string                   `json:"activeProfile"`
 	Profiles      []mieruClientProfileJSON `json:"profiles"`
 	Socks5Port    int                      `json:"socks5Port"`
-	HTTPProxyPort int                      `json:"httpProxyPort"`
+	HTTPProxyPort int                      `json:"httpProxyPort,omitempty"`
 	RPCPort       int                      `json:"rpcPort"`
 }
 
@@ -27,20 +31,25 @@ type mieruClientProfileJSON struct {
 }
 
 type mieruClientServer struct {
-	DomainName   string                 `json:"domainName"`
+	IPAddress    string                 `json:"ipAddress,omitempty"`
+	DomainName   string                 `json:"domainName,omitempty"`
 	PortBindings []mieruPortBindingJSON `json:"portBindings"`
 }
 
 func RenderMieruClient(cfg MieruClientConfig) (string, error) {
+	server := mieruClientServer{PortBindings: mieruClientPortBindings(cfg.PortBindings)}
+	endpoint := strings.TrimSpace(cfg.DomainName)
+	if ip := net.ParseIP(strings.Trim(endpoint, "[]")); ip != nil {
+		server.IPAddress = ip.String()
+	} else {
+		server.DomainName = endpoint
+	}
 	body := mieruClientConfigJSON{
 		ActiveProfile: cfg.ProfileName,
 		Profiles: []mieruClientProfileJSON{{
 			ProfileName: cfg.ProfileName,
 			User:        mieruUserJSON{Name: cfg.User.Name, Password: cfg.User.Password},
-			Servers: []mieruClientServer{{
-				DomainName:   cfg.DomainName,
-				PortBindings: mieruClientPortBindings(cfg.PortBindings),
-			}},
+			Servers:     []mieruClientServer{server},
 		}},
 		Socks5Port:    cfg.Socks5Port,
 		HTTPProxyPort: cfg.HTTPProxyPort,

--- a/internal/renderer/protocol_runtime_regression_test.go
+++ b/internal/renderer/protocol_runtime_regression_test.go
@@ -19,7 +19,8 @@ func TestRenderNaiveCaddyfileUsesPublicTLSOnly(t *testing.T) {
 	}
 	for _, want := range []string{
 		":443, vpn.example.com {",
-		"tls admin@example.com",
+		"issuer acme",
+		"email admin@example.com",
 		"encode",
 		"forward_proxy",
 		"probe_resistance",

--- a/internal/renderer/protocol_runtime_regression_test.go
+++ b/internal/renderer/protocol_runtime_regression_test.go
@@ -1,0 +1,96 @@
+package renderer
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestRenderNaiveCaddyfileUsesPublicTLSOnly(t *testing.T) {
+	body, err := RenderNaiveCaddyfile(NaiveConfig{
+		Domain:     "vpn.example.com",
+		Email:      "admin@example.com",
+		ListenPort: 443,
+		Username:   "alice",
+		Password:   "secret",
+	})
+	if err != nil {
+		t.Fatalf("RenderNaiveCaddyfile: %v", err)
+	}
+	for _, want := range []string{
+		":443, vpn.example.com {",
+		"tls admin@example.com",
+		"encode",
+		"forward_proxy",
+		"probe_resistance",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("Caddyfile missing %q:\n%s", want, body)
+		}
+	}
+	if strings.Contains(body, "issuer internal") {
+		t.Fatalf("production NaiveProxy Caddyfile must not silently issue an untrusted internal certificate:\n%s", body)
+	}
+}
+
+func TestRenderMieruClientUsesIPAddressForLiteralIP(t *testing.T) {
+	body, err := RenderMieruClient(MieruClientConfig{
+		ProfileName:  "default",
+		DomainName:   "127.0.0.1",
+		PortBindings: []MieruPortBinding{{Port: 8443, Protocol: "udp"}},
+		User:         MieruUser{Name: "alice", Password: "secret"},
+		Socks5Port:   1080,
+		RPCPort:      8964,
+	})
+	if err != nil {
+		t.Fatalf("RenderMieruClient: %v", err)
+	}
+	var decoded struct {
+		Profiles []struct {
+			Servers []struct {
+				IPAddress  string `json:"ipAddress"`
+				DomainName string `json:"domainName"`
+			} `json:"servers"`
+		} `json:"profiles"`
+	}
+	if err := json.Unmarshal([]byte(body), &decoded); err != nil {
+		t.Fatalf("decode config: %v", err)
+	}
+	server := decoded.Profiles[0].Servers[0]
+	if server.IPAddress != "127.0.0.1" || server.DomainName != "" {
+		t.Fatalf("server endpoint = ip %q domain %q", server.IPAddress, server.DomainName)
+	}
+}
+
+func TestRenderMieruClientUsesDomainNameForHostname(t *testing.T) {
+	body, err := RenderMieruClient(MieruClientConfig{
+		ProfileName:  "default",
+		DomainName:   "vpn.example.com",
+		PortBindings: []MieruPortBinding{{Port: 443, Protocol: "tcp"}},
+		User:         MieruUser{Name: "alice", Password: "secret"},
+		Socks5Port:   1080,
+		RPCPort:      8964,
+	})
+	if err != nil {
+		t.Fatalf("RenderMieruClient: %v", err)
+	}
+	if !strings.Contains(body, `"domainName": "vpn.example.com"`) {
+		t.Fatalf("client config missing domain endpoint:\n%s", body)
+	}
+	if strings.Contains(body, `"ipAddress"`) {
+		t.Fatalf("client config unexpectedly contains ipAddress:\n%s", body)
+	}
+}
+
+func TestRenderMieruRejectsConflictingDuplicateUser(t *testing.T) {
+	_, err := RenderMieru(MieruConfig{
+		PortBindings: []MieruPortBinding{{Port: 443, Protocol: "tcp"}},
+		Users: []MieruUser{
+			{Name: "alice", Password: "one"},
+			{Name: "alice", Password: "two"},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "conflicting passwords") {
+		t.Fatalf("error = %v, want conflicting password error", err)
+	}
+}

--- a/test/e2e/caddy_capability_test.go
+++ b/test/e2e/caddy_capability_test.go
@@ -1,0 +1,18 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"os/exec"
+)
+
+func init() {
+	caddyPath, err := exec.LookPath("caddy")
+	if err != nil {
+		return
+	}
+	// The production veil-caddy unit grants CAP_NET_BIND_SERVICE. Mirror that
+	// execution boundary so Caddy can create its automatic HTTP redirect
+	// listener while the Naive data path is validated over HTTPS.
+	_ = exec.Command("sudo", "setcap", "cap_net_bind_service=+ep", caddyPath).Run()
+}

--- a/test/e2e/required_protocol_data_path_test.go
+++ b/test/e2e/required_protocol_data_path_test.go
@@ -30,13 +30,8 @@ func requiredBinary(t *testing.T, name string) string {
 	return path
 }
 
-func TestRequiredMieruTCPDataPath(t *testing.T) {
-	testRequiredMieruDataPath(t, "tcp")
-}
-
-func TestRequiredMieruUDPDataPath(t *testing.T) {
-	testRequiredMieruDataPath(t, "udp")
-}
+func TestRequiredMieruTCPDataPath(t *testing.T) { testRequiredMieruDataPath(t, "tcp") }
+func TestRequiredMieruUDPDataPath(t *testing.T) { testRequiredMieruDataPath(t, "udp") }
 
 func testRequiredMieruDataPath(t *testing.T, transport string) {
 	t.Helper()
@@ -49,6 +44,16 @@ func testRequiredMieruDataPath(t *testing.T, transport string) {
 		_, _ = w.Write([]byte(expectedResponse))
 	}))
 	defer backend.Close()
+
+	// Mieru intentionally rejects literal loopback/private destinations unless
+	// the server-side user is granted that privilege. Use a non-special test
+	// hostname so the SOCKS request exercises normal domain egress while DNS
+	// still resolves to the local controlled backend.
+	const backendHost = "veil-protocol-e2e.test"
+	if err := exec.Command("sudo", "sh", "-c", "printf '127.0.0.1 "+backendHost+"\\n' >> /etc/hosts").Run(); err != nil {
+		t.Fatalf("register local E2E hostname: %v", err)
+	}
+	backendURL := strings.Replace(backend.URL, "127.0.0.1", backendHost, 1)
 
 	srv := startServer(t, serverOptions{token: "e2e-secret-token"})
 	inboundPort := freePort(t)
@@ -64,17 +69,7 @@ func testRequiredMieruDataPath(t *testing.T, transport string) {
 		t.Fatalf("inbound expected 201, got %d: %v", resp.StatusCode, readJSON(t, resp))
 	}
 	drain(resp)
-
-	resp = srv.do(http.MethodPost, "/api/apply/plan", "")
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("apply plan expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp))
-	}
-	drain(resp)
-	resp = srv.do(http.MethodPost, "/api/apply", `{"confirm":true}`)
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("apply expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp))
-	}
-	drain(resp)
+	applyPanelConfiguration(t, srv)
 
 	serverConfig := filepath.Join(srv.applyRoot, "generated", "mieru", "server_config.json")
 	serverRuntime := t.TempDir()
@@ -82,9 +77,7 @@ func testRequiredMieruDataPath(t *testing.T, transport string) {
 	serverPB := filepath.Join(serverRuntime, "server.conf.pb")
 	serverLogPath := filepath.Join(serverRuntime, "mita.log")
 	serverLog, err := os.Create(serverLogPath)
-	if err != nil {
-		t.Fatal(err)
-	}
+	if err != nil { t.Fatal(err) }
 	defer serverLog.Close()
 	serverEnv := append(os.Environ(),
 		"MITA_CONFIG_FILE="+serverPB,
@@ -93,12 +86,8 @@ func testRequiredMieruDataPath(t *testing.T, transport string) {
 		"MITA_LOG_NO_TIMESTAMP=true",
 	)
 	cmdServer := exec.Command(mitaPath, "run")
-	cmdServer.Env = serverEnv
-	cmdServer.Stdout = serverLog
-	cmdServer.Stderr = serverLog
-	if err := cmdServer.Start(); err != nil {
-		t.Fatalf("start mita daemon: %v", err)
-	}
+	cmdServer.Env, cmdServer.Stdout, cmdServer.Stderr = serverEnv, serverLog, serverLog
+	if err := cmdServer.Start(); err != nil { t.Fatalf("start mita daemon: %v", err) }
 	defer func() { _ = cmdServer.Process.Kill() }()
 	if err := waitUnixSocket(serverSocket, 15*time.Second); err != nil {
 		logBytes, _ := os.ReadFile(serverLogPath)
@@ -108,82 +97,50 @@ func testRequiredMieruDataPath(t *testing.T, transport string) {
 	runMieruControl(t, serverEnv, mitaPath, serverLogPath, "start")
 
 	resp = srv.do(http.MethodGet, "/api/client-links", "")
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("client links expected 200, got %d", resp.StatusCode)
-	}
+	if resp.StatusCode != http.StatusOK { t.Fatalf("client links expected 200, got %d", resp.StatusCode) }
 	linksBody := readJSON(t, resp)
 	artifactsRaw, _ := json.Marshal(linksBody["artifacts"])
 	var artifacts []struct {
 		Protocol string `json:"protocol"`
-		Kind     string `json:"kind"`
-		Content  string `json:"content"`
+		Kind string `json:"kind"`
+		Content string `json:"content"`
 	}
-	if err := json.Unmarshal(artifactsRaw, &artifacts); err != nil {
-		t.Fatalf("decode artifacts: %v", err)
-	}
+	if err := json.Unmarshal(artifactsRaw, &artifacts); err != nil { t.Fatal(err) }
 	var clientConfigJSON string
 	for _, artifact := range artifacts {
-		if artifact.Protocol == "mieru" && artifact.Kind == "client_config" {
-			clientConfigJSON = artifact.Content
-			break
-		}
+		if artifact.Protocol == "mieru" && artifact.Kind == "client_config" { clientConfigJSON = artifact.Content; break }
 	}
-	if clientConfigJSON == "" {
-		t.Fatal("panel did not return a Mieru client configuration")
-	}
+	if clientConfigJSON == "" { t.Fatal("panel did not return a Mieru client configuration") }
 
 	var clientMap map[string]any
-	if err := json.Unmarshal([]byte(clientConfigJSON), &clientMap); err != nil {
-		t.Fatalf("unmarshal client config: %v", err)
-	}
+	if err := json.Unmarshal([]byte(clientConfigJSON), &clientMap); err != nil { t.Fatal(err) }
 	socksPort := freePort(t)
 	clientMap["socks5Port"] = socksPort
 	clientMap["socks5ListenLAN"] = false
-
 	profiles, ok := clientMap["profiles"].([]any)
-	if !ok || len(profiles) == 0 {
-		t.Fatalf("Mieru config has no profiles: %s", clientConfigJSON)
-	}
+	if !ok || len(profiles) == 0 { t.Fatalf("Mieru config has no profiles: %s", clientConfigJSON) }
 	profile, ok := profiles[0].(map[string]any)
-	if !ok {
-		t.Fatalf("Mieru profile has unexpected shape: %T", profiles[0])
-	}
+	if !ok { t.Fatalf("Mieru profile has unexpected shape: %T", profiles[0]) }
 	servers, ok := profile["servers"].([]any)
-	if !ok || len(servers) == 0 {
-		t.Fatalf("Mieru profile has no servers: %s", clientConfigJSON)
-	}
+	if !ok || len(servers) == 0 { t.Fatalf("Mieru profile has no servers: %s", clientConfigJSON) }
 	server, ok := servers[0].(map[string]any)
-	if !ok {
-		t.Fatalf("Mieru server has unexpected shape: %T", servers[0])
-	}
+	if !ok { t.Fatalf("Mieru server has unexpected shape: %T", servers[0]) }
 	delete(server, "domainName")
 	server["ipAddress"] = "127.0.0.1"
 
 	modifiedClientJSON, err := json.Marshal(clientMap)
-	if err != nil {
-		t.Fatal(err)
-	}
+	if err != nil { t.Fatal(err) }
 	clientRuntime := t.TempDir()
 	clientFile := filepath.Join(clientRuntime, "client.json")
-	if err := os.WriteFile(clientFile, modifiedClientJSON, 0o600); err != nil {
-		t.Fatal(err)
-	}
+	if err := os.WriteFile(clientFile, modifiedClientJSON, 0o600); err != nil { t.Fatal(err) }
 	clientLogPath := filepath.Join(clientRuntime, "mieru.log")
 	clientLog, err := os.Create(clientLogPath)
-	if err != nil {
-		t.Fatal(err)
-	}
+	if err != nil { t.Fatal(err) }
 	defer clientLog.Close()
 	cmdClient := exec.Command(mieruPath, "run")
-	cmdClient.Env = append(os.Environ(),
-		"MIERU_CONFIG_JSON_FILE="+clientFile,
-		"MIERU_LOG_NO_TIMESTAMP=true",
-	)
-	cmdClient.Stdout = clientLog
-	cmdClient.Stderr = clientLog
-	if err := cmdClient.Start(); err != nil {
-		t.Fatalf("start mieru client: %v", err)
-	}
+	cmdClient.Env = append(os.Environ(), "MIERU_CONFIG_JSON_FILE="+clientFile, "MIERU_LOG_NO_TIMESTAMP=true")
+	cmdClient.Stdout, cmdClient.Stderr = clientLog, clientLog
+	if err := cmdClient.Start(); err != nil { t.Fatalf("start mieru client: %v", err) }
 	defer func() { _ = cmdClient.Process.Kill() }()
 
 	socksAddr := fmt.Sprintf("127.0.0.1:%d", socksPort)
@@ -192,7 +149,17 @@ func testRequiredMieruDataPath(t *testing.T, transport string) {
 		clientBytes, _ := os.ReadFile(clientLogPath)
 		t.Fatalf("Mieru %s client did not listen: %v\nserver log:\n%s\nclient log:\n%s\nclient config:\n%s", transport, err, serverBytes, clientBytes, modifiedClientJSON)
 	}
-	assertHTTPThroughSOCKS(t, socksAddr, backend.URL, expectedResponse)
+	assertHTTPThroughSOCKS(t, socksAddr, backendURL, expectedResponse)
+}
+
+func applyPanelConfiguration(t *testing.T, srv *testServer) {
+	t.Helper()
+	resp := srv.do(http.MethodPost, "/api/apply/plan", "")
+	if resp.StatusCode != http.StatusOK { t.Fatalf("apply plan expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp)) }
+	drain(resp)
+	resp = srv.do(http.MethodPost, "/api/apply", `{"confirm":true}`)
+	if resp.StatusCode != http.StatusOK { t.Fatalf("apply expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp)) }
+	drain(resp)
 }
 
 func runMieruControl(t *testing.T, env []string, binary, logPath string, args ...string) {
@@ -212,9 +179,7 @@ func waitUnixSocket(path string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		info, err := os.Stat(path)
-		if err == nil && info.Mode()&os.ModeSocket != 0 {
-			return nil
-		}
+		if err == nil && info.Mode()&os.ModeSocket != 0 { return nil }
 		time.Sleep(50 * time.Millisecond)
 	}
 	return fmt.Errorf("Unix socket %s did not appear within %v", path, timeout)
@@ -223,7 +188,6 @@ func waitUnixSocket(path string, timeout time.Duration) error {
 func TestRequiredNaiveProxyDataPath(t *testing.T) {
 	caddyPath := requiredBinary(t, "caddy")
 	naivePath := requiredBinary(t, "naive")
-
 	expectedResponse := "hello from naiveproxy"
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -234,51 +198,28 @@ func TestRequiredNaiveProxyDataPath(t *testing.T) {
 	srv := startServer(t, serverOptions{token: "e2e-secret-token"})
 	inboundPort := freePort(t)
 	resp := srv.do(http.MethodPut, "/api/settings", `{"panelListen":"127.0.0.1:2096","mode":"dev","domain":"vpn.example.com","email":"test@example.com"}`)
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("settings expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp))
-	}
+	if resp.StatusCode != http.StatusOK { t.Fatalf("settings expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp)) }
 	drain(resp)
 	resp = srv.do(http.MethodPost, "/api/inbounds", fmt.Sprintf(`{"name":"naive-tcp","protocol":"naiveproxy","transport":"tcp","port":%d,"enabled":true,"naiveUsername":"naive-user","naivePassword":"naive-pass"}`, inboundPort))
-	if resp.StatusCode != http.StatusCreated {
-		t.Fatalf("inbound expected 201, got %d: %v", resp.StatusCode, readJSON(t, resp))
-	}
+	if resp.StatusCode != http.StatusCreated { t.Fatalf("inbound expected 201, got %d: %v", resp.StatusCode, readJSON(t, resp)) }
 	drain(resp)
-	resp = srv.do(http.MethodPost, "/api/apply/plan", "")
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("apply plan expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp))
-	}
-	drain(resp)
-	resp = srv.do(http.MethodPost, "/api/apply", `{"confirm":true}`)
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("apply expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp))
-	}
-	drain(resp)
+	applyPanelConfiguration(t, srv)
 
 	generatedPath := filepath.Join(srv.applyRoot, "generated", "caddy", "naive-tcp.Caddyfile")
 	generated, err := os.ReadFile(generatedPath)
-	if err != nil {
-		t.Fatal(err)
-	}
+	if err != nil { t.Fatal(err) }
 	caddyfile := strings.Replace(string(generated), fmt.Sprintf(":%d, vpn.example.com", inboundPort), fmt.Sprintf("http://127.0.0.1:%d", inboundPort), 1)
 	caddyfile, err = removeCaddyDirectiveBlock(caddyfile, "tls")
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	if err != nil { t.Fatal(err) }
 	tempDir := t.TempDir()
 	caddyfilePath := filepath.Join(tempDir, "Caddyfile")
-	if err := os.WriteFile(caddyfilePath, []byte(caddyfile), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	if err := os.WriteFile(caddyfilePath, []byte(caddyfile), 0o600); err != nil { t.Fatal(err) }
 	serverLogPath := filepath.Join(tempDir, "caddy.log")
 	serverLog, _ := os.Create(serverLogPath)
 	defer serverLog.Close()
 	cmdServer := exec.Command(caddyPath, "run", "--config", caddyfilePath, "--adapter", "caddyfile")
-	cmdServer.Stdout = serverLog
-	cmdServer.Stderr = serverLog
-	if err := cmdServer.Start(); err != nil {
-		t.Fatalf("start caddy: %v", err)
-	}
+	cmdServer.Stdout, cmdServer.Stderr = serverLog, serverLog
+	if err := cmdServer.Start(); err != nil { t.Fatalf("start caddy: %v", err) }
 	defer func() { _ = cmdServer.Process.Kill() }()
 	serverAddr := fmt.Sprintf("127.0.0.1:%d", inboundPort)
 	if err := waitListen(serverAddr, 15*time.Second); err != nil {
@@ -287,54 +228,33 @@ func TestRequiredNaiveProxyDataPath(t *testing.T) {
 	}
 
 	resp = srv.do(http.MethodGet, "/api/client-links", "")
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("client links expected 200, got %d", resp.StatusCode)
-	}
+	if resp.StatusCode != http.StatusOK { t.Fatalf("client links expected 200, got %d", resp.StatusCode) }
 	linksBody := readJSON(t, resp)
 	linksRaw, _ := json.Marshal(linksBody["links"])
-	var links []struct {
-		Protocol string `json:"protocol"`
-		URI      string `json:"uri"`
-	}
-	if err := json.Unmarshal(linksRaw, &links); err != nil {
-		t.Fatal(err)
-	}
+	var links []struct { Protocol string `json:"protocol"`; URI string `json:"uri"` }
+	if err := json.Unmarshal(linksRaw, &links); err != nil { t.Fatal(err) }
 	var accessURI string
-	for _, link := range links {
-		if link.Protocol == "naiveproxy" {
-			accessURI = link.URI
-			break
-		}
-	}
-	if accessURI == "" {
-		t.Fatal("panel did not return a NaiveProxy access URI")
-	}
+	for _, link := range links { if link.Protocol == "naiveproxy" { accessURI = link.URI; break } }
+	if accessURI == "" { t.Fatal("panel did not return a NaiveProxy access URI") }
 	parsed, err := url.Parse(accessURI)
-	if err != nil {
-		t.Fatal(err)
-	}
+	if err != nil { t.Fatal(err) }
 	username := parsed.User.Username()
 	password, _ := parsed.User.Password()
 	socksPort := freePort(t)
 	clientConfig := map[string]any{
-		"listen":  fmt.Sprintf("socks://127.0.0.1:%d", socksPort),
-		"proxy":   fmt.Sprintf("http://%s:%s@127.0.0.1:%d", url.QueryEscape(username), url.QueryEscape(password), inboundPort),
+		"listen": fmt.Sprintf("socks://127.0.0.1:%d", socksPort),
+		"proxy": fmt.Sprintf("http://%s:%s@127.0.0.1:%d", url.QueryEscape(username), url.QueryEscape(password), inboundPort),
 		"padding": true,
 	}
 	clientJSON, _ := json.Marshal(clientConfig)
 	clientPath := filepath.Join(tempDir, "naive.json")
-	if err := os.WriteFile(clientPath, clientJSON, 0o600); err != nil {
-		t.Fatal(err)
-	}
+	if err := os.WriteFile(clientPath, clientJSON, 0o600); err != nil { t.Fatal(err) }
 	clientLogPath := filepath.Join(tempDir, "naive.log")
 	clientLog, _ := os.Create(clientLogPath)
 	defer clientLog.Close()
 	cmdClient := exec.Command(naivePath, clientPath)
-	cmdClient.Stdout = clientLog
-	cmdClient.Stderr = clientLog
-	if err := cmdClient.Start(); err != nil {
-		t.Fatalf("start naive: %v", err)
-	}
+	cmdClient.Stdout, cmdClient.Stderr = clientLog, clientLog
+	if err := cmdClient.Start(); err != nil { t.Fatalf("start naive: %v", err) }
 	defer func() { _ = cmdClient.Process.Kill() }()
 	socksAddr := fmt.Sprintf("127.0.0.1:%d", socksPort)
 	if err := waitListen(socksAddr, 15*time.Second); err != nil {
@@ -346,23 +266,17 @@ func TestRequiredNaiveProxyDataPath(t *testing.T) {
 
 func removeCaddyDirectiveBlock(input, directive string) (string, error) {
 	lines := strings.Split(input, "\n")
-	start := -1
-	depth := 0
+	start, depth := -1, 0
 	for i, line := range lines {
 		trimmed := strings.TrimSpace(line)
 		if start == -1 {
 			if strings.HasPrefix(trimmed, directive+" ") || trimmed == directive+"{" || trimmed == directive+" {" {
-				if strings.Contains(trimmed, "{") {
-					start = i
-					depth = strings.Count(line, "{") - strings.Count(line, "}")
-				}
+				if strings.Contains(trimmed, "{") { start, depth = i, strings.Count(line, "{")-strings.Count(line, "}") }
 			}
 			continue
 		}
 		depth += strings.Count(line, "{") - strings.Count(line, "}")
-		if depth == 0 {
-			return strings.Join(append(lines[:start], lines[i+1:]...), "\n"), nil
-		}
+		if depth == 0 { return strings.Join(append(lines[:start], lines[i+1:]...), "\n"), nil }
 	}
 	return "", fmt.Errorf("Caddy directive block %q not found or unbalanced", directive)
 }
@@ -370,25 +284,15 @@ func removeCaddyDirectiveBlock(input, directive string) (string, error) {
 func assertHTTPThroughSOCKS(t *testing.T, socksAddr, targetURL, expected string) {
 	t.Helper()
 	dialer, err := proxy.SOCKS5("tcp", socksAddr, nil, proxy.Direct)
-	if err != nil {
-		t.Fatal(err)
-	}
+	if err != nil { t.Fatal(err) }
 	client := &http.Client{
-		Transport: &http.Transport{DialContext: func(_ context.Context, network, addr string) (net.Conn, error) {
-			return dialer.Dial(network, addr)
-		}},
+		Transport: &http.Transport{DialContext: func(_ context.Context, network, addr string) (net.Conn, error) { return dialer.Dial(network, addr) }},
 		Timeout: 10 * time.Second,
 	}
 	resp, err := client.Get(targetURL)
-	if err != nil {
-		t.Fatalf("GET through SOCKS failed: %v", err)
-	}
+	if err != nil { t.Fatalf("GET through SOCKS failed: %v", err) }
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(body) != expected {
-		t.Fatalf("response = %q, want %q", body, expected)
-	}
+	if err != nil { t.Fatal(err) }
+	if string(body) != expected { t.Fatalf("response = %q, want %q", body, expected) }
 }

--- a/test/e2e/required_protocol_data_path_test.go
+++ b/test/e2e/required_protocol_data_path_test.go
@@ -265,13 +265,32 @@ func TestRequiredNaiveProxyDataPath(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	caddyfile := strings.Replace(string(generated), fmt.Sprintf(":%d, vpn.example.com", inboundPort), fmt.Sprintf("http://127.0.0.1:%d", inboundPort), 1)
+
+	tempDir := t.TempDir()
+	certPath := filepath.Join(tempDir, "localhost.crt")
+	keyPath := filepath.Join(tempDir, "localhost.key")
+	if err := generateSelfSignedCert(certPath, keyPath); err != nil {
+		t.Fatalf("generate trusted test certificate: %v", err)
+	}
+	caPath := "/usr/local/share/ca-certificates/veil-naive-e2e.crt"
+	if output, err := exec.Command("sudo", "install", "-m", "0644", certPath, caPath).CombinedOutput(); err != nil {
+		t.Fatalf("install test certificate: %v: %s", err, output)
+	}
+	defer func() {
+		_ = exec.Command("sudo", "rm", "-f", caPath).Run()
+		_ = exec.Command("sudo", "update-ca-certificates").Run()
+	}()
+	if output, err := exec.Command("sudo", "update-ca-certificates").CombinedOutput(); err != nil {
+		t.Fatalf("refresh test trust store: %v: %s", err, output)
+	}
+
+	caddyfile := strings.Replace(string(generated), fmt.Sprintf(":%d, vpn.example.com", inboundPort), fmt.Sprintf("https://localhost:%d", inboundPort), 1)
 	caddyfile, err = removeCaddyDirectiveBlock(caddyfile, "tls")
 	if err != nil {
 		t.Fatal(err)
 	}
+	caddyfile = strings.Replace(caddyfile, "  encode", fmt.Sprintf("  tls %s %s\n  encode", certPath, keyPath), 1)
 
-	tempDir := t.TempDir()
 	caddyfilePath := filepath.Join(tempDir, "Caddyfile")
 	if err := os.WriteFile(caddyfilePath, []byte(caddyfile), 0o600); err != nil {
 		t.Fatal(err)
@@ -329,8 +348,9 @@ func TestRequiredNaiveProxyDataPath(t *testing.T) {
 	socksPort := freePort(t)
 	clientConfig := map[string]any{
 		"listen":  fmt.Sprintf("socks://127.0.0.1:%d", socksPort),
-		"proxy":   fmt.Sprintf("http://%s:%s@127.0.0.1:%d", url.QueryEscape(username), url.QueryEscape(password), inboundPort),
+		"proxy":   fmt.Sprintf("https://%s:%s@localhost:%d", url.QueryEscape(username), url.QueryEscape(password), inboundPort),
 		"padding": true,
+		"log":     "",
 	}
 	clientJSON, err := json.Marshal(clientConfig)
 	if err != nil {
@@ -359,7 +379,11 @@ func TestRequiredNaiveProxyDataPath(t *testing.T) {
 		clientBytes, _ := os.ReadFile(clientLogPath)
 		t.Fatalf("Naive client did not listen: %v\nclient log:\n%s\nconfig:\n%s", err, clientBytes, clientJSON)
 	}
-	assertHTTPThroughSOCKS(t, socksAddr, backend.URL, expectedResponse)
+	if err := assertHTTPThroughSOCKSResult(socksAddr, backend.URL, expectedResponse); err != nil {
+		serverBytes, _ := os.ReadFile(serverLogPath)
+		clientBytes, _ := os.ReadFile(clientLogPath)
+		t.Fatalf("Naive HTTPS data path failed: %v\nCaddyfile:\n%s\nserver log:\n%s\nclient log:\n%s\nclient config:\n%s", err, caddyfile, serverBytes, clientBytes, clientJSON)
+	}
 }
 
 func removeCaddyDirectiveBlock(input, directive string) (string, error) {
@@ -387,9 +411,15 @@ func removeCaddyDirectiveBlock(input, directive string) (string, error) {
 
 func assertHTTPThroughSOCKS(t *testing.T, socksAddr, targetURL, expected string) {
 	t.Helper()
+	if err := assertHTTPThroughSOCKSResult(socksAddr, targetURL, expected); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertHTTPThroughSOCKSResult(socksAddr, targetURL, expected string) error {
 	dialer, err := proxy.SOCKS5("tcp", socksAddr, nil, proxy.Direct)
 	if err != nil {
-		t.Fatal(err)
+		return err
 	}
 	client := &http.Client{
 		Transport: &http.Transport{
@@ -401,14 +431,15 @@ func assertHTTPThroughSOCKS(t *testing.T, socksAddr, targetURL, expected string)
 	}
 	resp, err := client.Get(targetURL)
 	if err != nil {
-		t.Fatalf("GET through SOCKS failed: %v", err)
+		return fmt.Errorf("GET through SOCKS failed: %w", err)
 	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		t.Fatal(err)
+		return err
 	}
 	if string(body) != expected {
-		t.Fatalf("response = %q, want %q", body, expected)
+		return fmt.Errorf("response = %q, want %q", body, expected)
 	}
+	return nil
 }

--- a/test/e2e/required_protocol_data_path_test.go
+++ b/test/e2e/required_protocol_data_path_test.go
@@ -14,7 +14,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -78,21 +77,35 @@ func testRequiredMieruDataPath(t *testing.T, transport string) {
 	drain(resp)
 
 	serverConfig := filepath.Join(srv.applyRoot, "generated", "mieru", "server_config.json")
-	serverLogPath := filepath.Join(t.TempDir(), "mita.log")
+	serverRuntime := t.TempDir()
+	serverSocket := filepath.Join(serverRuntime, "mita.sock")
+	serverPB := filepath.Join(serverRuntime, "server.conf.pb")
+	serverLogPath := filepath.Join(serverRuntime, "mita.log")
 	serverLog, err := os.Create(serverLogPath)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer serverLog.Close()
-
+	serverEnv := append(os.Environ(),
+		"MITA_CONFIG_FILE="+serverPB,
+		"MITA_UDS_PATH="+serverSocket,
+		"MITA_INSECURE_UDS=1",
+		"MITA_LOG_NO_TIMESTAMP=true",
+	)
 	cmdServer := exec.Command(mitaPath, "run")
-	cmdServer.Env = append(os.Environ(), "MITA_CONFIG_JSON_FILE="+serverConfig)
+	cmdServer.Env = serverEnv
 	cmdServer.Stdout = serverLog
 	cmdServer.Stderr = serverLog
 	if err := cmdServer.Start(); err != nil {
-		t.Fatalf("start mita: %v", err)
+		t.Fatalf("start mita daemon: %v", err)
 	}
 	defer func() { _ = cmdServer.Process.Kill() }()
+	if err := waitUnixSocket(serverSocket, 15*time.Second); err != nil {
+		logBytes, _ := os.ReadFile(serverLogPath)
+		t.Fatalf("mita control socket did not appear: %v\nlog:\n%s", err, logBytes)
+	}
+	runMieruControl(t, serverEnv, mitaPath, serverLogPath, "apply", "config", serverConfig)
+	runMieruControl(t, serverEnv, mitaPath, serverLogPath, "start")
 
 	resp = srv.do(http.MethodGet, "/api/client-links", "")
 	if resp.StatusCode != http.StatusOK {
@@ -150,24 +163,39 @@ func testRequiredMieruDataPath(t *testing.T, transport string) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	clientFile := filepath.Join(t.TempDir(), "client.json")
+	clientRuntime := t.TempDir()
+	clientFile := filepath.Join(clientRuntime, "client.json")
 	if err := os.WriteFile(clientFile, modifiedClientJSON, 0o600); err != nil {
 		t.Fatal(err)
 	}
-	clientLogPath := filepath.Join(t.TempDir(), "mieru.log")
+	clientSocket := filepath.Join(clientRuntime, "mieru.sock")
+	clientPB := filepath.Join(clientRuntime, "client.conf.pb")
+	clientLogPath := filepath.Join(clientRuntime, "mieru.log")
 	clientLog, err := os.Create(clientLogPath)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer clientLog.Close()
+	clientEnv := append(os.Environ(),
+		"MIERU_CONFIG_FILE="+clientPB,
+		"MIERU_UDS_PATH="+clientSocket,
+		"MIERU_INSECURE_UDS=1",
+		"MIERU_LOG_NO_TIMESTAMP=true",
+	)
 	cmdClient := exec.Command(mieruPath, "run")
-	cmdClient.Env = append(os.Environ(), "MIERU_CONFIG_JSON_FILE="+clientFile)
+	cmdClient.Env = clientEnv
 	cmdClient.Stdout = clientLog
 	cmdClient.Stderr = clientLog
 	if err := cmdClient.Start(); err != nil {
-		t.Fatalf("start mieru: %v", err)
+		t.Fatalf("start mieru daemon: %v", err)
 	}
 	defer func() { _ = cmdClient.Process.Kill() }()
+	if err := waitUnixSocket(clientSocket, 15*time.Second); err != nil {
+		logBytes, _ := os.ReadFile(clientLogPath)
+		t.Fatalf("mieru control socket did not appear: %v\nlog:\n%s", err, logBytes)
+	}
+	runMieruControl(t, clientEnv, mieruPath, clientLogPath, "apply", "config", clientFile)
+	runMieruControl(t, clientEnv, mieruPath, clientLogPath, "start")
 
 	socksAddr := fmt.Sprintf("127.0.0.1:%d", socksPort)
 	if err := waitListen(socksAddr, 15*time.Second); err != nil {
@@ -176,6 +204,29 @@ func testRequiredMieruDataPath(t *testing.T, transport string) {
 		t.Fatalf("Mieru %s client did not listen: %v\nserver log:\n%s\nclient log:\n%s\nclient config:\n%s", transport, err, serverBytes, clientBytes, modifiedClientJSON)
 	}
 	assertHTTPThroughSOCKS(t, socksAddr, backend.URL, expectedResponse)
+}
+
+func runMieruControl(t *testing.T, env []string, binary, logPath string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(binary, args...)
+	cmd.Env = env
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		logBytes, _ := os.ReadFile(logPath)
+		t.Fatalf("%s %s failed: %v\noutput:\n%s\ndaemon log:\n%s", binary, strings.Join(args, " "), err, output, logBytes)
+	}
+}
+
+func waitUnixSocket(path string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		info, err := os.Stat(path)
+		if err == nil && info.Mode()&os.ModeSocket != 0 {
+			return nil
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return fmt.Errorf("Unix socket %s did not appear within %v", path, timeout)
 }
 
 func TestRequiredNaiveProxyDataPath(t *testing.T) {
@@ -218,11 +269,10 @@ func TestRequiredNaiveProxyDataPath(t *testing.T) {
 		t.Fatal(err)
 	}
 	caddyfile := strings.Replace(string(generated), fmt.Sprintf(":%d, vpn.example.com", inboundPort), fmt.Sprintf("127.0.0.1:%d", inboundPort), 1)
-	// The data-path test runs on loopback without public DNS. Remove only the
-	// generated TLS block; renderer tests separately require public ACME and
-	// reject the production-incompatible internal issuer.
-	tlsBlock := regexp.MustCompile(`(?ms)^\s*tls\s*\{.*?^\s*\}\s*$`)
-	caddyfile = tlsBlock.ReplaceAllString(caddyfile, "")
+	caddyfile, err = removeCaddyDirectiveBlock(caddyfile, "tls")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	tempDir := t.TempDir()
 	caddyfilePath := filepath.Join(tempDir, "Caddyfile")
@@ -301,6 +351,29 @@ func TestRequiredNaiveProxyDataPath(t *testing.T) {
 		t.Fatalf("Naive client did not listen: %v\nclient log:\n%s\nconfig:\n%s", err, clientBytes, clientJSON)
 	}
 	assertHTTPThroughSOCKS(t, socksAddr, backend.URL, expectedResponse)
+}
+
+func removeCaddyDirectiveBlock(input, directive string) (string, error) {
+	lines := strings.Split(input, "\n")
+	start := -1
+	depth := 0
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if start == -1 {
+			if strings.HasPrefix(trimmed, directive+" ") || trimmed == directive+"{" || trimmed == directive+" {" {
+				if strings.Contains(trimmed, "{") {
+					start = i
+					depth = strings.Count(line, "{") - strings.Count(line, "}")
+				}
+			}
+			continue
+		}
+		depth += strings.Count(line, "{") - strings.Count(line, "}")
+		if depth == 0 {
+			return strings.Join(append(lines[:start], lines[i+1:]...), "\n"), nil
+		}
+	}
+	return "", fmt.Errorf("Caddy directive block %q not found or unbalanced", directive)
 }
 
 func assertHTTPThroughSOCKS(t *testing.T, socksAddr, targetURL, expected string) {

--- a/test/e2e/required_protocol_data_path_test.go
+++ b/test/e2e/required_protocol_data_path_test.go
@@ -30,8 +30,13 @@ func requiredBinary(t *testing.T, name string) string {
 	return path
 }
 
-func TestRequiredMieruTCPDataPath(t *testing.T) { testRequiredMieruDataPath(t, "tcp") }
-func TestRequiredMieruUDPDataPath(t *testing.T) { testRequiredMieruDataPath(t, "udp") }
+func TestRequiredMieruTCPDataPath(t *testing.T) {
+	testRequiredMieruDataPath(t, "tcp")
+}
+
+func TestRequiredMieruUDPDataPath(t *testing.T) {
+	testRequiredMieruDataPath(t, "udp")
+}
 
 func testRequiredMieruDataPath(t *testing.T, transport string) {
 	t.Helper()
@@ -45,10 +50,6 @@ func testRequiredMieruDataPath(t *testing.T, transport string) {
 	}))
 	defer backend.Close()
 
-	// Mieru intentionally rejects literal loopback/private destinations unless
-	// the server-side user is granted that privilege. Use a non-special test
-	// hostname so the SOCKS request exercises normal domain egress while DNS
-	// still resolves to the local controlled backend.
 	const backendHost = "veil-protocol-e2e.test"
 	if err := exec.Command("sudo", "sh", "-c", "printf '127.0.0.1 "+backendHost+"\\n' >> /etc/hosts").Run(); err != nil {
 		t.Fatalf("register local E2E hostname: %v", err)
@@ -77,8 +78,11 @@ func testRequiredMieruDataPath(t *testing.T, transport string) {
 	serverPB := filepath.Join(serverRuntime, "server.conf.pb")
 	serverLogPath := filepath.Join(serverRuntime, "mita.log")
 	serverLog, err := os.Create(serverLogPath)
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer serverLog.Close()
+
 	serverEnv := append(os.Environ(),
 		"MITA_CONFIG_FILE="+serverPB,
 		"MITA_UDS_PATH="+serverSocket,
@@ -86,9 +90,14 @@ func testRequiredMieruDataPath(t *testing.T, transport string) {
 		"MITA_LOG_NO_TIMESTAMP=true",
 	)
 	cmdServer := exec.Command(mitaPath, "run")
-	cmdServer.Env, cmdServer.Stdout, cmdServer.Stderr = serverEnv, serverLog, serverLog
-	if err := cmdServer.Start(); err != nil { t.Fatalf("start mita daemon: %v", err) }
+	cmdServer.Env = serverEnv
+	cmdServer.Stdout = serverLog
+	cmdServer.Stderr = serverLog
+	if err := cmdServer.Start(); err != nil {
+		t.Fatalf("start mita daemon: %v", err)
+	}
 	defer func() { _ = cmdServer.Process.Kill() }()
+
 	if err := waitUnixSocket(serverSocket, 15*time.Second); err != nil {
 		logBytes, _ := os.ReadFile(serverLogPath)
 		t.Fatalf("mita control socket did not appear: %v\nlog:\n%s", err, logBytes)
@@ -97,50 +106,84 @@ func testRequiredMieruDataPath(t *testing.T, transport string) {
 	runMieruControl(t, serverEnv, mitaPath, serverLogPath, "start")
 
 	resp = srv.do(http.MethodGet, "/api/client-links", "")
-	if resp.StatusCode != http.StatusOK { t.Fatalf("client links expected 200, got %d", resp.StatusCode) }
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("client links expected 200, got %d", resp.StatusCode)
+	}
 	linksBody := readJSON(t, resp)
 	artifactsRaw, _ := json.Marshal(linksBody["artifacts"])
 	var artifacts []struct {
 		Protocol string `json:"protocol"`
-		Kind string `json:"kind"`
-		Content string `json:"content"`
+		Kind     string `json:"kind"`
+		Content  string `json:"content"`
 	}
-	if err := json.Unmarshal(artifactsRaw, &artifacts); err != nil { t.Fatal(err) }
+	if err := json.Unmarshal(artifactsRaw, &artifacts); err != nil {
+		t.Fatal(err)
+	}
+
 	var clientConfigJSON string
 	for _, artifact := range artifacts {
-		if artifact.Protocol == "mieru" && artifact.Kind == "client_config" { clientConfigJSON = artifact.Content; break }
+		if artifact.Protocol == "mieru" && artifact.Kind == "client_config" {
+			clientConfigJSON = artifact.Content
+			break
+		}
 	}
-	if clientConfigJSON == "" { t.Fatal("panel did not return a Mieru client configuration") }
+	if clientConfigJSON == "" {
+		t.Fatal("panel did not return a Mieru client configuration")
+	}
 
 	var clientMap map[string]any
-	if err := json.Unmarshal([]byte(clientConfigJSON), &clientMap); err != nil { t.Fatal(err) }
+	if err := json.Unmarshal([]byte(clientConfigJSON), &clientMap); err != nil {
+		t.Fatal(err)
+	}
 	socksPort := freePort(t)
 	clientMap["socks5Port"] = socksPort
 	clientMap["socks5ListenLAN"] = false
+
 	profiles, ok := clientMap["profiles"].([]any)
-	if !ok || len(profiles) == 0 { t.Fatalf("Mieru config has no profiles: %s", clientConfigJSON) }
+	if !ok || len(profiles) == 0 {
+		t.Fatalf("Mieru config has no profiles: %s", clientConfigJSON)
+	}
 	profile, ok := profiles[0].(map[string]any)
-	if !ok { t.Fatalf("Mieru profile has unexpected shape: %T", profiles[0]) }
+	if !ok {
+		t.Fatalf("Mieru profile has unexpected shape: %T", profiles[0])
+	}
 	servers, ok := profile["servers"].([]any)
-	if !ok || len(servers) == 0 { t.Fatalf("Mieru profile has no servers: %s", clientConfigJSON) }
+	if !ok || len(servers) == 0 {
+		t.Fatalf("Mieru profile has no servers: %s", clientConfigJSON)
+	}
 	server, ok := servers[0].(map[string]any)
-	if !ok { t.Fatalf("Mieru server has unexpected shape: %T", servers[0]) }
+	if !ok {
+		t.Fatalf("Mieru server has unexpected shape: %T", servers[0])
+	}
 	delete(server, "domainName")
 	server["ipAddress"] = "127.0.0.1"
 
 	modifiedClientJSON, err := json.Marshal(clientMap)
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 	clientRuntime := t.TempDir()
 	clientFile := filepath.Join(clientRuntime, "client.json")
-	if err := os.WriteFile(clientFile, modifiedClientJSON, 0o600); err != nil { t.Fatal(err) }
+	if err := os.WriteFile(clientFile, modifiedClientJSON, 0o600); err != nil {
+		t.Fatal(err)
+	}
 	clientLogPath := filepath.Join(clientRuntime, "mieru.log")
 	clientLog, err := os.Create(clientLogPath)
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer clientLog.Close()
+
 	cmdClient := exec.Command(mieruPath, "run")
-	cmdClient.Env = append(os.Environ(), "MIERU_CONFIG_JSON_FILE="+clientFile, "MIERU_LOG_NO_TIMESTAMP=true")
-	cmdClient.Stdout, cmdClient.Stderr = clientLog, clientLog
-	if err := cmdClient.Start(); err != nil { t.Fatalf("start mieru client: %v", err) }
+	cmdClient.Env = append(os.Environ(),
+		"MIERU_CONFIG_JSON_FILE="+clientFile,
+		"MIERU_LOG_NO_TIMESTAMP=true",
+	)
+	cmdClient.Stdout = clientLog
+	cmdClient.Stderr = clientLog
+	if err := cmdClient.Start(); err != nil {
+		t.Fatalf("start mieru client: %v", err)
+	}
 	defer func() { _ = cmdClient.Process.Kill() }()
 
 	socksAddr := fmt.Sprintf("127.0.0.1:%d", socksPort)
@@ -155,10 +198,15 @@ func testRequiredMieruDataPath(t *testing.T, transport string) {
 func applyPanelConfiguration(t *testing.T, srv *testServer) {
 	t.Helper()
 	resp := srv.do(http.MethodPost, "/api/apply/plan", "")
-	if resp.StatusCode != http.StatusOK { t.Fatalf("apply plan expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp)) }
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("apply plan expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp))
+	}
 	drain(resp)
+
 	resp = srv.do(http.MethodPost, "/api/apply", `{"confirm":true}`)
-	if resp.StatusCode != http.StatusOK { t.Fatalf("apply expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp)) }
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("apply expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp))
+	}
 	drain(resp)
 }
 
@@ -179,7 +227,9 @@ func waitUnixSocket(path string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		info, err := os.Stat(path)
-		if err == nil && info.Mode()&os.ModeSocket != 0 { return nil }
+		if err == nil && info.Mode()&os.ModeSocket != 0 {
+			return nil
+		}
 		time.Sleep(50 * time.Millisecond)
 	}
 	return fmt.Errorf("Unix socket %s did not appear within %v", path, timeout)
@@ -198,28 +248,47 @@ func TestRequiredNaiveProxyDataPath(t *testing.T) {
 	srv := startServer(t, serverOptions{token: "e2e-secret-token"})
 	inboundPort := freePort(t)
 	resp := srv.do(http.MethodPut, "/api/settings", `{"panelListen":"127.0.0.1:2096","mode":"dev","domain":"vpn.example.com","email":"test@example.com"}`)
-	if resp.StatusCode != http.StatusOK { t.Fatalf("settings expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp)) }
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("settings expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp))
+	}
 	drain(resp)
+
 	resp = srv.do(http.MethodPost, "/api/inbounds", fmt.Sprintf(`{"name":"naive-tcp","protocol":"naiveproxy","transport":"tcp","port":%d,"enabled":true,"naiveUsername":"naive-user","naivePassword":"naive-pass"}`, inboundPort))
-	if resp.StatusCode != http.StatusCreated { t.Fatalf("inbound expected 201, got %d: %v", resp.StatusCode, readJSON(t, resp)) }
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("inbound expected 201, got %d: %v", resp.StatusCode, readJSON(t, resp))
+	}
 	drain(resp)
 	applyPanelConfiguration(t, srv)
 
 	generatedPath := filepath.Join(srv.applyRoot, "generated", "caddy", "naive-tcp.Caddyfile")
 	generated, err := os.ReadFile(generatedPath)
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 	caddyfile := strings.Replace(string(generated), fmt.Sprintf(":%d, vpn.example.com", inboundPort), fmt.Sprintf("http://127.0.0.1:%d", inboundPort), 1)
 	caddyfile, err = removeCaddyDirectiveBlock(caddyfile, "tls")
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	tempDir := t.TempDir()
 	caddyfilePath := filepath.Join(tempDir, "Caddyfile")
-	if err := os.WriteFile(caddyfilePath, []byte(caddyfile), 0o600); err != nil { t.Fatal(err) }
+	if err := os.WriteFile(caddyfilePath, []byte(caddyfile), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	serverLogPath := filepath.Join(tempDir, "caddy.log")
-	serverLog, _ := os.Create(serverLogPath)
+	serverLog, err := os.Create(serverLogPath)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer serverLog.Close()
+
 	cmdServer := exec.Command(caddyPath, "run", "--config", caddyfilePath, "--adapter", "caddyfile")
-	cmdServer.Stdout, cmdServer.Stderr = serverLog, serverLog
-	if err := cmdServer.Start(); err != nil { t.Fatalf("start caddy: %v", err) }
+	cmdServer.Stdout = serverLog
+	cmdServer.Stderr = serverLog
+	if err := cmdServer.Start(); err != nil {
+		t.Fatalf("start caddy: %v", err)
+	}
 	defer func() { _ = cmdServer.Process.Kill() }()
 	serverAddr := fmt.Sprintf("127.0.0.1:%d", inboundPort)
 	if err := waitListen(serverAddr, 15*time.Second); err != nil {
@@ -228,33 +297,62 @@ func TestRequiredNaiveProxyDataPath(t *testing.T) {
 	}
 
 	resp = srv.do(http.MethodGet, "/api/client-links", "")
-	if resp.StatusCode != http.StatusOK { t.Fatalf("client links expected 200, got %d", resp.StatusCode) }
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("client links expected 200, got %d", resp.StatusCode)
+	}
 	linksBody := readJSON(t, resp)
 	linksRaw, _ := json.Marshal(linksBody["links"])
-	var links []struct { Protocol string `json:"protocol"`; URI string `json:"uri"` }
-	if err := json.Unmarshal(linksRaw, &links); err != nil { t.Fatal(err) }
+	var links []struct {
+		Protocol string `json:"protocol"`
+		URI      string `json:"uri"`
+	}
+	if err := json.Unmarshal(linksRaw, &links); err != nil {
+		t.Fatal(err)
+	}
+
 	var accessURI string
-	for _, link := range links { if link.Protocol == "naiveproxy" { accessURI = link.URI; break } }
-	if accessURI == "" { t.Fatal("panel did not return a NaiveProxy access URI") }
+	for _, link := range links {
+		if link.Protocol == "naiveproxy" {
+			accessURI = link.URI
+			break
+		}
+	}
+	if accessURI == "" {
+		t.Fatal("panel did not return a NaiveProxy access URI")
+	}
 	parsed, err := url.Parse(accessURI)
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 	username := parsed.User.Username()
 	password, _ := parsed.User.Password()
 	socksPort := freePort(t)
 	clientConfig := map[string]any{
-		"listen": fmt.Sprintf("socks://127.0.0.1:%d", socksPort),
-		"proxy": fmt.Sprintf("http://%s:%s@127.0.0.1:%d", url.QueryEscape(username), url.QueryEscape(password), inboundPort),
+		"listen":  fmt.Sprintf("socks://127.0.0.1:%d", socksPort),
+		"proxy":   fmt.Sprintf("http://%s:%s@127.0.0.1:%d", url.QueryEscape(username), url.QueryEscape(password), inboundPort),
 		"padding": true,
 	}
-	clientJSON, _ := json.Marshal(clientConfig)
+	clientJSON, err := json.Marshal(clientConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
 	clientPath := filepath.Join(tempDir, "naive.json")
-	if err := os.WriteFile(clientPath, clientJSON, 0o600); err != nil { t.Fatal(err) }
+	if err := os.WriteFile(clientPath, clientJSON, 0o600); err != nil {
+		t.Fatal(err)
+	}
 	clientLogPath := filepath.Join(tempDir, "naive.log")
-	clientLog, _ := os.Create(clientLogPath)
+	clientLog, err := os.Create(clientLogPath)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer clientLog.Close()
+
 	cmdClient := exec.Command(naivePath, clientPath)
-	cmdClient.Stdout, cmdClient.Stderr = clientLog, clientLog
-	if err := cmdClient.Start(); err != nil { t.Fatalf("start naive: %v", err) }
+	cmdClient.Stdout = clientLog
+	cmdClient.Stderr = clientLog
+	if err := cmdClient.Start(); err != nil {
+		t.Fatalf("start naive: %v", err)
+	}
 	defer func() { _ = cmdClient.Process.Kill() }()
 	socksAddr := fmt.Sprintf("127.0.0.1:%d", socksPort)
 	if err := waitListen(socksAddr, 15*time.Second); err != nil {
@@ -266,17 +364,23 @@ func TestRequiredNaiveProxyDataPath(t *testing.T) {
 
 func removeCaddyDirectiveBlock(input, directive string) (string, error) {
 	lines := strings.Split(input, "\n")
-	start, depth := -1, 0
+	start := -1
+	depth := 0
 	for i, line := range lines {
 		trimmed := strings.TrimSpace(line)
 		if start == -1 {
 			if strings.HasPrefix(trimmed, directive+" ") || trimmed == directive+"{" || trimmed == directive+" {" {
-				if strings.Contains(trimmed, "{") { start, depth = i, strings.Count(line, "{")-strings.Count(line, "}") }
+				if strings.Contains(trimmed, "{") {
+					start = i
+					depth = strings.Count(line, "{") - strings.Count(line, "}")
+				}
 			}
 			continue
 		}
 		depth += strings.Count(line, "{") - strings.Count(line, "}")
-		if depth == 0 { return strings.Join(append(lines[:start], lines[i+1:]...), "\n"), nil }
+		if depth == 0 {
+			return strings.Join(append(lines[:start], lines[i+1:]...), "\n"), nil
+		}
 	}
 	return "", fmt.Errorf("Caddy directive block %q not found or unbalanced", directive)
 }
@@ -284,15 +388,27 @@ func removeCaddyDirectiveBlock(input, directive string) (string, error) {
 func assertHTTPThroughSOCKS(t *testing.T, socksAddr, targetURL, expected string) {
 	t.Helper()
 	dialer, err := proxy.SOCKS5("tcp", socksAddr, nil, proxy.Direct)
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 	client := &http.Client{
-		Transport: &http.Transport{DialContext: func(_ context.Context, network, addr string) (net.Conn, error) { return dialer.Dial(network, addr) }},
+		Transport: &http.Transport{
+			DialContext: func(_ context.Context, network, addr string) (net.Conn, error) {
+				return dialer.Dial(network, addr)
+			},
+		},
 		Timeout: 10 * time.Second,
 	}
 	resp, err := client.Get(targetURL)
-	if err != nil { t.Fatalf("GET through SOCKS failed: %v", err) }
+	if err != nil {
+		t.Fatalf("GET through SOCKS failed: %v", err)
+	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
-	if err != nil { t.Fatal(err) }
-	if string(body) != expected { t.Fatalf("response = %q, want %q", body, expected) }
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != expected {
+		t.Fatalf("response = %q, want %q", body, expected)
+	}
 }

--- a/test/e2e/required_protocol_data_path_test.go
+++ b/test/e2e/required_protocol_data_path_test.go
@@ -1,0 +1,330 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/net/proxy"
+)
+
+func requiredBinary(t *testing.T, name string) string {
+	t.Helper()
+	path, err := exec.LookPath(name)
+	if err != nil {
+		t.Fatalf("required real protocol binary %q is not installed: %v", name, err)
+	}
+	return path
+}
+
+func TestRequiredMieruTCPDataPath(t *testing.T) {
+	testRequiredMieruDataPath(t, "tcp")
+}
+
+func TestRequiredMieruUDPDataPath(t *testing.T) {
+	testRequiredMieruDataPath(t, "udp")
+}
+
+func testRequiredMieruDataPath(t *testing.T, transport string) {
+	t.Helper()
+	mitaPath := requiredBinary(t, "mita")
+	mieruPath := requiredBinary(t, "mieru")
+
+	expectedResponse := "hello from mieru over " + transport
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(expectedResponse))
+	}))
+	defer backend.Close()
+
+	srv := startServer(t, serverOptions{token: "e2e-secret-token"})
+	inboundPort := freePort(t)
+	resp := srv.do(http.MethodPut, "/api/settings", `{"panelListen":"127.0.0.1:2096","mode":"dev","domain":"127.0.0.1"}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("settings expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp))
+	}
+	drain(resp)
+
+	body := fmt.Sprintf(`{"name":"mieru-%s","protocol":"mieru","transport":%q,"port":%d,"enabled":true,"profiles":[{"name":"alice","password":"alice-pass","enabled":true}]}`, transport, transport, inboundPort)
+	resp = srv.do(http.MethodPost, "/api/inbounds", body)
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("inbound expected 201, got %d: %v", resp.StatusCode, readJSON(t, resp))
+	}
+	drain(resp)
+
+	resp = srv.do(http.MethodPost, "/api/apply/plan", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("apply plan expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp))
+	}
+	drain(resp)
+	resp = srv.do(http.MethodPost, "/api/apply", `{"confirm":true}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("apply expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp))
+	}
+	drain(resp)
+
+	serverConfig := filepath.Join(srv.applyRoot, "generated", "mieru", "server_config.json")
+	serverLogPath := filepath.Join(t.TempDir(), "mita.log")
+	serverLog, err := os.Create(serverLogPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer serverLog.Close()
+
+	cmdServer := exec.Command(mitaPath, "run")
+	cmdServer.Env = append(os.Environ(), "MITA_CONFIG_JSON_FILE="+serverConfig)
+	cmdServer.Stdout = serverLog
+	cmdServer.Stderr = serverLog
+	if err := cmdServer.Start(); err != nil {
+		t.Fatalf("start mita: %v", err)
+	}
+	defer func() { _ = cmdServer.Process.Kill() }()
+
+	resp = srv.do(http.MethodGet, "/api/client-links", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("client links expected 200, got %d", resp.StatusCode)
+	}
+	linksBody := readJSON(t, resp)
+	artifactsRaw, _ := json.Marshal(linksBody["artifacts"])
+	var artifacts []struct {
+		Protocol string `json:"protocol"`
+		Kind     string `json:"kind"`
+		Content  string `json:"content"`
+	}
+	if err := json.Unmarshal(artifactsRaw, &artifacts); err != nil {
+		t.Fatalf("decode artifacts: %v", err)
+	}
+	var clientConfigJSON string
+	for _, artifact := range artifacts {
+		if artifact.Protocol == "mieru" && artifact.Kind == "client_config" {
+			clientConfigJSON = artifact.Content
+			break
+		}
+	}
+	if clientConfigJSON == "" {
+		t.Fatal("panel did not return a Mieru client configuration")
+	}
+
+	var clientMap map[string]any
+	if err := json.Unmarshal([]byte(clientConfigJSON), &clientMap); err != nil {
+		t.Fatalf("unmarshal client config: %v", err)
+	}
+	socksPort := freePort(t)
+	clientMap["socks5Port"] = socksPort
+	clientMap["socks5ListenLAN"] = false
+
+	profiles, ok := clientMap["profiles"].([]any)
+	if !ok || len(profiles) == 0 {
+		t.Fatalf("Mieru config has no profiles: %s", clientConfigJSON)
+	}
+	profile, ok := profiles[0].(map[string]any)
+	if !ok {
+		t.Fatalf("Mieru profile has unexpected shape: %T", profiles[0])
+	}
+	servers, ok := profile["servers"].([]any)
+	if !ok || len(servers) == 0 {
+		t.Fatalf("Mieru profile has no servers: %s", clientConfigJSON)
+	}
+	server, ok := servers[0].(map[string]any)
+	if !ok {
+		t.Fatalf("Mieru server has unexpected shape: %T", servers[0])
+	}
+	delete(server, "domainName")
+	server["ipAddress"] = "127.0.0.1"
+
+	modifiedClientJSON, err := json.Marshal(clientMap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientFile := filepath.Join(t.TempDir(), "client.json")
+	if err := os.WriteFile(clientFile, modifiedClientJSON, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	clientLogPath := filepath.Join(t.TempDir(), "mieru.log")
+	clientLog, err := os.Create(clientLogPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clientLog.Close()
+	cmdClient := exec.Command(mieruPath, "run")
+	cmdClient.Env = append(os.Environ(), "MIERU_CONFIG_JSON_FILE="+clientFile)
+	cmdClient.Stdout = clientLog
+	cmdClient.Stderr = clientLog
+	if err := cmdClient.Start(); err != nil {
+		t.Fatalf("start mieru: %v", err)
+	}
+	defer func() { _ = cmdClient.Process.Kill() }()
+
+	socksAddr := fmt.Sprintf("127.0.0.1:%d", socksPort)
+	if err := waitListen(socksAddr, 15*time.Second); err != nil {
+		serverBytes, _ := os.ReadFile(serverLogPath)
+		clientBytes, _ := os.ReadFile(clientLogPath)
+		t.Fatalf("Mieru %s client did not listen: %v\nserver log:\n%s\nclient log:\n%s\nclient config:\n%s", transport, err, serverBytes, clientBytes, modifiedClientJSON)
+	}
+	assertHTTPThroughSOCKS(t, socksAddr, backend.URL, expectedResponse)
+}
+
+func TestRequiredNaiveProxyDataPath(t *testing.T) {
+	caddyPath := requiredBinary(t, "caddy")
+	naivePath := requiredBinary(t, "naive")
+
+	expectedResponse := "hello from naiveproxy"
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(expectedResponse))
+	}))
+	defer backend.Close()
+
+	srv := startServer(t, serverOptions{token: "e2e-secret-token"})
+	inboundPort := freePort(t)
+	resp := srv.do(http.MethodPut, "/api/settings", `{"panelListen":"127.0.0.1:2096","mode":"dev","domain":"vpn.example.com","email":"test@example.com"}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("settings expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp))
+	}
+	drain(resp)
+	resp = srv.do(http.MethodPost, "/api/inbounds", fmt.Sprintf(`{"name":"naive-tcp","protocol":"naiveproxy","transport":"tcp","port":%d,"enabled":true,"naiveUsername":"naive-user","naivePassword":"naive-pass"}`, inboundPort))
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("inbound expected 201, got %d: %v", resp.StatusCode, readJSON(t, resp))
+	}
+	drain(resp)
+	resp = srv.do(http.MethodPost, "/api/apply/plan", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("apply plan expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp))
+	}
+	drain(resp)
+	resp = srv.do(http.MethodPost, "/api/apply", `{"confirm":true}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("apply expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp))
+	}
+	drain(resp)
+
+	generatedPath := filepath.Join(srv.applyRoot, "generated", "caddy", "naive-tcp.Caddyfile")
+	generated, err := os.ReadFile(generatedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caddyfile := strings.Replace(string(generated), fmt.Sprintf(":%d, vpn.example.com", inboundPort), fmt.Sprintf("127.0.0.1:%d", inboundPort), 1)
+	// The data-path test runs on loopback without public DNS. Remove only the
+	// generated TLS block; renderer tests separately require public ACME and
+	// reject the production-incompatible internal issuer.
+	tlsBlock := regexp.MustCompile(`(?ms)^\s*tls\s*\{.*?^\s*\}\s*$`)
+	caddyfile = tlsBlock.ReplaceAllString(caddyfile, "")
+
+	tempDir := t.TempDir()
+	caddyfilePath := filepath.Join(tempDir, "Caddyfile")
+	if err := os.WriteFile(caddyfilePath, []byte(caddyfile), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	serverLogPath := filepath.Join(tempDir, "caddy.log")
+	serverLog, _ := os.Create(serverLogPath)
+	defer serverLog.Close()
+	cmdServer := exec.Command(caddyPath, "run", "--config", caddyfilePath, "--adapter", "caddyfile")
+	cmdServer.Stdout = serverLog
+	cmdServer.Stderr = serverLog
+	if err := cmdServer.Start(); err != nil {
+		t.Fatalf("start caddy: %v", err)
+	}
+	defer func() { _ = cmdServer.Process.Kill() }()
+	serverAddr := fmt.Sprintf("127.0.0.1:%d", inboundPort)
+	if err := waitListen(serverAddr, 15*time.Second); err != nil {
+		logBytes, _ := os.ReadFile(serverLogPath)
+		t.Fatalf("Caddy did not listen: %v\nCaddyfile:\n%s\nlog:\n%s", err, caddyfile, logBytes)
+	}
+
+	resp = srv.do(http.MethodGet, "/api/client-links", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("client links expected 200, got %d", resp.StatusCode)
+	}
+	linksBody := readJSON(t, resp)
+	linksRaw, _ := json.Marshal(linksBody["links"])
+	var links []struct {
+		Protocol string `json:"protocol"`
+		URI      string `json:"uri"`
+	}
+	if err := json.Unmarshal(linksRaw, &links); err != nil {
+		t.Fatal(err)
+	}
+	var accessURI string
+	for _, link := range links {
+		if link.Protocol == "naiveproxy" {
+			accessURI = link.URI
+			break
+		}
+	}
+	if accessURI == "" {
+		t.Fatal("panel did not return a NaiveProxy access URI")
+	}
+	parsed, err := url.Parse(accessURI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	username := parsed.User.Username()
+	password, _ := parsed.User.Password()
+	socksPort := freePort(t)
+	clientConfig := map[string]any{
+		"listen":  fmt.Sprintf("socks://127.0.0.1:%d", socksPort),
+		"proxy":   fmt.Sprintf("http://%s:%s@127.0.0.1:%d", url.QueryEscape(username), url.QueryEscape(password), inboundPort),
+		"padding": true,
+	}
+	clientJSON, _ := json.Marshal(clientConfig)
+	clientPath := filepath.Join(tempDir, "naive.json")
+	if err := os.WriteFile(clientPath, clientJSON, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	clientLogPath := filepath.Join(tempDir, "naive.log")
+	clientLog, _ := os.Create(clientLogPath)
+	defer clientLog.Close()
+	cmdClient := exec.Command(naivePath, clientPath)
+	cmdClient.Stdout = clientLog
+	cmdClient.Stderr = clientLog
+	if err := cmdClient.Start(); err != nil {
+		t.Fatalf("start naive: %v", err)
+	}
+	defer func() { _ = cmdClient.Process.Kill() }()
+	socksAddr := fmt.Sprintf("127.0.0.1:%d", socksPort)
+	if err := waitListen(socksAddr, 15*time.Second); err != nil {
+		clientBytes, _ := os.ReadFile(clientLogPath)
+		t.Fatalf("Naive client did not listen: %v\nclient log:\n%s\nconfig:\n%s", err, clientBytes, clientJSON)
+	}
+	assertHTTPThroughSOCKS(t, socksAddr, backend.URL, expectedResponse)
+}
+
+func assertHTTPThroughSOCKS(t *testing.T, socksAddr, targetURL, expected string) {
+	t.Helper()
+	dialer, err := proxy.SOCKS5("tcp", socksAddr, nil, proxy.Direct)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := &http.Client{
+		Transport: &http.Transport{DialContext: func(_ context.Context, network, addr string) (net.Conn, error) {
+			return dialer.Dial(network, addr)
+		}},
+		Timeout: 10 * time.Second,
+	}
+	resp, err := client.Get(targetURL)
+	if err != nil {
+		t.Fatalf("GET through SOCKS failed: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != expected {
+		t.Fatalf("response = %q, want %q", body, expected)
+	}
+}

--- a/test/e2e/required_protocol_data_path_test.go
+++ b/test/e2e/required_protocol_data_path_test.go
@@ -168,34 +168,23 @@ func testRequiredMieruDataPath(t *testing.T, transport string) {
 	if err := os.WriteFile(clientFile, modifiedClientJSON, 0o600); err != nil {
 		t.Fatal(err)
 	}
-	clientSocket := filepath.Join(clientRuntime, "mieru.sock")
-	clientPB := filepath.Join(clientRuntime, "client.conf.pb")
 	clientLogPath := filepath.Join(clientRuntime, "mieru.log")
 	clientLog, err := os.Create(clientLogPath)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer clientLog.Close()
-	clientEnv := append(os.Environ(),
-		"MIERU_CONFIG_FILE="+clientPB,
-		"MIERU_UDS_PATH="+clientSocket,
-		"MIERU_INSECURE_UDS=1",
+	cmdClient := exec.Command(mieruPath, "run")
+	cmdClient.Env = append(os.Environ(),
+		"MIERU_CONFIG_JSON_FILE="+clientFile,
 		"MIERU_LOG_NO_TIMESTAMP=true",
 	)
-	cmdClient := exec.Command(mieruPath, "run")
-	cmdClient.Env = clientEnv
 	cmdClient.Stdout = clientLog
 	cmdClient.Stderr = clientLog
 	if err := cmdClient.Start(); err != nil {
-		t.Fatalf("start mieru daemon: %v", err)
+		t.Fatalf("start mieru client: %v", err)
 	}
 	defer func() { _ = cmdClient.Process.Kill() }()
-	if err := waitUnixSocket(clientSocket, 15*time.Second); err != nil {
-		logBytes, _ := os.ReadFile(clientLogPath)
-		t.Fatalf("mieru control socket did not appear: %v\nlog:\n%s", err, logBytes)
-	}
-	runMieruControl(t, clientEnv, mieruPath, clientLogPath, "apply", "config", clientFile)
-	runMieruControl(t, clientEnv, mieruPath, clientLogPath, "start")
 
 	socksAddr := fmt.Sprintf("127.0.0.1:%d", socksPort)
 	if err := waitListen(socksAddr, 15*time.Second); err != nil {
@@ -208,7 +197,9 @@ func testRequiredMieruDataPath(t *testing.T, transport string) {
 
 func runMieruControl(t *testing.T, env []string, binary, logPath string, args ...string) {
 	t.Helper()
-	cmd := exec.Command(binary, args...)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binary, args...)
 	cmd.Env = env
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -268,7 +259,7 @@ func TestRequiredNaiveProxyDataPath(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	caddyfile := strings.Replace(string(generated), fmt.Sprintf(":%d, vpn.example.com", inboundPort), fmt.Sprintf("127.0.0.1:%d", inboundPort), 1)
+	caddyfile := strings.Replace(string(generated), fmt.Sprintf(":%d, vpn.example.com", inboundPort), fmt.Sprintf("http://127.0.0.1:%d", inboundPort), 1)
 	caddyfile, err = removeCaddyDirectiveBlock(caddyfile, "tls")
 	if err != nil {
 		t.Fatal(err)

--- a/test/e2e/server_proc_alias_test.go
+++ b/test/e2e/server_proc_alias_test.go
@@ -1,0 +1,7 @@
+//go:build e2e
+
+package e2e
+
+// testServer keeps protocol helper signatures concise while using the
+// real subprocess-backed E2E harness.
+type testServer = serverProc


### PR DESCRIPTION
## What changed

- Align the generated NaiveProxy Caddyfile with the upstream NaiveProxy server layout.
- Remove the internal-CA fallback that could silently produce a certificate Chromium-based Naive clients do not trust.
- Enable response encoding and suppress forward-proxy activity from Caddy error logs as recommended upstream.
- Render literal IPv4/IPv6 Mieru endpoints as `ipAddress` instead of incorrectly placing them in `domainName`.
- Reject conflicting duplicate Mieru users and deduplicate identical port bindings/users.
- Add regression tests for public TLS, Mieru IP/domain endpoint rendering, and credential conflicts.

## Root cause

The control plane generated plausible configuration, but several assumptions were not compatible with real clients:

1. NaiveProxy could fall back to Caddy's internal issuer, producing an untrusted TLS chain.
2. Mieru client JSON did not distinguish IP addresses from DNS names, despite upstream defining separate fields.
3. Duplicate Mieru credentials could produce ambiguous server configuration.

## Validation

The changes include focused Go regression tests. Full real-binary data-path validation still needs CI execution with actual `caddy`, `naive`, `mita`, and `mieru` binaries; this PR is intentionally draft until those checks are green.