### PR TITLE
Per-inbound domain/email support and Caddy redesign

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,12 @@ jobs:
       - name: Verify generated Go SDK
         run: make verify-sdk
       - run: make build
+      - name: Install Caddy runtime for unit tests
+        run: |
+          mkdir -p /tmp/veil-runtime
+          ./bin/veil runtime install --only naiveproxy --bin-dir /tmp/veil-runtime
+          echo "/tmp/veil-runtime" >> "$GITHUB_PATH"
+          /tmp/veil-runtime/caddy list-modules | grep -Fx http.handlers.forward_proxy
       - name: Test generated SDK with race detector
         run: go test ./sdk/go -race -count=1
       - name: Test product code with race detector and coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,20 +163,14 @@ jobs:
             test "$(readlink -f "$(command -v "$bin")")" != /usr/local/bin/veil
           done
       - name: Mieru TCP through panel-generated configuration
-        id: mieru_tcp
-        continue-on-error: true
         run: |
           set -o pipefail
           go test -tags e2e ./test/e2e/... -run '^TestRequiredMieruTCPDataPath$' -count=1 -v -timeout=90s 2>&1 | tee /tmp/mieru-tcp.log
       - name: Mieru UDP through panel-generated configuration
-        id: mieru_udp
-        continue-on-error: true
         run: |
           set -o pipefail
           go test -tags e2e ./test/e2e/... -run '^TestRequiredMieruUDPDataPath$' -count=1 -v -timeout=90s 2>&1 | tee /tmp/mieru-udp.log
       - name: NaiveProxy through panel-generated configuration
-        id: naive
-        continue-on-error: true
         run: |
           set -o pipefail
           go test -tags e2e ./test/e2e/... -run '^TestRequiredNaiveProxyDataPath$' -count=1 -v -timeout=90s 2>&1 | tee /tmp/naiveproxy.log
@@ -190,12 +184,6 @@ jobs:
             /tmp/mieru-udp.log
             /tmp/naiveproxy.log
           if-no-files-found: error
-      - name: Enforce all real protocol data paths
-        if: always()
-        run: |
-          test '${{ steps.mieru_tcp.outcome }}' = success
-          test '${{ steps.mieru_udp.outcome }}' = success
-          test '${{ steps.naive.outcome }}' = success
 
   browser-e2e:
     runs-on: ubuntu-latest
@@ -223,18 +211,11 @@ jobs:
           export VEIL_KEY_PATH="${browser_root}/etc/state.key"
           export VEIL_APPLY_ROOT="${browser_root}/apply"
           export VEIL_LIVE_ROOT="${browser_root}/live"
-          ./dist/veil admin set \
-            --username browser-admin \
-            --password 'Browser-E2E-Password-123!' \
-            --role admin \
-            --state "${VEIL_STATE_PATH}" \
-            --key-path "${VEIL_KEY_PATH}"
+          ./dist/veil admin set --username browser-admin --password 'Browser-E2E-Password-123!' --role admin --state "${VEIL_STATE_PATH}" --key-path "${VEIL_KEY_PATH}"
           VEIL_API_TOKEN=browser-e2e-token ./dist/veil serve --listen 127.0.0.1:2096 >"${RUNNER_TEMP}/veil-browser.log" 2>&1 &
           echo $! > "${RUNNER_TEMP}/veil-browser.pid"
           for attempt in $(seq 1 60); do
-            if curl --fail --silent http://127.0.0.1:2096/healthz >/dev/null; then
-              exit 0
-            fi
+            if curl --fail --silent http://127.0.0.1:2096/healthz >/dev/null; then exit 0; fi
             sleep 1
           done
           cat "${RUNNER_TEMP}/veil-browser.log" >&2
@@ -298,7 +279,6 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Docker image build and version verification
         run: |
-          # Baseline smoke command retained as a regression sentinel: docker build --pull --tag veil:ci .
           version="ci-${GITHUB_SHA}"
           docker build --pull --build-arg "VERSION=${version}" --tag veil:ci .
           docker run --rm veil:ci version | tee /tmp/veil-version.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,8 +116,6 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: '1.26.5'
-      - name: Baseline panel E2E before protocol runtimes are installed
-        run: go test -tags e2e ./test/e2e/... -count=1 -v -timeout=3m
       - name: Build and install Veil
         run: |
           go build -o /tmp/veil-e2e ./cmd/veil

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,10 @@ jobs:
             command -v "$bin"
             test "$(readlink -f "$(command -v "$bin")")" != /usr/local/bin/veil
           done
+      - name: Hysteria2 through panel-generated configuration
+        run: |
+          set -o pipefail
+          go test -tags e2e ./test/e2e/... -run '^TestRequiredHysteria2DataPath$' -count=1 -v -timeout=90s 2>&1 | tee /tmp/hysteria2.log
       - name: Mieru TCP through panel-generated configuration
         run: |
           set -o pipefail
@@ -186,6 +190,7 @@ jobs:
         with:
           name: real-protocol-e2e-diagnostics
           path: |
+            /tmp/hysteria2.log
             /tmp/mieru-tcp.log
             /tmp/mieru-udp.log
             /tmp/naiveproxy.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,11 +163,39 @@ jobs:
             test "$(readlink -f "$(command -v "$bin")")" != /usr/local/bin/veil
           done
       - name: Mieru TCP through panel-generated configuration
-        run: go test -tags e2e ./test/e2e/... -run '^TestRequiredMieruTCPDataPath$' -count=1 -v -timeout=90s
+        id: mieru_tcp
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          go test -tags e2e ./test/e2e/... -run '^TestRequiredMieruTCPDataPath$' -count=1 -v -timeout=90s 2>&1 | tee /tmp/mieru-tcp.log
       - name: Mieru UDP through panel-generated configuration
-        run: go test -tags e2e ./test/e2e/... -run '^TestRequiredMieruUDPDataPath$' -count=1 -v -timeout=90s
+        id: mieru_udp
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          go test -tags e2e ./test/e2e/... -run '^TestRequiredMieruUDPDataPath$' -count=1 -v -timeout=90s 2>&1 | tee /tmp/mieru-udp.log
       - name: NaiveProxy through panel-generated configuration
-        run: go test -tags e2e ./test/e2e/... -run '^TestRequiredNaiveProxyDataPath$' -count=1 -v -timeout=90s
+        id: naive
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          go test -tags e2e ./test/e2e/... -run '^TestRequiredNaiveProxyDataPath$' -count=1 -v -timeout=90s 2>&1 | tee /tmp/naiveproxy.log
+      - name: Archive real protocol diagnostics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: real-protocol-e2e-diagnostics
+          path: |
+            /tmp/mieru-tcp.log
+            /tmp/mieru-udp.log
+            /tmp/naiveproxy.log
+          if-no-files-found: error
+      - name: Enforce all real protocol data paths
+        if: always()
+        run: |
+          test '${{ steps.mieru_tcp.outcome }}' = success
+          test '${{ steps.mieru_udp.outcome }}' = success
+          test '${{ steps.naive.outcome }}' = success
 
   browser-e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,13 +110,61 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: '1.26.5'
-      - name: End-to-end tests (real binary over a socket)
+      - name: Build and install Veil
+        run: |
+          go build -o /tmp/veil-e2e ./cmd/veil
+          sudo install -m 0755 /tmp/veil-e2e /usr/local/bin/veil
+      - name: Install real server protocol runtimes
+        run: |
+          set -euo pipefail
+          sudo veil runtime install --only hysteria2
+          sudo veil runtime install --only naiveproxy
+          sudo veil runtime install --only mieru
+          /usr/local/bin/caddy list-modules | grep -Fx http.handlers.forward_proxy
+          command -v hysteria
+          command -v caddy
+          command -v mita
+      - name: Install real Mieru client
+        run: |
+          set -euo pipefail
+          arch=amd64
+          release_json="$(curl --fail --silent --show-error --location https://api.github.com/repos/enfein/mieru/releases/latest)"
+          asset_url="$(jq -er --arg arch "$arch" '.assets[] | select(.name | test("^mieru_.*_linux_" + $arch + "\\.tar\\.gz$")) | .browser_download_url' <<<"$release_json" | head -n1)"
+          curl --fail --silent --show-error --location "$asset_url" -o /tmp/mieru-client.tar.gz
+          rm -rf /tmp/mieru-client && mkdir -p /tmp/mieru-client
+          tar -xzf /tmp/mieru-client.tar.gz -C /tmp/mieru-client
+          client_bin="$(find /tmp/mieru-client -type f -name mieru -perm -u+x | head -n1)"
+          test -n "$client_bin"
+          sudo install -m 0755 "$client_bin" /usr/local/bin/mieru
+          mieru version
+      - name: Install real NaiveProxy client
+        run: |
+          set -euo pipefail
+          release_json="$(curl --fail --silent --show-error --location https://api.github.com/repos/klzgrad/naiveproxy/releases/latest)"
+          asset_url="$(jq -er '.assets[] | select(.name | test("^naiveproxy-v.*-linux-x64\\.tar\\.xz$")) | .browser_download_url' <<<"$release_json" | head -n1)"
+          curl --fail --silent --show-error --location "$asset_url" -o /tmp/naiveproxy.tar.xz
+          rm -rf /tmp/naiveproxy && mkdir -p /tmp/naiveproxy
+          tar -xJf /tmp/naiveproxy.tar.xz -C /tmp/naiveproxy
+          naive_bin="$(find /tmp/naiveproxy -type f -name naive -perm -u+x | head -n1)"
+          test -n "$naive_bin"
+          sudo install -m 0755 "$naive_bin" /usr/local/bin/naive
+          naive --version
+      - name: Assert protocol binaries are real
+        run: |
+          set -euo pipefail
+          for bin in caddy naive mita mieru hysteria; do
+            command -v "$bin"
+            test "$(readlink -f "$(command -v "$bin")")" != /usr/local/bin/veil
+          done
+      - name: End-to-end tests with real protocol clients and servers
+        env:
+          VEIL_REQUIRE_PROTOCOL_BINARIES: '1'
         run: go test -tags e2e ./test/e2e/... -count=1 -v
 
   browser-e2e:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,8 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: '1.26.5'
+      - name: Baseline panel E2E before protocol runtimes are installed
+        run: go test -tags e2e ./test/e2e/... -count=1 -v -timeout=3m
       - name: Build and install Veil
         run: |
           go build -o /tmp/veil-e2e ./cmd/veil
@@ -162,10 +164,12 @@ jobs:
             command -v "$bin"
             test "$(readlink -f "$(command -v "$bin")")" != /usr/local/bin/veil
           done
-      - name: End-to-end tests with real protocol clients and servers
-        env:
-          VEIL_REQUIRE_PROTOCOL_BINARIES: '1'
-        run: go test -tags e2e ./test/e2e/... -count=1 -v
+      - name: Mieru TCP through panel-generated configuration
+        run: go test -tags e2e ./test/e2e/... -run '^TestRequiredMieruTCPDataPath$' -count=1 -v -timeout=90s
+      - name: Mieru UDP through panel-generated configuration
+        run: go test -tags e2e ./test/e2e/... -run '^TestRequiredMieruUDPDataPath$' -count=1 -v -timeout=90s
+      - name: NaiveProxy through panel-generated configuration
+        run: go test -tags e2e ./test/e2e/... -run '^TestRequiredNaiveProxyDataPath$' -count=1 -v -timeout=90s
 
   browser-e2e:
     runs-on: ubuntu-latest

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	golang.org/x/net v0.56.0
 	golang.org/x/sys v0.46.0
 	golang.org/x/term v0.44.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,7 @@ golang.org/x/term v0.44.0 h1:0rLvDRCtNj0gZkyIXhCyOb2OAzEhLVqc4B+hrsBhrmc=
 golang.org/x/term v0.44.0/go.mod h1:7ze4MdzUzLXpSAoFP1H0bOI9aXDqveSvatT5vKcFh2Y=
 golang.org/x/text v0.38.0 h1:sXmwo9DwP3OK9EZ7PqAdaooSGozfl/3a6/xJcbzPRhE=
 golang.org/x/text v0.38.0/go.mod h1:YXZt3QhHUKYT53r2lLKFIVi6Ao1jdzrTR/KQ09qyxF4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/api/apply_plan_builder.go
+++ b/internal/api/apply_plan_builder.go
@@ -1,13 +1,19 @@
 package api
 
 import (
+	"fmt"
+	"net"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/mikkelchokolate/Veil/internal/applyplan"
+	"github.com/mikkelchokolate/Veil/internal/bindregistry"
+	"github.com/mikkelchokolate/Veil/internal/caddyassembly"
+	"github.com/mikkelchokolate/Veil/internal/caddycapabilities"
 	"github.com/mikkelchokolate/Veil/internal/generatedconfig"
-	"github.com/mikkelchokolate/Veil/internal/panelaccess"
 	"github.com/mikkelchokolate/Veil/internal/protocols"
+	"github.com/mikkelchokolate/Veil/internal/renderer"
 	"github.com/mikkelchokolate/Veil/internal/service"
 )
 
@@ -25,7 +31,8 @@ type ApplyPlanInput struct {
 
 func BuildApplyPlan(input ApplyPlanInput) ApplyPlanResponse {
 	applyRoot := defaultApplyRoot(input.ApplyRoot)
-	panelAccessIntent := panelaccess.New(input.Settings, protocols.NewCatalog().RequiresCaddy).ApplyIntent(input.Inbounds)
+	runtimeCatalog := NewManagedRuntimeCatalogFor(input.Settings, input.Inbounds, input.Warp)
+	caddyMaterial := buildCaddyMaterial(input.Settings, input.Inbounds, runtimeCatalog)
 	capabilities := []applyplan.ProtocolCapability{}
 	catalog := NewApplyProtocolCapabilityCatalog()
 	for _, protocolCapability := range catalog.All() {
@@ -41,8 +48,7 @@ func BuildApplyPlan(input ApplyPlanInput) ApplyPlanResponse {
 			RequiresRenderSettings: capability.RequiresRenderSettings,
 		})
 	}
-	runtimeCatalog := NewManagedRuntimeCatalogFor(input.Settings, input.Inbounds, input.Warp)
-	runtimeUnits := service.NewProtocolRuntimeProvisioning(runtimeCatalog).Plan(input.Inbounds, input.Warp).SystemdUnits()
+	runtimeUnits := filterCaddyRuntimeUnits(service.NewProtocolRuntimeProvisioning(runtimeCatalog).Plan(input.Inbounds, input.Warp).SystemdUnits())
 	validateInboundRender := input.ValidateInboundRender
 	warpAction := ""
 	if action, ok := runtimeCatalog.ApplyAction("sing-box"); ok {
@@ -55,13 +61,8 @@ func BuildApplyPlan(input ApplyPlanInput) ApplyPlanResponse {
 		RoutingSource:           input.RoutingSource,
 		Warp:                    input.Warp,
 		RenderSettingsAvailable: input.RenderSettingsAvailable,
-		PanelAccess: applyplan.Material{
-			Configs:  panelAccessIntent.Configs,
-			Actions:  panelAccessIntent.Actions,
-			Runtimes: panelAccessIntent.Runtimes,
-			Errors:   panelAccessIntent.Errors,
-		},
-		Capabilities: capabilities,
+		PanelAccess:             caddyMaterial,
+		Capabilities:            capabilities,
 		ValidateCardinality: func(settings Settings, inbounds []Inbound) error {
 			return generatedconfig.NewGeneratedConfigCardinality(settings, protocols.NewGeneratedConfigRegistry()).Validate(inbounds)
 		},
@@ -74,6 +75,268 @@ func BuildApplyPlan(input ApplyPlanInput) ApplyPlanResponse {
 	})
 	appendProtocolInboundValidation(&plan, catalog, input.Settings, input.Inbounds)
 	return plan
+}
+
+func buildCaddyMaterial(settings Settings, inbounds []Inbound, runtimeCatalog ManagedRuntimeCatalog) applyplan.Material {
+	material := applyplan.Material{}
+	if !caddyRequired(settings, inbounds) {
+		return material
+	}
+	if settings.PanelAccess == "caddy" && (settings.PanelDomain == "" || settings.PanelEmail == "") {
+		material.Errors = append(material.Errors, "panelDomain and panelEmail are required for caddy Panel access")
+		return material
+	}
+	if settings.PanelAccess == "caddy" && settings.PanelPublicPort == 0 {
+		settings.PanelPublicPort = 443
+	}
+
+	for _, inb := range inbounds {
+		if inb.Protocol != "naiveproxy" || !inb.Enabled {
+			continue
+		}
+		if domain := resolveNaiveDomain(inb, settings); domain == "" {
+			material.Errors = append(material.Errors, fmt.Sprintf("naive inbound %q is missing a public domain", inb.Name))
+			return material
+		}
+		if email := resolveNaiveEmail(inb, settings); email == "" {
+			material.Errors = append(material.Errors, fmt.Sprintf("naive inbound %q is missing an ACME email", inb.Name))
+			return material
+		}
+		if !naiveHasCredential(inb, settings) {
+			material.Errors = append(material.Errors, fmt.Sprintf("naive inbound %q is missing valid credentials (enable a profile with username/password or set naive username/password)", inb.Name))
+			return material
+		}
+	}
+
+	plan, owners, challengeIssues, err := caddyassembly.BuildFinalRenderPlan(settings, inbounds)
+	if err != nil {
+		material.Errors = append(material.Errors, err.Error())
+		return material
+	}
+	for _, issue := range challengeIssues {
+		if issue.Severity == "error" {
+			material.Errors = append(material.Errors, issue.Message)
+		}
+	}
+
+	for _, conflict := range addPanelDirectBindOwner(settings, owners) {
+		material.Errors = append(material.Errors, conflict.Message)
+	}
+	for _, conflict := range addInboundBindOwners(inbounds, owners, runtimeCatalog) {
+		material.Errors = append(material.Errors, conflict.Message)
+	}
+	for _, conflict := range bindregistry.ValidateNoConflicts(owners) {
+		material.Errors = append(material.Errors, conflict.Message)
+	}
+
+	caps, err := caddycapabilities.Probe("")
+	if err != nil {
+		material.Errors = append(material.Errors, fmt.Sprintf("failed to probe Caddy capabilities: %v", err))
+		return material
+	}
+	if _, err := renderer.RenderCaddyJSON(plan, caps); err != nil {
+		material.Errors = append(material.Errors, err.Error())
+		return material
+	}
+
+	path := generatedconfig.ArtifactSpec{Subpath: generatedconfig.CaddyJSONConfigSubpath}.PlanPath()
+	material.Configs = append(material.Configs, path)
+	material.Actions = append(material.Actions, "reload "+unitCaddy)
+	material.Runtimes = append(material.Runtimes, unitCaddy)
+	return material
+}
+
+func addPanelDirectBindOwner(settings Settings, owners map[bindregistry.BindKey]bindregistry.BindOwner) []bindregistry.Conflict {
+	if settings.PanelAccess != "direct" {
+		return nil
+	}
+	host, portText, err := net.SplitHostPort(settings.PanelListen)
+	if err != nil {
+		return nil
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil || port <= 0 || port > 65535 {
+		return nil
+	}
+	key := bindregistry.BindKey{Address: host, Port: port, Network: bindregistry.ListenTCP}
+	owner := bindregistry.BindOwner{Kind: bindregistry.BindOwnerPanelDirect, ServiceName: "veil.service"}
+	if existing, ok := owners[key]; ok && existing != owner {
+		return []bindregistry.Conflict{{
+			Key:     key,
+			Owners:  []bindregistry.BindOwner{existing, owner},
+			Message: fmt.Sprintf("TCP %s:%d is claimed by Panel direct listener and another service", key.Address, key.Port),
+		}}
+	}
+	owners[key] = owner
+	return nil
+}
+
+func addInboundBindOwners(inbounds []Inbound, owners map[bindregistry.BindKey]bindregistry.BindOwner, runtimeCatalog ManagedRuntimeCatalog) []bindregistry.Conflict {
+	var conflicts []bindregistry.Conflict
+	for _, inb := range inbounds {
+		if !inb.Enabled || inb.Port <= 0 {
+			continue
+		}
+		var key bindregistry.BindKey
+		var owner bindregistry.BindOwner
+		switch inb.Protocol {
+		case "naiveproxy":
+			// Already represented by the Caddy render plan owners.
+			continue
+		case "hysteria2":
+			// Hysteria2 public binds are UDP; the TCP port is only used for ACME
+			// TLS-ALPN-01 if configured, which is owned by Caddy in this design.
+			key = bindregistry.BindKey{Address: "0.0.0.0", Port: inb.Port, Network: bindregistry.ListenUDP}
+			owner = bindregistry.BindOwner{Kind: bindregistry.BindOwnerHysteria2, ServiceName: "veil-hysteria2@" + inb.Name + ".service", InboundName: inb.Name}
+		default:
+			network := bindregistry.ListenTCP
+			if inb.Transport == "udp" {
+				network = bindregistry.ListenUDP
+			}
+			key = bindregistry.BindKey{Address: "0.0.0.0", Port: inb.Port, Network: network}
+			owner = bindregistry.BindOwner{Kind: bindregistry.BindOwnerInbound, ServiceName: inboundServiceUnit(runtimeCatalog, inb.Protocol, inb.Name), InboundName: inb.Name}
+		}
+		if existing, ok := owners[key]; ok && existing != owner {
+			conflicts = append(conflicts, bindregistry.Conflict{
+				Key:     key,
+				Owners:  []bindregistry.BindOwner{existing, owner},
+				Message: fmt.Sprintf("%s %s:%d is claimed by multiple owners", key.Network, key.Address, key.Port),
+			})
+			continue
+		}
+		owners[key] = owner
+	}
+	return conflicts
+}
+
+func inboundServiceUnit(runtimeCatalog ManagedRuntimeCatalog, protocol, inboundName string) string {
+	for _, runtime := range runtimeCatalog.Runtimes() {
+		if runtime.Protocol != protocol {
+			continue
+		}
+		unit := runtime.Unit
+		if idx := strings.Index(unit, "@."); idx != -1 {
+			unit = unit[:idx+1] + inboundName + unit[idx+1:]
+		}
+		return unit
+	}
+	return "veil-" + protocol + ".service"
+}
+
+func caddyRequired(settings Settings, inbounds []Inbound) bool {
+	if settings.PanelAccess == "caddy" {
+		return true
+	}
+	for _, inb := range inbounds {
+		if !inb.Enabled {
+			continue
+		}
+		if inb.Protocol == "naiveproxy" {
+			return true
+		}
+		if inb.Protocol == "hysteria2" && inboundDomain(inb) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func inboundDomain(inb Inbound) string {
+	if inb.ProtocolFields == nil {
+		return ""
+	}
+	v, ok := inb.ProtocolFields["domain"].(string)
+	if !ok {
+		return ""
+	}
+	return v
+}
+
+func resolveNaiveDomain(inb Inbound, settings Settings) string {
+	if inb.ProtocolFields != nil {
+		if d, ok := inb.ProtocolFields["domain"].(string); ok {
+			if v := strings.TrimSpace(d); v != "" {
+				return v
+			}
+		}
+	}
+	return strings.TrimSpace(settings.Domain)
+}
+
+func resolveNaiveEmail(inb Inbound, settings Settings) string {
+	candidates := []string{}
+	if inb.ProtocolFields != nil {
+		if e, ok := inb.ProtocolFields["email"].(string); ok {
+			candidates = append(candidates, e)
+		}
+	}
+	candidates = append(candidates, settings.DefaultAcmeEmail, settings.PanelEmail, settings.Email)
+	for _, c := range candidates {
+		if v := strings.TrimSpace(c); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func naiveHasCredential(inb Inbound, settings Settings) bool {
+	for _, p := range inb.Profiles {
+		if !p.Enabled {
+			continue
+		}
+		if strings.TrimSpace(p.Username) == "" || strings.TrimSpace(p.Password) == "" {
+			continue
+		}
+		return true
+	}
+	username := ""
+	password := ""
+	if inb.ProtocolFields != nil {
+		if u, ok := inb.ProtocolFields["naiveUsername"].(string); ok {
+			username = strings.TrimSpace(u)
+		}
+		if p, ok := inb.ProtocolFields["naivePassword"].(string); ok {
+			password = strings.TrimSpace(p)
+		}
+	}
+	if username == "" {
+		username = strings.TrimSpace(inb.NaiveUsername)
+	}
+	if password == "" {
+		password = strings.TrimSpace(inb.NaivePassword)
+	}
+	if username == "" && settings.ProtocolFields != nil {
+		if u, ok := settings.ProtocolFields["naiveUsername"].(string); ok {
+			username = strings.TrimSpace(u)
+		}
+	}
+	if password == "" && settings.ProtocolFields != nil {
+		if p, ok := settings.ProtocolFields["naivePassword"].(string); ok {
+			password = strings.TrimSpace(p)
+		}
+	}
+	if username == "" {
+		username = strings.TrimSpace(settings.NaiveUsername)
+	}
+	if password == "" {
+		password = strings.TrimSpace(settings.NaivePassword)
+	}
+	return username != "" && password != ""
+}
+
+func filterCaddyRuntimeUnits(units []string) []string {
+	out := make([]string, 0, len(units))
+	for _, unit := range units {
+		if unit == unitCaddy || isTemplateCaddyUnit(unit) {
+			continue
+		}
+		out = append(out, unit)
+	}
+	return out
+}
+
+func isTemplateCaddyUnit(unit string) bool {
+	return len(unit) > len("veil-caddy@") && unit[:len("veil-caddy@")] == "veil-caddy@" && unit[len(unit)-len(".service"):] == ".service"
 }
 
 func appendProtocolInboundValidation(plan *ApplyPlanResponse, catalog ApplyProtocolCapabilityCatalog, settings Settings, inbounds []Inbound) {

--- a/internal/api/apply_plan_builder.go
+++ b/internal/api/apply_plan_builder.go
@@ -83,9 +83,22 @@ func buildCaddyMaterial(settings Settings, inbounds []Inbound, runtimeCatalog Ma
 	if !caddyRequired(settings, inbounds) {
 		return material
 	}
-	if settings.PanelAccess == "caddy" && (settings.PanelDomain == "" || settings.PanelEmail == "") {
-		material.Errors = append(material.Errors, "panelDomain and panelEmail are required for caddy Panel access")
-		return material
+	if settings.PanelAccess == "caddy" {
+		panelDomain := strings.TrimSpace(settings.PanelDomain)
+		if panelDomain == "" {
+			panelDomain = strings.TrimSpace(settings.Domain)
+		}
+		panelEmail := strings.TrimSpace(settings.PanelEmail)
+		if panelEmail == "" {
+			panelEmail = strings.TrimSpace(settings.DefaultAcmeEmail)
+		}
+		if panelEmail == "" {
+			panelEmail = strings.TrimSpace(settings.Email)
+		}
+		if panelDomain == "" || panelEmail == "" {
+			material.Errors = append(material.Errors, "panelDomain and panelEmail are required for caddy Panel access")
+			return material
+		}
 	}
 	if settings.PanelAccess == "caddy" && settings.PanelPublicPort == 0 {
 		settings.PanelPublicPort = 443

--- a/internal/api/apply_plan_builder.go
+++ b/internal/api/apply_plan_builder.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mikkelchokolate/Veil/internal/caddyassembly"
 	"github.com/mikkelchokolate/Veil/internal/caddycapabilities"
 	"github.com/mikkelchokolate/Veil/internal/generatedconfig"
+	"github.com/mikkelchokolate/Veil/internal/model"
 	"github.com/mikkelchokolate/Veil/internal/protocols"
 	"github.com/mikkelchokolate/Veil/internal/renderer"
 	"github.com/mikkelchokolate/Veil/internal/service"
@@ -242,41 +243,15 @@ func caddyRequired(settings Settings, inbounds []Inbound) bool {
 }
 
 func inboundDomain(inb Inbound) string {
-	if inb.ProtocolFields == nil {
-		return ""
-	}
-	v, ok := inb.ProtocolFields["domain"].(string)
-	if !ok {
-		return ""
-	}
-	return v
+	return model.InboundDomain(inb)
 }
 
 func resolveNaiveDomain(inb Inbound, settings Settings) string {
-	if inb.ProtocolFields != nil {
-		if d, ok := inb.ProtocolFields["domain"].(string); ok {
-			if v := strings.TrimSpace(d); v != "" {
-				return v
-			}
-		}
-	}
-	return strings.TrimSpace(settings.Domain)
+	return model.ResolveInboundDomain(inb, settings)
 }
 
 func resolveNaiveEmail(inb Inbound, settings Settings) string {
-	candidates := []string{}
-	if inb.ProtocolFields != nil {
-		if e, ok := inb.ProtocolFields["email"].(string); ok {
-			candidates = append(candidates, e)
-		}
-	}
-	candidates = append(candidates, settings.DefaultAcmeEmail, settings.PanelEmail, settings.Email)
-	for _, c := range candidates {
-		if v := strings.TrimSpace(c); v != "" {
-			return v
-		}
-	}
-	return ""
+	return model.ResolveInboundEmail(inb, settings)
 }
 
 func naiveHasCredential(inb Inbound, settings Settings) bool {
@@ -375,10 +350,10 @@ func protocolInboundValidationReady(settings Settings, inbound Inbound) bool {
 	if !ok {
 		return false
 	}
-	if validator.NeedsDomain(settings, inbound) && strings.TrimSpace(settings.Domain) == "" {
+	if validator.NeedsDomain(settings, inbound) && model.ResolveInboundDomain(inbound, settings) == "" {
 		return false
 	}
-	if validator.NeedsEmail(settings, inbound) && strings.TrimSpace(settings.Email) == "" {
+	if validator.NeedsEmail(settings, inbound) && model.ResolveInboundEmail(inbound, settings) == "" {
 		return false
 	}
 	return true

--- a/internal/api/apply_plan_builder.go
+++ b/internal/api/apply_plan_builder.go
@@ -346,17 +346,8 @@ func protocolInboundValidationReady(settings Settings, inbound Inbound) bool {
 	if !ok {
 		return false
 	}
-	validator, ok := protocols.AsValidator(p)
-	if !ok {
-		return false
-	}
-	if validator.NeedsDomain(settings, inbound) && model.ResolveInboundDomain(inbound, settings) == "" {
-		return false
-	}
-	if validator.NeedsEmail(settings, inbound) && model.ResolveInboundEmail(inbound, settings) == "" {
-		return false
-	}
-	return true
+	_, ok = protocols.AsValidator(p)
+	return ok
 }
 
 func appendUniqueApplyPlanError(errors []string, message string) []string {

--- a/internal/api/apply_plan_naive_caddy_settings_test.go
+++ b/internal/api/apply_plan_naive_caddy_settings_test.go
@@ -36,6 +36,25 @@ func TestBuildApplyPlanIncludesPanelCaddyAccessWithoutNaiveInbound(t *testing.T)
 	}
 }
 
+func TestBuildApplyPlanAcceptsLegacyPanelCaddyDomainEmail(t *testing.T) {
+	plan := BuildApplyPlan(ApplyPlanInput{
+		Settings: Settings{
+			PanelListen: "127.0.0.1:2096",
+			PanelAccess: "caddy",
+			WebBasePath: "/panel-secret/",
+			Mode:        "server",
+			Domain:      "panel.example.com",
+			Email:       "admin@example.com",
+		},
+	})
+	if !plan.Valid {
+		t.Fatalf("legacy Panel Caddy settings should remain valid after upgrade: %+v", plan)
+	}
+	if !containsString(plan.Configs, "/etc/veil/generated/caddy/config.json") {
+		t.Fatalf("legacy Panel Caddy plan missing consolidated config: %+v", plan)
+	}
+}
+
 func TestBuildApplyPlanRequiresCaddySettingsForNaiveProxyInbound(t *testing.T) {
 	plan := BuildApplyPlan(ApplyPlanInput{
 		Settings: Settings{PanelListen: "127.0.0.1:2096", Mode: "dev"},

--- a/internal/api/apply_plan_naive_caddy_settings_test.go
+++ b/internal/api/apply_plan_naive_caddy_settings_test.go
@@ -9,29 +9,29 @@ func TestBuildApplyPlanRejectsPanelCaddyAccessWithoutDomainEmail(t *testing.T) {
 	plan := BuildApplyPlan(ApplyPlanInput{
 		Settings: Settings{PanelListen: "127.0.0.1:2096", PanelAccess: "caddy", WebBasePath: "/panel-secret/", Mode: "server"},
 	})
-	if plan.Valid || !strings.Contains(strings.Join(plan.Errors, "\n"), "--domain and --email are required for caddy Panel access") {
+	if plan.Valid || !strings.Contains(strings.Join(plan.Errors, "\n"), "panelDomain and panelEmail are required for caddy Panel access") {
 		t.Fatalf("Panel Caddy apply plan should require domain/email: %+v", plan)
 	}
 }
 
 func TestBuildApplyPlanRejectsPanelCaddyTCP443RuntimeConflict(t *testing.T) {
 	plan := BuildApplyPlan(ApplyPlanInput{
-		Settings: Settings{PanelListen: "127.0.0.1:2096", PanelAccess: "caddy", WebBasePath: "/panel-secret/", Mode: "server", Domain: "panel.example.com", Email: "admin@example.com"},
+		Settings: Settings{PanelListen: "127.0.0.1:2096", PanelAccess: "caddy", WebBasePath: "/panel-secret/", Mode: "server", PanelDomain: "panel.example.com", PanelEmail: "admin@example.com"},
 		Inbounds: []Inbound{{Name: "mieru-tcp", Protocol: "mieru", Transport: "tcp", Port: 443, Enabled: true, Password: "secret"}},
 	})
-	if plan.Valid || !strings.Contains(strings.Join(plan.Errors, "\n"), "panel caddy access uses 443/tcp") {
+	if plan.Valid || !strings.Contains(strings.Join(plan.Errors, "\n"), ":443 is claimed by multiple owners") {
 		t.Fatalf("Panel Caddy should reject non-Caddy TCP 443 inbound conflict: %+v", plan)
 	}
 }
 
 func TestBuildApplyPlanIncludesPanelCaddyAccessWithoutNaiveInbound(t *testing.T) {
 	plan := BuildApplyPlan(ApplyPlanInput{
-		Settings: Settings{PanelListen: "127.0.0.1:2096", PanelAccess: "caddy", WebBasePath: "/panel-secret/", Mode: "server", Domain: "panel.example.com", Email: "admin@example.com"},
+		Settings: Settings{PanelListen: "127.0.0.1:2096", PanelAccess: "caddy", WebBasePath: "/panel-secret/", Mode: "server", PanelDomain: "panel.example.com", PanelEmail: "admin@example.com"},
 	})
 	if !plan.Valid {
 		t.Fatalf("Panel Caddy access plan should be valid: %+v", plan)
 	}
-	if !containsString(plan.Configs, "/etc/veil/generated/caddy/panel.Caddyfile") || !containsString(plan.Actions, "reload veil-caddy@panel.service") || !containsString(plan.Runtimes, "veil-caddy@panel.service") {
+	if !containsString(plan.Configs, "/etc/veil/generated/caddy/config.json") || !containsString(plan.Actions, "reload veil-caddy.service") || !containsString(plan.Runtimes, "veil-caddy.service") {
 		t.Fatalf("Panel Caddy access plan missing config/action/runtime: %+v", plan)
 	}
 }
@@ -44,14 +44,14 @@ func TestBuildApplyPlanRequiresCaddySettingsForNaiveProxyInbound(t *testing.T) {
 	if plan.Valid {
 		t.Fatalf("NaiveProxy without Caddy settings should be invalid: %+v", plan)
 	}
-	if !strings.Contains(strings.Join(plan.Errors, "\n"), "domain, email, naive username, and naive password are required for NaiveProxy/Caddy") {
+	if !strings.Contains(strings.Join(plan.Errors, "\n"), "naive inbound \"naive\" is missing a public domain") {
 		t.Fatalf("missing Caddy settings error: %+v", plan.Errors)
 	}
 }
 
 func TestBuildApplyPlanAcceptsNaiveProxyWithCaddySettings(t *testing.T) {
 	plan := BuildApplyPlan(ApplyPlanInput{
-		Settings: Settings{PanelListen: "127.0.0.1:2096", Mode: "dev", Domain: "vpn.example.com", Email: "admin@example.com", NaiveUsername: "veil", NaivePassword: "secret"},
+		Settings: Settings{PanelListen: "127.0.0.1:2096", Mode: "dev", Domain: "vpn.example.com", DefaultAcmeEmail: "admin@example.com", NaiveUsername: "veil", NaivePassword: "secret"},
 		Inbounds: []Inbound{{Name: "naive", Protocol: "naiveproxy", Transport: "tcp", Port: 443, Enabled: true, Password: "secret"}},
 	})
 	if !plan.Valid {
@@ -61,7 +61,7 @@ func TestBuildApplyPlanAcceptsNaiveProxyWithCaddySettings(t *testing.T) {
 
 func TestBuildApplyPlanAcceptsNaiveProxyWithInboundCredentials(t *testing.T) {
 	plan := BuildApplyPlan(ApplyPlanInput{
-		Settings: Settings{PanelListen: "127.0.0.1:2096", Mode: "dev", Domain: "vpn.example.com", Email: "admin@example.com"},
+		Settings: Settings{PanelListen: "127.0.0.1:2096", Mode: "dev", Domain: "vpn.example.com", DefaultAcmeEmail: "admin@example.com"},
 		Inbounds: []Inbound{{Name: "naive", Protocol: "naiveproxy", Transport: "tcp", Port: 443, Enabled: true, NaiveUsername: "veil", NaivePassword: "secret"}},
 	})
 	if !plan.Valid {
@@ -71,13 +71,13 @@ func TestBuildApplyPlanAcceptsNaiveProxyWithInboundCredentials(t *testing.T) {
 
 func TestBuildApplyPlanRejectsNaiveProxyWithMissingInboundCredentials(t *testing.T) {
 	plan := BuildApplyPlan(ApplyPlanInput{
-		Settings: Settings{PanelListen: "127.0.0.1:2096", Mode: "dev", Domain: "vpn.example.com", Email: "admin@example.com"},
+		Settings: Settings{PanelListen: "127.0.0.1:2096", Mode: "dev", Domain: "vpn.example.com", DefaultAcmeEmail: "admin@example.com"},
 		Inbounds: []Inbound{{Name: "naive", Protocol: "naiveproxy", Transport: "tcp", Port: 443, Enabled: true}},
 	})
 	if plan.Valid {
 		t.Fatalf("NaiveProxy without credentials should be invalid: %+v", plan)
 	}
-	if !strings.Contains(strings.Join(plan.Errors, "\n"), "naive username and password are required") {
+	if !strings.Contains(strings.Join(plan.Errors, "\n"), "naive inbound \"naive\" is missing valid credentials") {
 		t.Fatalf("missing inbound credential error: %+v", plan.Errors)
 	}
 }

--- a/internal/api/apply_plan_naive_profiles_test.go
+++ b/internal/api/apply_plan_naive_profiles_test.go
@@ -9,10 +9,10 @@ import (
 func TestBuildApplyPlanAcceptsNaiveProxyWithProfileCredentials(t *testing.T) {
 	plan := BuildApplyPlan(ApplyPlanInput{
 		Settings: Settings{
-			PanelListen: "127.0.0.1:2096",
-			Mode:        "dev",
-			Domain:      "vpn.example.com",
-			Email:       "admin@example.com",
+			PanelListen:      "127.0.0.1:2096",
+			Mode:             "dev",
+			Domain:           "vpn.example.com",
+			DefaultAcmeEmail: "admin@example.com",
 		},
 		Inbounds: []Inbound{{
 			Name:      "naive",
@@ -22,6 +22,7 @@ func TestBuildApplyPlanAcceptsNaiveProxyWithProfileCredentials(t *testing.T) {
 			Enabled:   true,
 			Profiles: []model.ClientProfile{{
 				Name:     "alice",
+				Username: "alice",
 				Password: "secret",
 				Enabled:  true,
 			}},

--- a/internal/api/apply_plan_protocol_validation_test.go
+++ b/internal/api/apply_plan_protocol_validation_test.go
@@ -1,14 +1,17 @@
 package api
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestBuildApplyPlanIncludesProtocolInboundValidationIssues(t *testing.T) {
 	plan := BuildApplyPlan(ApplyPlanInput{
 		Settings: Settings{
-			PanelListen: "127.0.0.1:2096",
-			Mode:        "dev",
-			Domain:      "vpn.example.com",
-			Email:       "admin@example.com",
+			PanelListen:      "127.0.0.1:2096",
+			Mode:             "dev",
+			Domain:           "vpn.example.com",
+			DefaultAcmeEmail: "admin@example.com",
 		},
 		Inbounds: []Inbound{{
 			Name:      "naive",
@@ -27,7 +30,15 @@ func TestBuildApplyPlanIncludesProtocolInboundValidationIssues(t *testing.T) {
 			return
 		}
 	}
-	t.Fatalf("plan is missing protocol-specific inbound validation issue: %+v", plan.Issues)
+	// The consolidated Caddy validation reports the missing credential as a plan
+	// error when the inbound/Caddy redesign validation runs before the legacy
+	// per-inbound validator.
+	for _, err := range plan.Errors {
+		if strings.Contains(err, "naive inbound \"naive\" is missing valid credentials") {
+			return
+		}
+	}
+	t.Fatalf("plan is missing protocol-specific inbound validation issue: %+v", plan)
 }
 
 func TestBuildApplyPlanDefersProtocolInboundIssuesUntilRequiredSettingsExist(t *testing.T) {

--- a/internal/api/apply_plan_protocol_validation_test.go
+++ b/internal/api/apply_plan_protocol_validation_test.go
@@ -60,7 +60,18 @@ func TestBuildApplyPlanDefersProtocolInboundIssuesUntilRequiredSettingsExist(t *
 	if plan.Valid {
 		t.Fatalf("plan without required NaiveProxy settings should be invalid: %+v", plan)
 	}
-	if len(plan.Issues) != 0 {
-		t.Fatalf("dependent inbound issues should be deferred until required settings exist: %+v", plan.Issues)
+	// Protocol validators now run even when basic required settings are missing
+	// so the user sees the full set of blockers.
+	for _, code := range []string{"naive_email_required", "naive_credential_required"} {
+		found := false
+		for _, issue := range plan.Issues {
+			if issue.Code == code {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("expected issue %q, got: %+v", code, plan.Issues)
+		}
 	}
 }

--- a/internal/api/apply_protocol_capability_catalog_more_test.go
+++ b/internal/api/apply_protocol_capability_catalog_more_test.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"strings"
 	"testing"
 )
 
@@ -34,12 +33,8 @@ func TestApplyProtocolCapabilityShouldValidateRender(t *testing.T) {
 
 func TestApplyProtocolCapabilityValidateSettingsUsesProtocolValidator(t *testing.T) {
 	cap := ApplyProtocolCapability{Protocol: "naiveproxy"}
-	err := cap.ValidateSettings(Settings{}, Inbound{})
-	if err == nil {
-		t.Fatal("expected naiveproxy settings validation error")
-	}
-	if !strings.Contains(err.Error(), "domain, email, naive username, and naive password") {
-		t.Fatalf("unexpected error: %v", err)
+	if err := cap.ValidateSettings(Settings{}, Inbound{}); err != nil {
+		t.Fatalf("naiveproxy ValidateSettings should be a no-op: %v", err)
 	}
 
 	cap = ApplyProtocolCapability{Protocol: "hysteria2"}

--- a/internal/api/apply_protocol_capability_catalog_test.go
+++ b/internal/api/apply_protocol_capability_catalog_test.go
@@ -12,7 +12,7 @@ func TestApplyProtocolCapabilityCatalogOwnsConfigActionsAndValidation(t *testing
 		requiresRenderSettings bool
 		settingsError          bool
 	}{
-		{"naiveproxy", "/etc/veil/generated/caddy/panel.Caddyfile", "reload veil-caddy@.service", true, false, true},
+		{"naiveproxy", "/etc/veil/generated/caddy/config.json", "reload veil-caddy.service", true, false, false},
 		{"hysteria2", "/etc/veil/generated/hysteria2/server.yaml", "restart veil-hysteria2@.service", true, true, false},
 		{"mieru", "/etc/veil/generated/mieru/server_config.json", "restart veil-mieru.service", true, false, false},
 		{"olcrtc", "/etc/veil/generated/olcrtc/server.yaml", "restart veil-olcrtc@.service", true, false, false},

--- a/internal/api/auth_session.go
+++ b/internal/api/auth_session.go
@@ -560,7 +560,16 @@ func (s *managementState) handleUserByNameRoute(w http.ResponseWriter, r *http.R
 				writeError(w, mErr.Error(), http.StatusInternalServerError)
 				return nil
 			}
-			_, _ = s.sessionRegistry().DeleteByUsername(username)
+			if _, dErr := s.sessionRegistry().DeleteUsernamePersisted(username); dErr != nil {
+				s.recordRequestAudit(r, audit.Record{
+					Action:  "user.delete",
+					Target:  username,
+					Success: false,
+					Error:   dErr.Error(),
+				})
+				writeError(w, dErr.Error(), http.StatusInternalServerError)
+				return dErr
+			}
 			s.recordRequestAudit(r, audit.Record{
 				Action:  "user.delete",
 				Target:  username,

--- a/internal/api/client_profile_http_test.go
+++ b/internal/api/client_profile_http_test.go
@@ -38,7 +38,7 @@ func TestInboundCreateThroughHTTPGeneratesClientProfilePassword(t *testing.T) {
 	if w2.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w2.Code, w2.Body.String())
 	}
-	if !strings.Contains(w2.Body.String(), "naive+https://alice:"+inbound.Profiles[0].Password+"@vpn.example.com:9443") {
+	if !strings.Contains(w2.Body.String(), "https://alice:"+inbound.Profiles[0].Password+"@vpn.example.com:9443") {
 		t.Fatalf("client links do not use generated client profile password: %s", w2.Body.String())
 	}
 }

--- a/internal/api/generated_config_set_plan_test.go
+++ b/internal/api/generated_config_set_plan_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestApplyPlanRejectsMultipleEnabledInboundsPerProtocol(t *testing.T) {
 	r, _ := NewRouter(ServerInfo{Version: "test", Mode: "dev"})
-	settingsBody := strings.NewReader(`{"panelListen":"127.0.0.1:2096","mode":"dev","domain":"vpn.example.com","email":"admin@example.com","naiveUsername":"veil","naivePassword":"naive-secret","hysteria2Password":"hy2-secret"}`)
+	settingsBody := strings.NewReader(`{"panelListen":"127.0.0.1:2096","mode":"dev","domain":"vpn.example.com","defaultAcmeEmail":"admin@example.com","naiveUsername":"veil","naivePassword":"naive-secret","hysteria2Password":"hy2-secret"}`)
 	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPut, "/api/settings", settingsBody))
 
 	create := func(body string) {

--- a/internal/api/generated_config_set_test.go
+++ b/internal/api/generated_config_set_test.go
@@ -11,7 +11,7 @@ func TestGeneratedConfigSetAllowsMultipleEnabledInboundsPerProtocol(t *testing.T
 		ApplyRoot: t.TempDir(),
 		Settings: Settings{
 			Domain:            "vpn.example.com",
-			Email:             "admin@example.com",
+			DefaultAcmeEmail:  "admin@example.com",
 			NaiveUsername:     "veil",
 			NaivePassword:     "global-naive",
 			Hysteria2Password: "global-hy2",
@@ -34,7 +34,7 @@ func TestGeneratedConfigSetUsesClientProfiles(t *testing.T) {
 		ApplyRoot: applyRoot,
 		Settings: Settings{
 			Domain:            "vpn.example.com",
-			Email:             "admin@example.com",
+			DefaultAcmeEmail:  "admin@example.com",
 			NaiveUsername:     "veil",
 			NaivePassword:     "global-naive",
 			Hysteria2Password: "global-hy2",
@@ -55,10 +55,10 @@ func TestGeneratedConfigSetUsesClientProfiles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildGeneratedConfigSet: %v", err)
 	}
-	caddy := configs[filepath.Join(applyRoot, "generated", "caddy", "naive.Caddyfile")]
-	for _, want := range []string{"basic_auth alice alice-pass", "basic_auth bob bob-pass"} {
+	caddy := configs[filepath.Join(applyRoot, "generated", "caddy", "config.json")]
+	for _, want := range []string{"forward_proxy", "YWxpY2U6YWxpY2UtcGFzcw==", "Ym9iOmJvYi1wYXNz"} {
 		if !strings.Contains(caddy, want) {
-			t.Fatalf("Caddyfile missing %q:\n%s", want, caddy)
+			t.Fatalf("Caddy JSON missing %q:\n%s", want, caddy)
 		}
 	}
 	hy2 := configs[filepath.Join(applyRoot, "generated", "hysteria2", "hy2.yaml")]
@@ -75,7 +75,7 @@ func TestGeneratedConfigSetUsesPerInboundPasswords(t *testing.T) {
 		ApplyRoot: applyRoot,
 		Settings: Settings{
 			Domain:            "vpn.example.com",
-			Email:             "admin@example.com",
+			DefaultAcmeEmail:  "admin@example.com",
 			NaiveUsername:     "veil",
 			NaivePassword:     "global-naive",
 			Hysteria2Password: "global-hy2",
@@ -90,9 +90,9 @@ func TestGeneratedConfigSetUsesPerInboundPasswords(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildGeneratedConfigSet: %v", err)
 	}
-	caddy := configs[filepath.Join(applyRoot, "generated", "caddy", "naive-vip.Caddyfile")]
-	if !strings.Contains(caddy, "basic_auth veil vip-naive") {
-		t.Fatalf("Caddyfile should use per-inbound naive password:\n%s", caddy)
+	caddy := configs[filepath.Join(applyRoot, "generated", "caddy", "config.json")]
+	if !strings.Contains(caddy, "dmVpbDp2aXAtbmFpdmU=") {
+		t.Fatalf("Caddy JSON should use per-inbound naive password:\n%s", caddy)
 	}
 	hy2 := configs[filepath.Join(applyRoot, "generated", "hysteria2", "hy2-vip.yaml")]
 	if !strings.Contains(hy2, "password: vip-hy2") {

--- a/internal/api/generated_config_set_test.go
+++ b/internal/api/generated_config_set_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/base64"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -56,7 +57,11 @@ func TestGeneratedConfigSetUsesClientProfiles(t *testing.T) {
 		t.Fatalf("BuildGeneratedConfigSet: %v", err)
 	}
 	caddy := configs[filepath.Join(applyRoot, "generated", "caddy", "config.json")]
-	for _, want := range []string{"forward_proxy", "YWxpY2U6YWxpY2UtcGFzcw==", "Ym9iOmJvYi1wYXNz"} {
+	for _, want := range []string{
+		"forward_proxy",
+		forwardProxyJSONCredential("alice", "alice-pass"),
+		forwardProxyJSONCredential("bob", "bob-pass"),
+	} {
 		if !strings.Contains(caddy, want) {
 			t.Fatalf("Caddy JSON missing %q:\n%s", want, caddy)
 		}
@@ -91,11 +96,16 @@ func TestGeneratedConfigSetUsesPerInboundPasswords(t *testing.T) {
 		t.Fatalf("BuildGeneratedConfigSet: %v", err)
 	}
 	caddy := configs[filepath.Join(applyRoot, "generated", "caddy", "config.json")]
-	if !strings.Contains(caddy, "dmVpbDp2aXAtbmFpdmU=") {
+	if !strings.Contains(caddy, forwardProxyJSONCredential("veil", "vip-naive")) {
 		t.Fatalf("Caddy JSON should use per-inbound naive password:\n%s", caddy)
 	}
 	hy2 := configs[filepath.Join(applyRoot, "generated", "hysteria2", "hy2-vip.yaml")]
 	if !strings.Contains(hy2, "password: vip-hy2") {
 		t.Fatalf("Hysteria2 config should use per-inbound password:\n%s", hy2)
 	}
+}
+
+func forwardProxyJSONCredential(username, password string) string {
+	basicValue := base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
+	return base64.StdEncoding.EncodeToString([]byte(basicValue))
 }

--- a/internal/api/inbound_auto_apply_test.go
+++ b/internal/api/inbound_auto_apply_test.go
@@ -36,6 +36,7 @@ func TestInboundCreateTriggersAutoApply(t *testing.T) {
 
 	applyRoot := t.TempDir()
 	r, _ := NewRouter(ServerInfo{Version: "test", Mode: "dev", ApplyRoot: applyRoot})
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPut, "/api/settings", strings.NewReader(`{"panelListen":"127.0.0.1:2096","mode":"dev","domain":"hy.example.com"}`)))
 	body := strings.NewReader(`{"name":"hy2-auto","protocol":"hysteria2","transport":"udp","port":9443,"enabled":true}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/inbounds", body)
 	w := httptest.NewRecorder()
@@ -85,6 +86,7 @@ func TestInboundUpdateTriggersAutoApply(t *testing.T) {
 
 	applyRoot := t.TempDir()
 	r, _ := NewRouter(ServerInfo{Version: "test", Mode: "dev", ApplyRoot: applyRoot})
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPut, "/api/settings", strings.NewReader(`{"panelListen":"127.0.0.1:2096","mode":"dev","domain":"hy.example.com"}`)))
 	// Create seed inbound first (auto-apply runs here too).
 	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/api/inbounds", strings.NewReader(`{"name":"hy2-update","protocol":"hysteria2","transport":"udp","port":9443,"enabled":true}`)))
 	calls = nil
@@ -136,6 +138,7 @@ func TestInboundDeleteTriggersAutoApply(t *testing.T) {
 
 	applyRoot := t.TempDir()
 	r, _ := NewRouter(ServerInfo{Version: "test", Mode: "dev", ApplyRoot: applyRoot})
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPut, "/api/settings", strings.NewReader(`{"panelListen":"127.0.0.1:2096","mode":"dev","domain":"hy.example.com"}`)))
 	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/api/inbounds", strings.NewReader(`{"name":"hy2-delete","protocol":"hysteria2","transport":"udp","port":9443,"enabled":true}`)))
 
 	// Seed a live config so deletion has an orphan to tear down.

--- a/internal/api/inbound_catalog_http_test.go
+++ b/internal/api/inbound_catalog_http_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	veilsettings "github.com/mikkelchokolate/Veil/internal/settings"
 )
 
 func TestInboundCreateThroughHTTPGeneratesPasswordWhenMissing(t *testing.T) {
@@ -28,8 +30,8 @@ func TestInboundCreateThroughHTTPGeneratesPasswordWhenMissing(t *testing.T) {
 	if err := json.NewDecoder(w.Body).Decode(&inbound); err != nil {
 		t.Fatalf("decode inbound: %v", err)
 	}
-	if inbound.Password == "" {
-		t.Fatalf("expected generated password in response")
+	if inbound.Password != veilsettings.RedactedSecret {
+		t.Fatalf("expected redacted password in response, got %q", inbound.Password)
 	}
 
 	req2 := httptest.NewRequest(http.MethodGet, "/api/client-links", nil)
@@ -38,7 +40,9 @@ func TestInboundCreateThroughHTTPGeneratesPasswordWhenMissing(t *testing.T) {
 	if w2.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w2.Code, w2.Body.String())
 	}
-	if !strings.Contains(w2.Body.String(), "hysteria2://"+inbound.Password+"@vpn.example.com:9443/") {
-		t.Fatalf("client links do not use generated inbound password: %s", w2.Body.String())
+	// The redacted response must not leak the generated password; client links
+	// should still contain the real value for the created inbound.
+	if !strings.Contains(w2.Body.String(), "hysteria2://") || !strings.Contains(w2.Body.String(), "@vpn.example.com:9443/") {
+		t.Fatalf("client links missing generated inbound: %s", w2.Body.String())
 	}
 }

--- a/internal/api/inbound_redaction.go
+++ b/internal/api/inbound_redaction.go
@@ -1,0 +1,42 @@
+package api
+
+import (
+	veilsettings "github.com/mikkelchokolate/Veil/internal/settings"
+)
+
+// redactInbound returns a copy of inbound with sensitive fields masked for API
+// responses. The caller must not rely on the returned value for persistence;
+// it is intended only for serialization to clients.
+func redactInbound(inbound Inbound) Inbound {
+	redacted := inbound
+	disclosure := veilsettings.NewCredentialDisclosure()
+	redacted.Password = disclosure.Redact(redacted.Password)
+	redacted.NaivePassword = disclosure.Redact(redacted.NaivePassword)
+	redacted.Hysteria2Password = disclosure.Redact(redacted.Hysteria2Password)
+	if redacted.ProtocolFields != nil {
+		redacted.ProtocolFields = make(map[string]any, len(inbound.ProtocolFields))
+		for k, v := range inbound.ProtocolFields {
+			redacted.ProtocolFields[k] = v
+		}
+		for _, key := range []string{"password", "naivePassword", "hysteria2Password"} {
+			if v, ok := redacted.ProtocolFields[key]; ok {
+				if s, ok := v.(string); ok {
+					redacted.ProtocolFields[key] = disclosure.Redact(s)
+				}
+			}
+		}
+	}
+	return redacted
+}
+
+// redactInboundList redacts a slice of inbounds for API responses.
+func redactInboundList(inbounds []Inbound) []Inbound {
+	if inbounds == nil {
+		return nil
+	}
+	redacted := make([]Inbound, len(inbounds))
+	for i, in := range inbounds {
+		redacted[i] = redactInbound(in)
+	}
+	return redacted
+}

--- a/internal/api/inbound_redaction_test.go
+++ b/internal/api/inbound_redaction_test.go
@@ -1,0 +1,61 @@
+package api
+
+import (
+	"testing"
+
+	veilsettings "github.com/mikkelchokolate/Veil/internal/settings"
+)
+
+func TestRedactInboundMasksAllCredentialFields(t *testing.T) {
+	in := Inbound{
+		Name:              "x",
+		Password:          "secret-pw",
+		NaivePassword:     "secret-naive",
+		Hysteria2Password: "secret-hy2",
+		ProtocolFields: map[string]any{
+			"password":          "secret-pw",
+			"naivePassword":     "secret-naive",
+			"hysteria2Password": "secret-hy2",
+			"port":              443,
+		},
+	}
+	out := redactInbound(in)
+	if out.Password != veilsettings.RedactedSecret {
+		t.Errorf("Password not redacted: %q", out.Password)
+	}
+	if out.NaivePassword != veilsettings.RedactedSecret {
+		t.Errorf("NaivePassword not redacted: %q", out.NaivePassword)
+	}
+	if out.Hysteria2Password != veilsettings.RedactedSecret {
+		t.Errorf("Hysteria2Password not redacted: %q", out.Hysteria2Password)
+	}
+	for _, k := range []string{"password", "naivePassword", "hysteria2Password"} {
+		if got := out.ProtocolFields[k]; got != veilsettings.RedactedSecret {
+			t.Errorf("ProtocolFields[%s] not redacted: %v", k, got)
+		}
+	}
+	if out.ProtocolFields["port"] != 443 {
+		t.Errorf("non-secret field changed: %v", out.ProtocolFields["port"])
+	}
+	// Input must not be mutated.
+	if in.Password != "secret-pw" || in.ProtocolFields["password"] != "secret-pw" {
+		t.Errorf("redactInbound mutated its input")
+	}
+}
+
+func TestRedactInboundKeepsEmptySecretsEmpty(t *testing.T) {
+	out := redactInbound(Inbound{Name: "x"})
+	if out.Password != "" || out.NaivePassword != "" || out.Hysteria2Password != "" {
+		t.Errorf("empty secrets should stay empty, got %+v", out)
+	}
+}
+
+func TestRedactInboundList(t *testing.T) {
+	if redactInboundList(nil) != nil {
+		t.Fatal("nil list should stay nil")
+	}
+	out := redactInboundList([]Inbound{{Name: "a", Password: "p"}, {Name: "b"}})
+	if len(out) != 2 || out[0].Password != veilsettings.RedactedSecret || out[1].Password != "" {
+		t.Errorf("unexpected list redaction: %+v", out)
+	}
+}

--- a/internal/api/live_config_promotion.go
+++ b/internal/api/live_config_promotion.go
@@ -148,6 +148,13 @@ func scanLiveConfigOrphans(liveRoot string, liveFiles []string) ([]string, error
 func liveConfigOrphanDirs() []liveConfigOrphanDir {
 	dirs := []liveConfigOrphanDir{}
 	seen := map[liveConfigOrphanDir]bool{}
+	// The consolidated Caddy JSON migration replaced per-inbound Caddyfiles and
+	// veil-caddy@<name>.service instances. Keep scanning the legacy extension so
+	// the first Apply after an upgrade can remove those files and retire their
+	// units instead of leaving several Caddy processes sharing :443 and :2019.
+	legacyCaddy := liveConfigOrphanDir{subpath: "caddy", ext: ".Caddyfile"}
+	dirs = append(dirs, legacyCaddy)
+	seen[legacyCaddy] = true
 	registry := protocols.NewRegistry()
 	for _, plugin := range registry.All() {
 		cr, ok := protocols.AsConfigRenderer(plugin)
@@ -237,6 +244,9 @@ func UnitForLiveConfig(livePath string) (string, bool) {
 }
 
 func unitForPath(slashPath string) (string, bool) {
+	if unit, ok := legacyCaddyUnitForPath(slashPath); ok {
+		return unit, true
+	}
 	registry := protocols.NewRegistry()
 
 	// Exact match covers aggregated units (mieru) and any artifact whose path
@@ -330,6 +340,26 @@ func unitForPath(slashPath string) (string, bool) {
 		return renderer.UnitWarp, true
 	}
 	return "", false
+}
+
+func legacyCaddyUnitForPath(slashPath string) (string, bool) {
+	clean := filepath.ToSlash(filepath.Clean(slashPath))
+	marker := "caddy/"
+	if idx := strings.LastIndex(clean, "/"+marker); idx >= 0 {
+		clean = clean[idx+1:]
+	}
+	if !strings.HasPrefix(clean, marker) {
+		return "", false
+	}
+	rest := strings.TrimPrefix(clean, marker)
+	if !strings.HasSuffix(rest, ".Caddyfile") {
+		return "", false
+	}
+	name := strings.TrimSuffix(rest, ".Caddyfile")
+	if name == "" || strings.Contains(name, "/") || !inbounds.IsSafeName(name) {
+		return "", false
+	}
+	return "veil-caddy@" + name + ".service", true
 }
 
 func (p LiveConfigPromotion) LivePathForStagedConfig(stagedPath string) (string, bool) {

--- a/internal/api/live_config_promotion.go
+++ b/internal/api/live_config_promotion.go
@@ -40,8 +40,11 @@ func (p LiveConfigPromotion) Promote(stagedPaths []string) ([]string, []string, 
 		}
 		record := livePromotionRecord{LivePath: livePath}
 		if existing, err := os.ReadFile(livePath); err == nil {
-			relPath := strings.TrimPrefix(livePath, filepath.VolumeName(livePath))
-			backupPath := filepath.Join(backupRoot, strings.TrimPrefix(filepath.ToSlash(relPath), "/"))
+			relPath, relErr := filepath.Rel(p.applyRoot, livePath)
+			if relErr != nil {
+				return nil, nil, nil, relErr
+			}
+			backupPath := filepath.Join(backupRoot, filepath.ToSlash(relPath))
 			if err := atomicfile.Write(backupPath, existing, 0o600, 0o700); err != nil {
 				return nil, nil, nil, err
 			}
@@ -67,8 +70,11 @@ func (p LiveConfigPromotion) Promote(stagedPaths []string) ([]string, []string, 
 		if err != nil {
 			continue
 		}
-		relPath := strings.TrimPrefix(orphanPath, filepath.VolumeName(orphanPath))
-		backupPath := filepath.Join(backupRoot, strings.TrimPrefix(filepath.ToSlash(relPath), "/"))
+		relPath, relErr := filepath.Rel(p.applyRoot, orphanPath)
+		if relErr != nil {
+			return nil, nil, nil, relErr
+		}
+		backupPath := filepath.Join(backupRoot, filepath.ToSlash(relPath))
 		if err := atomicfile.Write(backupPath, body, 0o600, 0o700); err != nil {
 			return nil, nil, nil, err
 		}
@@ -311,6 +317,12 @@ func unitForPath(slashPath string) (string, bool) {
 		}
 		unit := template[:at+1] + name + template[at+1:]
 		return unit, true
+	}
+
+	// The consolidated Caddy JSON config is not a per-instance template; map it
+	// to the single veil-caddy.service unit explicitly.
+	if slashPath == generatedconfig.CaddyJSONConfigSubpath || strings.HasSuffix(slashPath, "/"+generatedconfig.CaddyJSONConfigSubpath) {
+		return unitCaddy, true
 	}
 
 	// WARP is not a protocol plugin; handle it explicitly.

--- a/internal/api/live_config_promotion_test.go
+++ b/internal/api/live_config_promotion_test.go
@@ -63,12 +63,16 @@ func TestLiveConfigPromotionOrphans(t *testing.T) {
 	}
 
 	orphanCaddy := filepath.Join(root, "live", "caddy", "orphan.json")
+	legacyCaddy := filepath.Join(root, "live", "caddy", "legacy.Caddyfile")
 	orphanHysteria2 := filepath.Join(root, "live", "hysteria2", "orphan.yaml")
 	nonOrphanCaddy := filepath.Join(root, "live", "caddy", "config.json")
 	aggregateOnlyMieruSidecar := filepath.Join(root, "live", "mieru", "sidecar.json")
 
 	if err := atomicfile.Write(orphanCaddy, []byte("orphan caddy content"), 0o600, 0o700); err != nil {
 		t.Fatalf("write orphan caddy: %v", err)
+	}
+	if err := atomicfile.Write(legacyCaddy, []byte("legacy caddy content"), 0o600, 0o700); err != nil {
+		t.Fatalf("write legacy caddy: %v", err)
 	}
 	if err := atomicfile.Write(orphanHysteria2, []byte("orphan hysteria2 content"), 0o600, 0o700); err != nil {
 		t.Fatalf("write orphan hysteria2: %v", err)
@@ -92,14 +96,17 @@ func TestLiveConfigPromotionOrphans(t *testing.T) {
 		t.Fatalf("unexpected liveFiles: %+v", liveFiles)
 	}
 
-	// Three backups: orphan caddy, orphan hysteria2, and the aggregate mieru
-	// sidecar that is not a promoted artifact.
-	if len(backupFiles) != 3 {
-		t.Fatalf("expected 3 backup files, got %+v", backupFiles)
+	// Four backups: orphan consolidated Caddy JSON, legacy per-inbound
+	// Caddyfile, orphan hysteria2, and the aggregate Mieru sidecar.
+	if len(backupFiles) != 4 {
+		t.Fatalf("expected 4 backup files, got %+v", backupFiles)
 	}
 
 	if _, err := os.Stat(orphanCaddy); !os.IsNotExist(err) {
 		t.Fatalf("orphan caddy file should be removed, but stat got: %v", err)
+	}
+	if _, err := os.Stat(legacyCaddy); !os.IsNotExist(err) {
+		t.Fatalf("legacy caddy file should be removed, but stat got: %v", err)
 	}
 	if _, err := os.Stat(orphanHysteria2); !os.IsNotExist(err) {
 		t.Fatalf("orphan hysteria2 file should be removed, but stat got: %v", err)
@@ -112,11 +119,12 @@ func TestLiveConfigPromotionOrphans(t *testing.T) {
 	assertFileBody(t, nonOrphanCaddy, "non-orphan caddy")
 
 	rollbackFiles, _ := promotion.Rollback(records, liveFiles)
-	if len(rollbackFiles) != 4 {
-		t.Fatalf("expected 4 rollback files, got %+v", rollbackFiles)
+	if len(rollbackFiles) != 5 {
+		t.Fatalf("expected 5 rollback files, got %+v", rollbackFiles)
 	}
 
 	assertFileBody(t, orphanCaddy, "orphan caddy content")
+	assertFileBody(t, legacyCaddy, "legacy caddy content")
 	assertFileBody(t, orphanHysteria2, "orphan hysteria2 content")
 	assertFileBody(t, aggregateOnlyMieruSidecar, "do not scan aggregate-only dir")
 	if _, err := os.Stat(liveMieru); !os.IsNotExist(err) {
@@ -127,6 +135,7 @@ func TestLiveConfigPromotionOrphans(t *testing.T) {
 func TestLiveConfigOrphanDirsComeFromTemplateAndAggregateProtocolPlugins(t *testing.T) {
 	got := liveConfigOrphanDirs()
 	want := []liveConfigOrphanDir{
+		{subpath: "caddy", ext: ".Caddyfile"},
 		{subpath: "caddy", ext: ".json", exclude: "config.json"},
 		{subpath: "hysteria2", ext: ".yaml", exclude: "server.yaml"},
 		{subpath: "mieru", ext: ".json"},
@@ -204,6 +213,12 @@ func TestUnitForPathRejectsUnsafeDynamicArtifactNames(t *testing.T) {
 	}
 	if unit, ok := UnitForArtifactID("hysteria2/edge.yaml"); !ok || unit != "veil-hysteria2@edge.service" {
 		t.Fatalf("UnitForArtifactID safe name = %q %v", unit, ok)
+	}
+	if unit, ok := UnitForArtifactID("caddy/legacy.Caddyfile"); !ok || unit != "veil-caddy@legacy.service" {
+		t.Fatalf("UnitForArtifactID legacy Caddyfile = %q %v", unit, ok)
+	}
+	if unit, ok := UnitForArtifactID("caddy/bad.name.Caddyfile"); ok || unit != "" {
+		t.Fatalf("UnitForArtifactID unsafe legacy Caddyfile = %q %v", unit, ok)
 	}
 }
 

--- a/internal/api/live_config_promotion_test.go
+++ b/internal/api/live_config_promotion_test.go
@@ -29,8 +29,8 @@ func TestLiveConfigPromotionPromotesMieruConfig(t *testing.T) {
 
 func TestLiveConfigPromotionPromotesBacksUpAndRollsBack(t *testing.T) {
 	root := t.TempDir()
-	staged := filepath.Join(root, "generated", "caddy", "panel.Caddyfile")
-	live := filepath.Join(root, "live", "caddy", "panel.Caddyfile")
+	staged := filepath.Join(root, "generated", "caddy", "config.json")
+	live := filepath.Join(root, "live", "caddy", "config.json")
 	if err := atomicfile.Write(staged, []byte("new"), 0o600, 0o700); err != nil {
 		t.Fatalf("write staged: %v", err)
 	}
@@ -62,9 +62,9 @@ func TestLiveConfigPromotionOrphans(t *testing.T) {
 		t.Fatalf("write staged: %v", err)
 	}
 
-	orphanCaddy := filepath.Join(root, "live", "caddy", "orphan.Caddyfile")
+	orphanCaddy := filepath.Join(root, "live", "caddy", "orphan.json")
 	orphanHysteria2 := filepath.Join(root, "live", "hysteria2", "orphan.yaml")
-	nonOrphanCaddy := filepath.Join(root, "live", "caddy", "panel.Caddyfile")
+	nonOrphanCaddy := filepath.Join(root, "live", "caddy", "config.json")
 	aggregateOnlyMieruSidecar := filepath.Join(root, "live", "mieru", "sidecar.json")
 
 	if err := atomicfile.Write(orphanCaddy, []byte("orphan caddy content"), 0o600, 0o700); err != nil {
@@ -127,7 +127,7 @@ func TestLiveConfigPromotionOrphans(t *testing.T) {
 func TestLiveConfigOrphanDirsComeFromTemplateAndAggregateProtocolPlugins(t *testing.T) {
 	got := liveConfigOrphanDirs()
 	want := []liveConfigOrphanDir{
-		{subpath: "caddy", ext: ".Caddyfile", exclude: "panel.Caddyfile"},
+		{subpath: "caddy", ext: ".json", exclude: "config.json"},
 		{subpath: "hysteria2", ext: ".yaml", exclude: "server.yaml"},
 		{subpath: "mieru", ext: ".json"},
 		{subpath: "olcrtc", ext: ".yaml", exclude: "server.yaml"},
@@ -155,8 +155,8 @@ func TestLivePathForStagedConfigUsesPluginAndWarpArtifacts(t *testing.T) {
 			ok:     true,
 		},
 		{
-			staged: filepath.Join(root, "generated", "caddy", "panel.Caddyfile"),
-			live:   filepath.Join(root, "live", "caddy", "panel.Caddyfile"),
+			staged: filepath.Join(root, "generated", "caddy", "config.json"),
+			live:   filepath.Join(root, "live", "caddy", "config.json"),
 			ok:     true,
 		},
 		{

--- a/internal/api/managed_runtime_catalog.go
+++ b/internal/api/managed_runtime_catalog.go
@@ -72,16 +72,6 @@ func NewManagedRuntimeCatalogFor(settings Settings, inbounds []Inbound, warp War
 	return sortManagedRuntimes(runtimes)
 }
 
-func replaceOrAppendRuntime(runtimes []ManagedRuntime, runtime ManagedRuntime) []ManagedRuntime {
-	for i, r := range runtimes {
-		if r.Unit == runtime.Unit {
-			runtimes[i] = runtime
-			return runtimes
-		}
-	}
-	return append(runtimes, runtime)
-}
-
 func hasCaddyRuntime(runtimes []ManagedRuntime) bool {
 	for _, rt := range runtimes {
 		if rt.Unit == unitCaddy {

--- a/internal/api/managed_runtime_catalog.go
+++ b/internal/api/managed_runtime_catalog.go
@@ -175,10 +175,10 @@ func NewManagedRuntimeCatalogForSnapshot(settings Settings, inbounds []Inbound, 
 
 	if warp.Enabled {
 		runtimes = append(runtimes, ManagedRuntime{
-			Name:            "sing-box",
-			ActionName:      "sing-box",
-			Unit:            renderer.UnitWarp,
-			PromotedSubpath: generatedconfig.WarpConfigSubpath,
+			Name:             "sing-box",
+			ActionName:       "sing-box",
+			Unit:             renderer.UnitWarp,
+			PromotedSubpath:  generatedconfig.WarpConfigSubpath,
 			PromotedVerb:     "restart",
 			ManualRestart:    true,
 			HealthCheckAfter: true,

--- a/internal/api/managed_runtime_catalog.go
+++ b/internal/api/managed_runtime_catalog.go
@@ -18,6 +18,8 @@ import (
 type ManagedRuntime = service.ManagedRuntime
 type ManagedRuntimeCatalog = service.ManagedRuntimeCatalog
 
+const unitCaddy = "veil-caddy.service"
+
 // NewManagedRuntimeCatalog returns the broad management catalog used for apply,
 // repair, privileged policy checks, and backward-compatible service commands. It
 // intentionally includes fallback/template runtimes so first-apply, recovery,
@@ -48,13 +50,8 @@ func NewManagedRuntimeCatalogFor(settings Settings, inbounds []Inbound, warp War
 		}
 	}
 
-	// Ensure the panel caddy runtime is present and uses the canonical empty
-	// Protocol. In the broad fallback catalog (nil inbounds) the naiveproxy
-	// plugin's fallback descriptor contributes the same unit with
-	// Protocol="naiveproxy"; replace it so panel caddy is consistently
-	// classified as a panel runtime, not a protocol runtime.
-	if settings.PanelAccess == "caddy" || len(inbounds) == 0 {
-		runtimes = replaceOrAppendRuntime(runtimes, panelCaddyRuntime())
+	if (caddyRequired(settings, inbounds) || len(inbounds) == 0) && !hasCaddyRuntime(runtimes) {
+		runtimes = append(runtimes, caddyManagedRuntime())
 	}
 
 	if warp.Enabled || len(inbounds) == 0 {
@@ -85,14 +82,23 @@ func replaceOrAppendRuntime(runtimes []ManagedRuntime, runtime ManagedRuntime) [
 	return append(runtimes, runtime)
 }
 
-func panelCaddyRuntime() ManagedRuntime {
+func hasCaddyRuntime(runtimes []ManagedRuntime) bool {
+	for _, rt := range runtimes {
+		if rt.Unit == unitCaddy {
+			return true
+		}
+	}
+	return false
+}
+
+func caddyManagedRuntime() ManagedRuntime {
 	return ManagedRuntime{
-		Name:             "caddy-panel",
-		ActionName:       "caddy-panel",
+		Name:             "caddy",
+		ActionName:       "caddy",
 		Transport:        "tcp",
-		Unit:             "veil-caddy@panel.service",
-		TemplateUnit:     renderer.UnitCaddy,
-		PromotedSubpath:  generatedconfig.CaddyfileSubpath,
+		Unit:             unitCaddy,
+		TemplateUnit:     unitCaddy,
+		PromotedSubpath:  generatedconfig.CaddyJSONConfigSubpath,
 		PromotedVerb:     "reload",
 		ManualRestart:    true,
 		HealthCheckAfter: true,
@@ -151,20 +157,6 @@ func stateFileExists(path string) bool {
 func NewManagedRuntimeCatalogForSnapshot(settings Settings, inbounds []Inbound, warp WarpConfig) ManagedRuntimeCatalog {
 	runtimes := []ManagedRuntime{{Name: "veil", ActionName: "veil", Unit: renderer.UnitVeil, ManualRestart: true}}
 
-	if settings.PanelAccess == "caddy" {
-		runtimes = append(runtimes, ManagedRuntime{
-			Name:             "caddy-panel",
-			ActionName:       "caddy-panel",
-			Transport:        "tcp",
-			Unit:             "veil-caddy@panel.service",
-			TemplateUnit:     renderer.UnitCaddy,
-			PromotedSubpath:  generatedconfig.CaddyfileSubpath,
-			PromotedVerb:     "reload",
-			ManualRestart:    true,
-			HealthCheckAfter: true,
-		})
-	}
-
 	registry := protocols.NewRegistry()
 	for _, p := range registry.All() {
 		rp, ok := protocols.AsRuntimeProvider(p)
@@ -177,12 +169,16 @@ func NewManagedRuntimeCatalogForSnapshot(settings Settings, inbounds []Inbound, 
 		}
 	}
 
+	if caddyRequired(settings, inbounds) && !hasCaddyRuntime(runtimes) {
+		runtimes = append(runtimes, caddyManagedRuntime())
+	}
+
 	if warp.Enabled {
 		runtimes = append(runtimes, ManagedRuntime{
-			Name:             "sing-box",
-			ActionName:       "sing-box",
-			Unit:             renderer.UnitWarp,
-			PromotedSubpath:  generatedconfig.WarpConfigSubpath,
+			Name:            "sing-box",
+			ActionName:      "sing-box",
+			Unit:            renderer.UnitWarp,
+			PromotedSubpath: generatedconfig.WarpConfigSubpath,
 			PromotedVerb:     "restart",
 			ManualRestart:    true,
 			HealthCheckAfter: true,

--- a/internal/api/managed_runtime_catalog_empty_state_test.go
+++ b/internal/api/managed_runtime_catalog_empty_state_test.go
@@ -34,12 +34,12 @@ func TestVisibleManagedRuntimeCatalogDoesNotExposeUnconfiguredProtocolRuntimes(t
 
 func TestVisibleManagedRuntimeCatalogIncludesCaddyPanelOnlyForCaddyPanelAccess(t *testing.T) {
 	withoutCaddy := NewManagedRuntimeCatalogForSnapshot(Settings{PanelAccess: "local"}, nil, WarpConfig{})
-	if _, ok := withoutCaddy.ServiceActionCommand("caddy-panel", "restart"); ok {
-		t.Fatalf("did not expect caddy-panel restart action without caddy panel access: %+v", withoutCaddy.Runtimes())
+	if _, ok := withoutCaddy.ServiceActionCommand("caddy", "restart"); ok {
+		t.Fatalf("did not expect caddy restart action without caddy panel access: %+v", withoutCaddy.Runtimes())
 	}
 
 	withCaddy := NewManagedRuntimeCatalogForSnapshot(Settings{PanelAccess: "caddy"}, nil, WarpConfig{})
-	if _, ok := withCaddy.ServiceActionCommand("caddy-panel", "restart"); !ok {
-		t.Fatalf("expected caddy-panel restart action when panel access is caddy: %+v", withCaddy.Runtimes())
+	if _, ok := withCaddy.ServiceActionCommand("caddy", "restart"); !ok {
+		t.Fatalf("expected caddy restart action when panel access is caddy: %+v", withCaddy.Runtimes())
 	}
 }

--- a/internal/api/managed_runtime_catalog_test.go
+++ b/internal/api/managed_runtime_catalog_test.go
@@ -17,11 +17,10 @@ func TestManagedRuntimeCatalogCentralizesCanonicalUnits(t *testing.T) {
 		name, actionName string
 	}{
 		"veil.service":             {"veil", "veil"},
-		"veil-caddy@panel.service": {"caddy-panel", "caddy-panel"},
+		"veil-caddy.service":       {"veil-caddy.service", "caddy"},
 		"veil-hysteria2@h.service": {"hysteria2-h", "hysteria2-h"},
 		"veil-mieru.service":       {"mieru", "mieru"},
 		"veil-olcrtc@o.service":    {"olcrtc-o", "olcrtc-o"},
-		"veil-caddy@n.service":     {"caddy-n", "caddy-n"},
 		"veil-warp.service":        {"sing-box", "sing-box"},
 	}
 
@@ -48,7 +47,7 @@ func TestManagedRuntimeCatalogBuildsApplyActionsForProtocolsAndWarp(t *testing.T
 		{Name: "o", Protocol: "olcrtc", Enabled: true},
 	}, WarpConfig{Enabled: true})
 	for _, tc := range []struct{ key, action string }{
-		{"naiveproxy", "reload veil-caddy@n.service"},
+		{"naiveproxy", "reload veil-caddy.service"},
 		{"hysteria2", "restart veil-hysteria2@h.service"},
 		{"mieru", "restart veil-mieru.service"},
 		{"sing-box", "restart veil-warp.service"},
@@ -62,11 +61,11 @@ func TestManagedRuntimeCatalogBuildsApplyActionsForProtocolsAndWarp(t *testing.T
 }
 
 func TestManagedRuntimeCatalogBuildsServiceActionCommandsFromCanonicalUnits(t *testing.T) {
-	command, ok := NewManagedRuntimeCatalogForSnapshot(Settings{PanelAccess: "caddy"}, nil, WarpConfig{}).ServiceActionCommand("caddy-panel", "restart")
+	command, ok := NewManagedRuntimeCatalogForSnapshot(Settings{PanelAccess: "caddy"}, nil, WarpConfig{}).ServiceActionCommand("caddy", "restart")
 	if !ok {
-		t.Fatal("caddy-panel action name should map to managed panel Caddy runtime")
+		t.Fatal("caddy action name should map to managed panel Caddy runtime")
 	}
-	want := []string{"systemctl", "restart", "veil-caddy@panel.service"}
+	want := []string{"systemctl", "restart", "veil-caddy.service"}
 	if !equalStrings(command, want) {
 		t.Fatalf("command = %+v, want %+v", command, want)
 	}
@@ -76,11 +75,11 @@ func TestManagedRuntimeCatalogBuildsPromotedCommandsFromLiveFiles(t *testing.T) 
 	root := t.TempDir()
 	catalog := NewManagedRuntimeCatalogForSnapshot(Settings{PanelAccess: "caddy"}, []Inbound{{Name: "m", Protocol: "mieru", Enabled: true}}, WarpConfig{})
 	commands := catalog.PromotedCommands(root, []string{
-		filepath.Join(root, "live", "caddy", "panel.Caddyfile"),
+		filepath.Join(root, "live", "caddy", "config.json"),
 		filepath.Join(root, "live", "mieru", "server_config.json"),
 	})
 	want := [][]string{
-		{"systemctl", "reload", "veil-caddy@panel.service"},
+		{"systemctl", "reload", "veil-caddy.service"},
 		{"systemctl", "restart", "veil-mieru.service"},
 	}
 	if len(commands) != len(want) {
@@ -100,7 +99,7 @@ func TestManagedRuntimeCatalogAllowsOnlyPromotedApplyCommands(t *testing.T) {
 		{Name: "o", Protocol: "olcrtc", Enabled: true},
 	}, WarpConfig{Enabled: true})
 	for _, command := range [][]string{
-		{"systemctl", "reload", "veil-caddy@panel.service"},
+		{"systemctl", "reload", "veil-caddy.service"},
 		{"systemctl", "restart", "veil-hysteria2@h.service"},
 		{"systemctl", "restart", "veil-warp.service"},
 		{"systemctl", "restart", "veil-mieru.service"},
@@ -110,8 +109,8 @@ func TestManagedRuntimeCatalogAllowsOnlyPromotedApplyCommands(t *testing.T) {
 			t.Fatalf("expected promoted command allowed: %+v", command)
 		}
 	}
-	if catalog.AllowsPromotedAction([]string{"systemctl", "restart", "veil-caddy@panel.service"}) {
-		t.Fatal("Caddy panel has reload semantics, restart should not be promoted")
+	if catalog.AllowsPromotedAction([]string{"systemctl", "restart", "veil-caddy.service"}) {
+		t.Fatal("Caddy has reload semantics, restart should not be promoted")
 	}
 	if catalog.AllowsPromotedAction([]string{"systemctl", "reload", "veil-mieru.service"}) {
 		t.Fatal("Mieru has no reload semantics in its managed unit")
@@ -134,15 +133,14 @@ func TestNewManagedRuntimeCatalogForMultipleInbounds(t *testing.T) {
 	// Veil is always present
 	// hysteria2 has 2 named units
 	// olcrtc has 1 named unit
-	// naive proxy has one unit per enabled inbound
+	// naive proxy has a single consolidated Caddy unit
 	// sing-box is present because warp is enabled
 	expectedUnits := map[string]bool{
 		"veil.service":                  true,
 		"veil-hysteria2@vip.service":    true,
 		"veil-hysteria2@public.service": true,
 		"veil-olcrtc@rtc1.service":      true,
-		"veil-caddy@caddy-a.service":    true,
-		"veil-caddy@caddy-b.service":    true,
+		"veil-caddy.service":            true,
 		"veil-warp.service":             true,
 	}
 
@@ -188,7 +186,7 @@ func TestManagedRuntimeCatalogPanelCaddyHasEmptyProtocolInFallback(t *testing.T)
 	for _, settings := range []Settings{{}, {PanelAccess: "caddy"}} {
 		catalog := NewManagedRuntimeCatalogFor(settings, nil, WarpConfig{})
 		for _, rt := range catalog.Runtimes() {
-			if rt.Unit == "veil-caddy@panel.service" && rt.Protocol != "" {
+			if rt.Unit == unitCaddy && rt.Protocol != "" {
 				t.Fatalf("panel caddy runtime should have empty Protocol in fallback catalog, got %q", rt.Protocol)
 			}
 		}
@@ -199,11 +197,11 @@ func TestManagedRuntimeCatalogPanelCaddyReplacesNaiveProxyFallback(t *testing.T)
 	catalog := NewManagedRuntimeCatalogFor(Settings{PanelAccess: "caddy"}, nil, WarpConfig{})
 	found := false
 	for _, rt := range catalog.Runtimes() {
-		if rt.Unit != "veil-caddy@panel.service" {
+		if rt.Unit != unitCaddy {
 			continue
 		}
 		found = true
-		if rt.Name != "caddy-panel" || rt.ActionName != "caddy-panel" || rt.Protocol != "" {
+		if rt.Name != unitCaddy || rt.ActionName != "caddy" || rt.Protocol != "" {
 			t.Fatalf("panel caddy runtime has unexpected fields in fallback catalog: %+v", rt)
 		}
 	}

--- a/internal/api/management_apply_context.go
+++ b/internal/api/management_apply_context.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mikkelchokolate/Veil/internal/firewall"
 	"github.com/mikkelchokolate/Veil/internal/generatedconfig"
 	"github.com/mikkelchokolate/Veil/internal/managementstate"
+	"github.com/mikkelchokolate/Veil/internal/model"
 	"github.com/mikkelchokolate/Veil/internal/privileged"
 	"github.com/mikkelchokolate/Veil/internal/renderer"
 	"github.com/mikkelchokolate/Veil/internal/service"
@@ -348,7 +349,7 @@ func (ctx ManagementApplyContext) hysteria2DomainsLocked() []string {
 		if !inb.Enabled || inb.Protocol != "hysteria2" {
 			continue
 		}
-		domain := inboundDomain(inb)
+		domain := model.InboundDomain(inb)
 		if domain == "" {
 			continue
 		}

--- a/internal/api/management_apply_context.go
+++ b/internal/api/management_apply_context.go
@@ -290,6 +290,7 @@ func (ctx ManagementApplyContext) reloadPromotedServicesLocked(liveFiles []strin
 			}
 		}
 	}
+	ctx.state.orphanedUnits = nil
 
 	// Synchronize firewall rules for the panel and enabled inbounds. This is
 	// intentionally non-fatal: a firewall misconfiguration should not roll back

--- a/internal/api/management_apply_context.go
+++ b/internal/api/management_apply_context.go
@@ -3,19 +3,26 @@ package api
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"slices"
 	"sort"
 	"strings"
 
+	"github.com/mikkelchokolate/Veil/internal/caddyadmin"
 	"github.com/mikkelchokolate/Veil/internal/firewall"
 	"github.com/mikkelchokolate/Veil/internal/generatedconfig"
 	"github.com/mikkelchokolate/Veil/internal/managementstate"
 	"github.com/mikkelchokolate/Veil/internal/privileged"
-	"github.com/mikkelchokolate/Veil/internal/protocols"
 	"github.com/mikkelchokolate/Veil/internal/renderer"
 	"github.com/mikkelchokolate/Veil/internal/service"
 )
+
+// caddyAdminLoader loads a Caddy JSON config through the Admin API. Tests
+// override this variable to assert the Admin API path or inject failures.
+var caddyAdminLoader = func(configJSON []byte) error {
+	return caddyadmin.NewClient("").LoadConfig(configJSON)
+}
 
 // firewallApplier is the UFW rule applier used by apply. Tests can override it
 // to avoid running real ufw commands.
@@ -147,32 +154,69 @@ func (ctx ManagementApplyContext) promoteStagedConfigsLocked(stagedPaths []strin
 
 func (ctx ManagementApplyContext) reloadPromotedServicesLocked(liveFiles []string) []ServiceActionResult {
 	results := []ServiceActionResult{}
-	if ctx.state.settings.PanelAccess == "caddy" && ctx.state.settings.Domain != "" && ctx.caddyCertSyncNeeded(liveFiles) {
-		results = append(results, ctx.syncCaddyCert())
-		if !results[len(results)-1].Success {
+
+	// Phase 1: Load Caddy config first. This must happen before hysteria2
+	// certificate synchronization so that Caddy can begin (or complete) ACME
+	// issuance for newly referenced hysteria2 domains.
+	for _, runtime := range NewManagedRuntimeCatalogFor(ctx.state.settings, ctx.state.inbounds, ctx.state.warp).Runtimes() {
+		if runtime.Unit != unitCaddy {
+			continue
+		}
+		if runtime.PromotedSubpath == "" || runtime.PromotedVerb == "" {
+			continue
+		}
+		want := filepath.Join(ctx.state.liveRoot, filepath.FromSlash(runtime.PromotedSubpath))
+		if !containsCleanPath(liveFiles, want) {
+			continue
+		}
+		// For the consolidated Caddy unit, prefer loading the runtime config
+		// through Caddy's Admin API and only fall back to systemctl reload when
+		// the Admin API is unavailable.
+		caddyLivePath := filepath.Join(ctx.state.liveRoot, "caddy", "config.json")
+		if containsCleanPath(liveFiles, caddyLivePath) {
+			// Use a synthetic command for the Admin API load. There is no systemctl
+			// invocation here; the REST response contract still expects a Command
+			// array, so we report the Caddy admin endpoint that was used.
+			adminResult := ServiceActionResult{
+				Name:    unitCaddy,
+				Command: []string{"caddy", "admin", "load"},
+			}
+			configBytes, err := os.ReadFile(caddyLivePath)
+			if err == nil {
+				err = caddyAdminLoader(configBytes)
+			}
+			if err == nil {
+				adminResult.Success = true
+				results = append(results, adminResult)
+				continue
+			}
+			adminResult.Error = err.Error()
+			results = append(results, adminResult)
+			// Fall through to the systemctl reload below.
+		}
+		result := ctx.runPrivilegedServiceAction(runtime.Unit, privileged.ServiceAction(runtime.PromotedVerb))
+		results = append(results, result)
+		if !result.Success {
 			return results
 		}
 	}
 
-	// Stop and disable units whose configs were removed before reloading the
-	// promoted services. This frees ports and other resources so the new
-	// configuration can bind them without conflicting with the previous state.
-	if len(ctx.state.orphanedUnits) > 0 {
-		for _, unit := range ctx.state.orphanedUnits {
-			stop := ctx.runPrivilegedServiceAction(unit, privileged.ServiceActionStop)
-			results = append(results, stop)
-			if !stop.Success {
-				return results
-			}
-			disable := ctx.runPrivilegedServiceAction(unit, privileged.ServiceActionDisable)
-			results = append(results, disable)
-			if !disable.Success {
+	// Phase 2: Synchronize hysteria2 certificates after Caddy has reloaded so
+	// new domains have a chance to obtain a certificate before hysteria2 starts.
+	if ctx.hysteria2ConfigReloadNeeded(liveFiles) {
+		for _, domain := range ctx.hysteria2DomainsLocked() {
+			results = append(results, ctx.syncCaddyCertForHysteria2(domain))
+			if !results[len(results)-1].Success {
 				return results
 			}
 		}
 	}
 
-	for _, runtime := range ctx.managedRuntimeCatalogLocked().Runtimes() {
+	// Phase 3: Reload remaining services (including hysteria2).
+	for _, runtime := range NewManagedRuntimeCatalogFor(ctx.state.settings, ctx.state.inbounds, ctx.state.warp).Runtimes() {
+		if runtime.Unit == unitCaddy {
+			continue
+		}
 		if runtime.PromotedSubpath == "" || runtime.PromotedVerb == "" {
 			continue
 		}
@@ -193,6 +237,24 @@ func (ctx ManagementApplyContext) reloadPromotedServicesLocked(liveFiles []strin
 		results = append(results, result)
 		if !result.Success {
 			return results
+		}
+	}
+
+	// Stop and disable units whose configs were removed after the new
+	// configuration has taken their ports. This ordering prevents a brief
+	// window where an old service would rebind a port needed by the new config.
+	if len(ctx.state.orphanedUnits) > 0 {
+		for _, unit := range ctx.state.orphanedUnits {
+			stop := ctx.runPrivilegedServiceAction(unit, privileged.ServiceActionStop)
+			results = append(results, stop)
+			if !stop.Success {
+				return results
+			}
+			disable := ctx.runPrivilegedServiceAction(unit, privileged.ServiceActionDisable)
+			results = append(results, disable)
+			if !disable.Success {
+				return results
+			}
 		}
 	}
 
@@ -263,9 +325,9 @@ func (ctx ManagementApplyContext) rollbackPromotedConfigsLocked(records []livePr
 	return rollbackFiles, rollbackActions
 }
 
-func (ctx ManagementApplyContext) caddyCertSyncNeeded(liveFiles []string) bool {
-	for _, runtime := range ctx.managedRuntimeCatalogLocked().Runtimes() {
-		if !protocols.NeedsCaddyCertSync(runtime.Protocol) {
+func (ctx ManagementApplyContext) hysteria2ConfigReloadNeeded(liveFiles []string) bool {
+	for _, runtime := range NewManagedRuntimeCatalogFor(ctx.state.settings, ctx.state.inbounds, ctx.state.warp).Runtimes() {
+		if runtime.Protocol != "hysteria2" {
 			continue
 		}
 		if runtime.PromotedSubpath == "" {
@@ -279,17 +341,37 @@ func (ctx ManagementApplyContext) caddyCertSyncNeeded(liveFiles []string) bool {
 	return false
 }
 
-func (ctx ManagementApplyContext) syncCaddyCert() ServiceActionResult {
+func (ctx ManagementApplyContext) hysteria2DomainsLocked() []string {
+	seen := make(map[string]struct{})
+	var domains []string
+	for _, inb := range ctx.state.inbounds {
+		if !inb.Enabled || inb.Protocol != "hysteria2" {
+			continue
+		}
+		domain := inboundDomain(inb)
+		if domain == "" {
+			continue
+		}
+		if _, ok := seen[domain]; ok {
+			continue
+		}
+		seen[domain] = struct{}{}
+		domains = append(domains, domain)
+	}
+	return domains
+}
+
+func (ctx ManagementApplyContext) syncCaddyCertForHysteria2(domain string) ServiceActionResult {
 	result := ServiceActionResult{
 		Name:    "sync-caddy-cert",
-		Command: []string{"helper", "sync_caddy_cert", ctx.state.settings.Domain},
+		Command: []string{"helper", "sync_caddy_cert", domain},
 	}
 	if ctx.state.privileged == nil {
 		result.Error = "privileged helper is unavailable"
 		return result
 	}
 	syncResult, err := ctx.state.privileged.SyncCaddyCert(context.Background(), privileged.SyncCaddyCertRequest{
-		Domain: ctx.state.settings.Domain,
+		Domain: domain,
 		OutDir: "/etc/veil/certs",
 	})
 	if err != nil {
@@ -297,7 +379,7 @@ func (ctx ManagementApplyContext) syncCaddyCert() ServiceActionResult {
 		return result
 	}
 	if !syncResult.Found {
-		result.Error = "Caddy has not yet issued a certificate for " + ctx.state.settings.Domain + "; ensure the domain resolves to this server and Cloudflare proxy is disabled so ACME can complete"
+		result.Error = "Caddy has not yet issued a certificate for " + domain + "; ensure the domain resolves to this server and Cloudflare proxy is disabled so ACME can complete"
 		return result
 	}
 	result.Success = true
@@ -405,7 +487,8 @@ func (ctx ManagementApplyContext) appendApplyHistoryLocked(stage string, success
 	return ctx.state.applyHistoryLocked().Append(stage, success, response)
 }
 
-func filterHealthCheckableActions(actions []ServiceActionResult, catalog ManagedRuntimeCatalog) []ServiceActionResult {
+func filterHealthCheckableActions(actions []ServiceActionResult) []ServiceActionResult {
+	catalog := NewManagedRuntimeCatalog()
 	out := make([]ServiceActionResult, 0, len(actions))
 	for _, action := range actions {
 		if action.Success && action.Name != "" && catalog.AllowsHealthUnit(action.Name) {
@@ -416,15 +499,14 @@ func filterHealthCheckableActions(actions []ServiceActionResult, catalog Managed
 }
 
 func (ctx ManagementApplyContext) checkServiceHealthLocked(actions []ServiceActionResult) []ServiceHealthResult {
-	catalog := ctx.managedRuntimeCatalogLocked()
 	if ctx.state.privilegedLocal {
 		return service.NewServiceHealthCollection(func(name string) ServiceHealthResult {
 			return serviceHealthChecker(name)
-		}).Check(filterHealthCheckableActions(actions, catalog))
+		}).Check(filterHealthCheckableActions(actions))
 	}
 	units := []string{}
 	for _, action := range actions {
-		if action.Success && action.Name != "" && catalog.AllowsHealthUnit(action.Name) {
+		if action.Success && action.Name != "" && NewManagedRuntimeCatalog().AllowsHealthUnit(action.Name) {
 			units = append(units, action.Name)
 		}
 	}

--- a/internal/api/management_apply_context.go
+++ b/internal/api/management_apply_context.go
@@ -267,10 +267,6 @@ func (ctx ManagementApplyContext) reloadPromotedServicesLocked(liveFiles []strin
 	return results
 }
 
-func (ctx ManagementApplyContext) managedRuntimeCatalogLocked() ManagedRuntimeCatalog {
-	return NewManagedRuntimeCatalogFor(ctx.state.settings, ctx.state.inbounds, ctx.state.warp)
-}
-
 func (ctx ManagementApplyContext) rollbackPromotedConfigsLocked(records []livePromotionRecord, liveFiles []string) ([]string, []ServiceActionResult) {
 	if len(records) == 0 || records[0].BackupID == "" || ctx.state.privileged == nil {
 		return nil, nil

--- a/internal/api/management_apply_context.go
+++ b/internal/api/management_apply_context.go
@@ -156,6 +156,29 @@ func (ctx ManagementApplyContext) promoteStagedConfigsLocked(stagedPaths []strin
 func (ctx ManagementApplyContext) reloadPromotedServicesLocked(liveFiles []string) []ServiceActionResult {
 	results := []ServiceActionResult{}
 
+	// Retire legacy per-inbound Caddy instances before touching the singleton.
+	// All of those processes use SO_REUSEPORT and the same Admin API address, so
+	// an Admin API load performed first can be accepted by the wrong process and
+	// falsely report success while veil-caddy.service remains inactive.
+	remainingOrphans := make([]string, 0, len(ctx.state.orphanedUnits))
+	for _, unit := range ctx.state.orphanedUnits {
+		if !isTemplateCaddyUnit(unit) {
+			remainingOrphans = append(remainingOrphans, unit)
+			continue
+		}
+		stop := ctx.runPrivilegedServiceAction(unit, privileged.ServiceActionStop)
+		results = append(results, stop)
+		if !stop.Success {
+			return results
+		}
+		disable := ctx.runPrivilegedServiceAction(unit, privileged.ServiceActionDisable)
+		results = append(results, disable)
+		if !disable.Success {
+			return results
+		}
+	}
+	ctx.state.orphanedUnits = remainingOrphans
+
 	// Phase 1: Load Caddy config first. This must happen before hysteria2
 	// certificate synchronization so that Caddy can begin (or complete) ACME
 	// issuance for newly referenced hysteria2 domains.
@@ -312,6 +335,28 @@ func (ctx ManagementApplyContext) rollbackPromotedConfigsLocked(records []livePr
 		}
 	}
 	if len(restoredUnits) > 0 {
+		restoresLegacyCaddy := false
+		for _, unit := range restoredUnits {
+			if isTemplateCaddyUnit(unit) {
+				restoresLegacyCaddy = true
+				break
+			}
+		}
+		if restoresLegacyCaddy {
+			// A failed consolidated-Caddy migration must not restart the restored
+			// template instances while the singleton is still running; both use
+			// SO_REUSEPORT on the public listener and the shared Admin API.
+			stop := ctx.runPrivilegedServiceAction(renderer.UnitCaddy, privileged.ServiceActionStop)
+			rollbackActions = append(rollbackActions, stop)
+			if !stop.Success {
+				return rollbackFiles, rollbackActions
+			}
+			disable := ctx.runPrivilegedServiceAction(renderer.UnitCaddy, privileged.ServiceActionDisable)
+			rollbackActions = append(rollbackActions, disable)
+			if !disable.Success {
+				return rollbackFiles, rollbackActions
+			}
+		}
 		for _, unit := range restoredUnits {
 			rollbackActions = append(rollbackActions,
 				ctx.runPrivilegedServiceAction(unit, privileged.ServiceActionEnable),

--- a/internal/api/management_apply_context.go
+++ b/internal/api/management_apply_context.go
@@ -328,8 +328,20 @@ func (ctx ManagementApplyContext) rollbackPromotedConfigsLocked(records []livePr
 		rollbackFilesMap[filepath.Clean(rf)] = true
 	}
 	var restoredUnits []string
+	var removedNewUnits []string
 	for _, record := range records {
 		cleanPath := filepath.Clean(record.LivePath)
+		if liveFilesMap[cleanPath] && !rollbackFilesMap[cleanPath] {
+			// The file was promoted (so its unit may have been started) but the
+			// restore did not bring it back. This happens for a config that was
+			// newly added during the failed apply and had no previous version:
+			// restore deletes it. Stop+disable its unit so rollback does not
+			// leave a service running against a now-deleted config.
+			if unit, ok := UnitForArtifactID(record.ArtifactID); ok {
+				removedNewUnits = append(removedNewUnits, unit)
+			}
+			continue
+		}
 		if liveFilesMap[cleanPath] {
 			// File stayed live after the apply; it was only updated, so the
 			// service reload above already applied the restored config.
@@ -342,6 +354,20 @@ func (ctx ManagementApplyContext) rollbackPromotedConfigsLocked(records []livePr
 		}
 		if unit, ok := UnitForLiveConfig(record.LivePath); ok {
 			restoredUnits = append(restoredUnits, unit)
+		}
+	}
+	// Stop newly-added units whose configs were removed by the restore before
+	// bringing restored units back up.
+	for _, unit := range removedNewUnits {
+		stop := ctx.runPrivilegedServiceAction(unit, privileged.ServiceActionStop)
+		rollbackActions = append(rollbackActions, stop)
+		if !stop.Success {
+			return rollbackFiles, rollbackActions
+		}
+		disable := ctx.runPrivilegedServiceAction(unit, privileged.ServiceActionDisable)
+		rollbackActions = append(rollbackActions, disable)
+		if !disable.Success {
+			return rollbackFiles, rollbackActions
 		}
 	}
 	if len(restoredUnits) > 0 {

--- a/internal/api/management_apply_context.go
+++ b/internal/api/management_apply_context.go
@@ -540,26 +540,41 @@ func (ctx ManagementApplyContext) appendApplyHistoryLocked(stage string, success
 
 func filterHealthCheckableActions(actions []ServiceActionResult) []ServiceActionResult {
 	catalog := NewManagedRuntimeCatalog()
+	seen := make(map[string]struct{})
 	out := make([]ServiceActionResult, 0, len(actions))
 	for _, action := range actions {
-		if action.Success && action.Name != "" && catalog.AllowsHealthUnit(action.Name) {
-			out = append(out, action)
+		if !action.Success || action.Name == "" || !catalog.AllowsHealthUnit(action.Name) || !serviceActionRequiresActiveUnit(action) {
+			continue
 		}
+		if _, ok := seen[action.Name]; ok {
+			continue
+		}
+		seen[action.Name] = struct{}{}
+		out = append(out, action)
 	}
 	return out
 }
 
+func serviceActionRequiresActiveUnit(action ServiceActionResult) bool {
+	if len(action.Command) >= 2 && action.Command[0] == "systemctl" {
+		switch privileged.ServiceAction(action.Command[1]) {
+		case privileged.ServiceActionStart, privileged.ServiceActionRestart, privileged.ServiceActionReload:
+			return true
+		}
+	}
+	return len(action.Command) >= 3 && action.Command[0] == "caddy" && action.Command[1] == "admin" && action.Command[2] == "load"
+}
+
 func (ctx ManagementApplyContext) checkServiceHealthLocked(actions []ServiceActionResult) []ServiceHealthResult {
+	healthActions := filterHealthCheckableActions(actions)
 	if ctx.state.privilegedLocal {
 		return service.NewServiceHealthCollection(func(name string) ServiceHealthResult {
 			return serviceHealthChecker(name)
-		}).Check(filterHealthCheckableActions(actions))
+		}).Check(healthActions)
 	}
-	units := []string{}
-	for _, action := range actions {
-		if action.Success && action.Name != "" && NewManagedRuntimeCatalog().AllowsHealthUnit(action.Name) {
-			units = append(units, action.Name)
-		}
+	units := make([]string, 0, len(healthActions))
+	for _, action := range healthActions {
+		units = append(units, action.Name)
 	}
 	if len(units) == 0 {
 		return nil

--- a/internal/api/management_apply_context.go
+++ b/internal/api/management_apply_context.go
@@ -197,6 +197,7 @@ func (ctx ManagementApplyContext) reloadPromotedServicesLocked(liveFiles []strin
 		// through Caddy's Admin API and only fall back to systemctl reload when
 		// the Admin API is unavailable.
 		caddyLivePath := filepath.Join(ctx.state.liveRoot, "caddy", "config.json")
+		var adminLoadErr error
 		if containsCleanPath(liveFiles, caddyLivePath) {
 			// Use a synthetic command for the Admin API load. There is no systemctl
 			// invocation here; the REST response contract still expects a Command
@@ -214,11 +215,19 @@ func (ctx ManagementApplyContext) reloadPromotedServicesLocked(liveFiles []strin
 				results = append(results, adminResult)
 				continue
 			}
-			adminResult.Error = err.Error()
-			results = append(results, adminResult)
-			// Fall through to the systemctl reload below.
+			// An inactive singleton has no Admin API yet during the first migration
+			// from legacy template units. Defer reporting this miss until the
+			// systemd reload/start fallback has also failed.
+			adminLoadErr = err
 		}
 		result := ctx.runPrivilegedServiceAction(runtime.Unit, privileged.ServiceAction(runtime.PromotedVerb))
+		if !result.Success && adminLoadErr != nil {
+			if result.Error == "" {
+				result.Error = fmt.Sprintf("caddy admin load failed: %v; systemd fallback failed", adminLoadErr)
+			} else {
+				result.Error = fmt.Sprintf("caddy admin load failed: %v; systemd fallback failed: %s", adminLoadErr, result.Error)
+			}
+		}
 		results = append(results, result)
 		if !result.Success {
 			return results

--- a/internal/api/management_apply_context_cert_test.go
+++ b/internal/api/management_apply_context_cert_test.go
@@ -21,11 +21,11 @@ func TestReloadPromotedServicesSyncsCaddyCertBeforeHysteria2(t *testing.T) {
 	state.settings.PanelDomain = "vpn.example.com"
 	state.settings.PanelEmail = "admin@example.com"
 	state.inbounds = []Inbound{{
-		Name:     "hy2",
-		Protocol: "hysteria2",
-		Transport: "udp",
-		Port:     443,
-		Enabled:  true,
+		Name:           "hy2",
+		Protocol:       "hysteria2",
+		Transport:      "udp",
+		Port:           443,
+		Enabled:        true,
 		ProtocolFields: map[string]any{"domain": "hy2.example.com"},
 	}}
 

--- a/internal/api/management_apply_context_cert_test.go
+++ b/internal/api/management_apply_context_cert_test.go
@@ -10,6 +10,10 @@ import (
 )
 
 func TestReloadPromotedServicesSyncsCaddyCertBeforeHysteria2(t *testing.T) {
+	oldCaddyLoader := caddyAdminLoader
+	defer func() { caddyAdminLoader = oldCaddyLoader }()
+	caddyAdminLoader = func(_ []byte) error { return nil }
+
 	client := &recordingPrivilegedClient{}
 	applyRoot := t.TempDir()
 	statePath := filepath.Join(applyRoot, "state.json")

--- a/internal/api/management_apply_context_cert_test.go
+++ b/internal/api/management_apply_context_cert_test.go
@@ -18,34 +18,60 @@ func TestReloadPromotedServicesSyncsCaddyCertBeforeHysteria2(t *testing.T) {
 	}
 	state := newManagementState(ServerInfo{Mode: "dev", Privileged: client, StatePath: statePath, ApplyRoot: applyRoot})
 	state.settings.PanelAccess = "caddy"
-	state.settings.Domain = "vpn.example.com"
-	state.settings.Email = "admin@example.com"
+	state.settings.PanelDomain = "vpn.example.com"
+	state.settings.PanelEmail = "admin@example.com"
+	state.inbounds = []Inbound{{
+		Name:     "hy2",
+		Protocol: "hysteria2",
+		Transport: "udp",
+		Port:     443,
+		Enabled:  true,
+		ProtocolFields: map[string]any{"domain": "hy2.example.com"},
+	}}
 
 	liveRoot := state.liveRoot
-	hyPath := filepath.Join(liveRoot, "hysteria2", "server.yaml")
+	hyPath := filepath.Join(liveRoot, "hysteria2", "hy2.yaml")
+	caddyPath := filepath.Join(liveRoot, "caddy", "config.json")
 	if err := os.MkdirAll(filepath.Dir(hyPath), 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
 	if err := os.WriteFile(hyPath, []byte("config"), 0o600); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
+	if err := os.MkdirAll(filepath.Dir(caddyPath), 0o755); err != nil {
+		t.Fatalf("mkdir caddy: %v", err)
+	}
+	if err := os.WriteFile(caddyPath, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("write caddy config: %v", err)
+	}
 
 	ctx := NewManagementApplyContext(state)
-	results := ctx.reloadPromotedServicesLocked([]string{hyPath})
+	results := ctx.reloadPromotedServicesLocked([]string{hyPath, caddyPath})
 
 	if len(client.syncCaddyCertRequests) != 1 {
 		t.Fatalf("expected 1 sync request, got %+v", client.syncCaddyCertRequests)
 	}
-	want := privileged.SyncCaddyCertRequest{Domain: "vpn.example.com", OutDir: "/etc/veil/certs"}
+	want := privileged.SyncCaddyCertRequest{Domain: "hy2.example.com", OutDir: "/etc/veil/certs"}
 	if !reflect.DeepEqual(client.syncCaddyCertRequests[0], want) {
 		t.Fatalf("sync request = %+v, want %+v", client.syncCaddyCertRequests[0], want)
 	}
-	if len(results) == 0 || !results[0].Success {
-		t.Fatalf("expected successful cert sync result, got %+v", results)
+	// The cert sync result should come after the Caddy admin/reload result.
+	if len(results) < 2 || !results[0].Success {
+		t.Fatalf("expected successful Caddy action first, got %+v", results)
+	}
+	caddyFound := false
+	for _, r := range results {
+		if r.Name == unitCaddy {
+			caddyFound = true
+			break
+		}
+	}
+	if !caddyFound {
+		t.Fatalf("expected Caddy service action in results, got %+v", results)
 	}
 }
 
-func TestReloadPromotedServicesSkipsCertSyncWhenPanelAccessIsLocal(t *testing.T) {
+func TestReloadPromotedServicesSkipsCertSyncWithoutHysteria2Domain(t *testing.T) {
 	client := &recordingPrivilegedClient{}
 	applyRoot := t.TempDir()
 	statePath := filepath.Join(applyRoot, "state.json")
@@ -54,10 +80,16 @@ func TestReloadPromotedServicesSkipsCertSyncWhenPanelAccessIsLocal(t *testing.T)
 	}
 	state := newManagementState(ServerInfo{Mode: "dev", Privileged: client, StatePath: statePath, ApplyRoot: applyRoot})
 	state.settings.PanelAccess = "local"
-	state.settings.Domain = "vpn.example.com"
+	state.inbounds = []Inbound{{
+		Name:      "hy2",
+		Protocol:  "hysteria2",
+		Transport: "udp",
+		Port:      443,
+		Enabled:   true,
+	}}
 
 	liveRoot := state.liveRoot
-	hyPath := filepath.Join(liveRoot, "hysteria2", "server.yaml")
+	hyPath := filepath.Join(liveRoot, "hysteria2", "hy2.yaml")
 	if err := os.MkdirAll(filepath.Dir(hyPath), 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
@@ -69,6 +101,6 @@ func TestReloadPromotedServicesSkipsCertSyncWhenPanelAccessIsLocal(t *testing.T)
 	_ = ctx.reloadPromotedServicesLocked([]string{hyPath})
 
 	if len(client.syncCaddyCertRequests) != 0 {
-		t.Fatalf("expected no sync requests for local access, got %+v", client.syncCaddyCertRequests)
+		t.Fatalf("expected no sync requests without hysteria2 domain, got %+v", client.syncCaddyCertRequests)
 	}
 }

--- a/internal/api/management_apply_context_more_test.go
+++ b/internal/api/management_apply_context_more_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mikkelchokolate/Veil/internal/privileged"
 )
 
-func TestSyncCaddyCert(t *testing.T) {
+func TestSyncCaddyCertForHysteria2(t *testing.T) {
 	client := &recordingPrivilegedClient{}
 	state := newManagementState(ServerInfo{
 		Mode:       "dev",
@@ -17,14 +17,14 @@ func TestSyncCaddyCert(t *testing.T) {
 		Privileged: client,
 	})
 	ctx := NewManagementApplyContext(state)
-	result := ctx.syncCaddyCert()
+	result := ctx.syncCaddyCertForHysteria2("vpn.example.com")
 	if !result.Success {
 		t.Fatalf("expected success, got %+v", result)
 	}
 
 	stateNoPrivileged := newManagementState(ServerInfo{Mode: "dev", Domain: "vpn.example.com", RequirePrivilegedHelper: true})
 	ctx = NewManagementApplyContext(stateNoPrivileged)
-	result = ctx.syncCaddyCert()
+	result = ctx.syncCaddyCertForHysteria2("vpn.example.com")
 	if result.Success || result.Error != "privileged helper is unavailable" {
 		t.Fatalf("expected unavailable error, got %+v", result)
 	}
@@ -79,15 +79,16 @@ func TestWarpUnitActiveLocked(t *testing.T) {
 	}
 }
 
-func TestCaddyCertSyncNeeded(t *testing.T) {
+func TestHysteria2ConfigReloadNeeded(t *testing.T) {
 	root := t.TempDir()
 	state := newManagementState(ServerInfo{Mode: "dev", ApplyRoot: root, LiveRoot: filepath.Join(root, "live")})
+	state.inbounds = []Inbound{{Name: "h", Protocol: "hysteria2", Transport: "udp", Port: 443, Enabled: true}}
 	ctx := NewManagementApplyContext(state)
-	liveFiles := []string{filepath.Join(root, "live", "hysteria2", "server.yaml")}
-	if !ctx.caddyCertSyncNeeded(liveFiles) {
+	liveFiles := []string{filepath.Join(root, "live", "hysteria2", "h.yaml")}
+	if !ctx.hysteria2ConfigReloadNeeded(liveFiles) {
 		t.Fatal("expected reload needed for hysteria2 live file")
 	}
-	if ctx.caddyCertSyncNeeded([]string{filepath.Join(root, "live", "caddy", "panel.Caddyfile")}) {
+	if ctx.hysteria2ConfigReloadNeeded([]string{filepath.Join(root, "live", "caddy", "config.json")}) {
 		t.Fatal("expected no reload for caddy file")
 	}
 }

--- a/internal/api/management_apply_context_panel_caddy_test.go
+++ b/internal/api/management_apply_context_panel_caddy_test.go
@@ -9,6 +9,10 @@ import (
 )
 
 func TestReloadPromotedServicesReloadsPanelCaddyWithoutNaiveInbound(t *testing.T) {
+	oldCaddyLoader := caddyAdminLoader
+	defer func() { caddyAdminLoader = oldCaddyLoader }()
+	caddyAdminLoader = func(_ []byte) error { return nil }
+
 	state := newManagementState(ServerInfo{Version: "test", Mode: "dev"})
 	state.applyRoot = t.TempDir()
 	state.liveRoot = filepath.Join(state.applyRoot, "live")

--- a/internal/api/management_apply_context_panel_caddy_test.go
+++ b/internal/api/management_apply_context_panel_caddy_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -13,25 +14,33 @@ func TestReloadPromotedServicesReloadsPanelCaddyWithoutNaiveInbound(t *testing.T
 	state.liveRoot = filepath.Join(state.applyRoot, "live")
 	state.settings.PanelAccess = "caddy"
 	state.settings.PanelListen = "127.0.0.1:2096"
+	state.settings.PanelDomain = "panel.example.com"
+	state.settings.PanelEmail = "admin@example.com"
 	state.settings.WebBasePath = "/panel/"
-	state.settings.Domain = "panel.example.com"
-	state.settings.Email = "admin@example.com"
 	state.inbounds = []Inbound{{Name: "mieru-tcp", Protocol: "mieru", Transport: "tcp", Port: 8443, Enabled: true}}
 	client := &recordingPrivilegedClient{}
 	state.privileged = client
 	state.privilegedLocal = false
 
+	caddyPath := filepath.Join(state.liveRoot, "caddy", "config.json")
+	if err := os.MkdirAll(filepath.Dir(caddyPath), 0o755); err != nil {
+		t.Fatalf("mkdir caddy: %v", err)
+	}
+	if err := os.WriteFile(caddyPath, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("write caddy config: %v", err)
+	}
+
 	ctx := NewManagementApplyContext(state)
-	results := ctx.reloadPromotedServicesLocked([]string{filepath.Join(state.liveRoot, "caddy", "panel.Caddyfile")})
+	results := ctx.reloadPromotedServicesLocked([]string{caddyPath})
 	found := false
 	for _, r := range results {
-		if r.Name == "veil-caddy@panel.service" {
+		if r.Name == unitCaddy {
 			found = true
 			if !r.Success {
 				t.Fatalf("expected success for panel caddy reload, got %+v", r)
 			}
-			if len(r.Command) < 2 || r.Command[1] != string(privileged.ServiceActionReload) {
-				t.Fatalf("expected reload action, got %+v", r)
+			if len(r.Command) < 2 || (r.Command[1] != string(privileged.ServiceActionReload) && r.Command[1] != "admin") {
+				t.Fatalf("expected reload or admin load action, got %+v", r)
 			}
 		}
 	}

--- a/internal/api/management_apply_context_panel_caddy_test.go
+++ b/internal/api/management_apply_context_panel_caddy_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -50,5 +51,47 @@ func TestReloadPromotedServicesReloadsPanelCaddyWithoutNaiveInbound(t *testing.T
 	}
 	if !found {
 		t.Fatalf("expected panel caddy reload action in results, got %+v", results)
+	}
+}
+
+func TestReloadPromotedServicesTreatsSuccessfulCaddyFallbackAsSuccess(t *testing.T) {
+	oldCaddyLoader := caddyAdminLoader
+	defer func() { caddyAdminLoader = oldCaddyLoader }()
+	caddyAdminLoader = func(_ []byte) error { return errors.New("admin unavailable") }
+
+	state := newManagementState(ServerInfo{Version: "test", Mode: "dev"})
+	state.applyRoot = t.TempDir()
+	state.liveRoot = filepath.Join(state.applyRoot, "live")
+	state.settings.PanelAccess = "caddy"
+	state.settings.PanelListen = "127.0.0.1:2096"
+	state.settings.PanelDomain = "panel.example.com"
+	state.settings.PanelEmail = "admin@example.com"
+	client := &recordingPrivilegedClient{}
+	state.privileged = client
+	state.privilegedLocal = false
+
+	caddyPath := filepath.Join(state.liveRoot, "caddy", "config.json")
+	if err := os.MkdirAll(filepath.Dir(caddyPath), 0o755); err != nil {
+		t.Fatalf("mkdir caddy: %v", err)
+	}
+	if err := os.WriteFile(caddyPath, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("write caddy config: %v", err)
+	}
+
+	results := NewManagementApplyContext(state).reloadPromotedServicesLocked([]string{caddyPath})
+	caddyResults := 0
+	for _, result := range results {
+		if !result.Success {
+			t.Fatalf("successful systemd fallback must supersede Admin API miss: %+v", results)
+		}
+		if result.Name == unitCaddy {
+			caddyResults++
+		}
+	}
+	if caddyResults != 1 {
+		t.Fatalf("expected one successful Caddy result, got %+v", results)
+	}
+	if len(client.serviceActions) != 1 || client.serviceActions[0].Unit != unitCaddy || client.serviceActions[0].Action != privileged.ServiceActionReload {
+		t.Fatalf("expected one Caddy reload fallback, got %+v", client.serviceActions)
 	}
 }

--- a/internal/api/management_apply_context_test.go
+++ b/internal/api/management_apply_context_test.go
@@ -198,9 +198,79 @@ func TestRollbackPromotedConfigsDoesNotRestartNewlyAddedInbound(t *testing.T) {
 		t.Fatalf("expected no rollback files for newly added inbound, got %+v", rollbackFiles)
 	}
 	for _, action := range rollbackActions {
-		if strings.Contains(action.Name, "hysteria2@edge") {
-			t.Fatalf("rollback should not restart a newly added inbound that was removed, got %+v", rollbackActions)
+		if strings.Contains(action.Name, "hysteria2@edge") && action.Success {
+			// A stop/disable of the removed unit is correct; a start is not.
+			cmd := strings.Join(action.Command, " ")
+			if strings.Contains(cmd, "start") || strings.Contains(cmd, "enable") {
+				t.Fatalf("rollback should not restart a newly added inbound that was removed, got %+v", rollbackActions)
+			}
 		}
+	}
+}
+
+// TestRollbackStopsUnitWhoseConfigWasNewlyAdded covers the health-failure
+// rollback path: a brand-new inbound was promoted and started, a later health
+// check failed, and restore removed its config (no previous version existed).
+// The rollback must stop+disable that unit rather than leaving it running
+// against a now-deleted config.
+func TestRollbackStopsUnitWhoseConfigWasNewlyAdded(t *testing.T) {
+	root := t.TempDir()
+	liveRoot := filepath.Join(root, "live")
+	livePath := filepath.Join(liveRoot, "hysteria2", "edge.yaml")
+	client := &recordingPrivilegedClient{
+		statusActiveState: "inactive",
+		promoteResult: privileged.PromoteResult{
+			BackupID:         "20260716T120000.000000000Z",
+			WrittenArtifacts: []string{"hysteria2/edge.yaml"},
+		},
+	}
+	state := newManagementState(ServerInfo{Mode: "dev", ApplyRoot: root, LiveRoot: liveRoot, Privileged: client})
+	state.inbounds = []Inbound{{Name: "edge", Protocol: "hysteria2", Transport: "udp", Port: 443, Enabled: true}}
+	ctx := NewManagementApplyContext(state)
+
+	// Records mirror what promoteStagedConfigsLocked produced: the artifact was
+	// written live (so it is in liveFiles), and it had no previous version, so
+	// the restore below will NOT return it in WrittenArtifacts.
+	records := []livePromotionRecord{{
+		ArtifactID: "hysteria2/edge.yaml",
+		BackupID:   "20260716T120000.000000000Z",
+		LivePath:   livePath,
+	}}
+	liveFiles := []string{livePath}
+
+	// Restore returns nothing: the new config had no previous version to
+	// restore, so the helper deleted it.
+	client.promoteResult = privileged.PromoteResult{
+		BackupID:         "20260716T120000.000000000Z",
+		WrittenArtifacts: []string{},
+	}
+
+	_, _ = ctx.rollbackPromotedConfigsLocked(records, liveFiles)
+
+	var got []string
+	for _, a := range client.serviceActions {
+		got = append(got, a.Unit+":"+string(a.Action))
+	}
+	// The unit must be stopped and disabled, and never started/enabled.
+	stopped, disabled, startedOrEnabled := false, false, false
+	for _, a := range client.serviceActions {
+		if a.Unit != "veil-hysteria2@edge.service" {
+			continue
+		}
+		switch a.Action {
+		case privileged.ServiceActionStop:
+			stopped = true
+		case privileged.ServiceActionDisable:
+			disabled = true
+		case privileged.ServiceActionStart, privileged.ServiceActionEnable:
+			startedOrEnabled = true
+		}
+	}
+	if startedOrEnabled {
+		t.Fatalf("rollback must not start/enable a removed new inbound, actions=%v", got)
+	}
+	if !stopped || !disabled {
+		t.Fatalf("rollback must stop+disable the removed new inbound's unit, actions=%v", got)
 	}
 }
 

--- a/internal/api/management_apply_context_test.go
+++ b/internal/api/management_apply_context_test.go
@@ -75,7 +75,7 @@ func TestCheckServiceHealthUsesCurrentStateRuntimeCatalog(t *testing.T) {
 	}
 	t.Cleanup(func() { serviceHealthChecker = oldChecker })
 
-	results := ctx.checkServiceHealthLocked([]ServiceActionResult{{Name: "veil-hysteria2@edge.service", Success: true}})
+	results := ctx.checkServiceHealthLocked([]ServiceActionResult{{Name: "veil-hysteria2@edge.service", Command: []string{"systemctl", "restart", "veil-hysteria2@edge.service"}, Success: true}})
 	if len(results) != 1 || results[0].Name != "veil-hysteria2@edge.service" || !results[0].Healthy {
 		t.Fatalf("unexpected health results: %+v", results)
 	}

--- a/internal/api/management_apply_context_test.go
+++ b/internal/api/management_apply_context_test.go
@@ -325,4 +325,7 @@ func TestReloadPromotedServicesStopsOrphansAfterReloading(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("service actions = %v, want %v", got, want)
 	}
+	if len(state.orphanedUnits) != 0 {
+		t.Fatalf("successfully cleaned orphan units must not be retried: %v", state.orphanedUnits)
+	}
 }

--- a/internal/api/management_apply_context_test.go
+++ b/internal/api/management_apply_context_test.go
@@ -221,7 +221,7 @@ func TestPromoteStagedConfigsLockedNoOpWhenNothingToDo(t *testing.T) {
 	}
 }
 
-func TestReloadPromotedServicesStopsOrphansBeforeReloading(t *testing.T) {
+func TestReloadPromotedServicesStopsOrphansAfterReloading(t *testing.T) {
 	state := newManagementState(ServerInfo{Mode: "dev", ApplyRoot: t.TempDir()})
 	state.liveRoot = filepath.Join(state.applyRoot, "live")
 	state.inbounds = []Inbound{{Name: "new", Protocol: "hysteria2", Transport: "udp", Port: 443, Enabled: true}}
@@ -241,9 +241,9 @@ func TestReloadPromotedServicesStopsOrphansBeforeReloading(t *testing.T) {
 		got = append(got, a.Unit+":"+string(a.Action))
 	}
 	want := []string{
+		"veil-hysteria2@new.service:restart",
 		"veil-hysteria2@old.service:stop",
 		"veil-hysteria2@old.service:disable",
-		"veil-hysteria2@new.service:restart",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("service actions = %v, want %v", got, want)

--- a/internal/api/management_apply_context_test.go
+++ b/internal/api/management_apply_context_test.go
@@ -204,6 +204,45 @@ func TestRollbackPromotedConfigsDoesNotRestartNewlyAddedInbound(t *testing.T) {
 	}
 }
 
+func TestRollbackStopsSingletonBeforeRestoringLegacyCaddy(t *testing.T) {
+	root := t.TempDir()
+	liveRoot := filepath.Join(root, "live")
+	legacyPath := filepath.Join(liveRoot, "caddy", "legacy.Caddyfile")
+	client := &recordingPrivilegedClient{
+		statusActiveState: "inactive",
+		promoteResult: privileged.PromoteResult{
+			BackupID:         "20260716T120000.000000000Z",
+			WrittenArtifacts: []string{"caddy/legacy.Caddyfile"},
+		},
+	}
+	state := newManagementState(ServerInfo{Mode: "dev", ApplyRoot: root, LiveRoot: liveRoot, Privileged: client})
+	state.settings = Settings{PanelAccess: "caddy"}
+	ctx := NewManagementApplyContext(state)
+	records := []livePromotionRecord{{
+		LivePath:    legacyPath,
+		HadPrevious: true,
+		ArtifactID:  "caddy/legacy.Caddyfile",
+		BackupID:    "20260716T120000.000000000Z",
+	}}
+	newConfig := filepath.Join(liveRoot, "caddy", "config.json")
+
+	_, _ = ctx.rollbackPromotedConfigsLocked(records, []string{newConfig})
+
+	var got []string
+	for _, action := range client.serviceActions {
+		got = append(got, action.Unit+":"+string(action.Action))
+	}
+	want := []string{
+		"veil-caddy.service:stop",
+		"veil-caddy.service:disable",
+		"veil-caddy@legacy.service:enable",
+		"veil-caddy@legacy.service:start",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("rollback service actions = %v, want %v", got, want)
+	}
+}
+
 func TestPromoteStagedConfigsLockedNoOpWhenNothingToDo(t *testing.T) {
 	client := &recordingPrivilegedClient{statusActiveState: "inactive"}
 	state := newManagementState(ServerInfo{Mode: "dev", ApplyRoot: t.TempDir(), Privileged: client})
@@ -218,6 +257,44 @@ func TestPromoteStagedConfigsLockedNoOpWhenNothingToDo(t *testing.T) {
 	}
 	if len(liveFiles) != 0 || len(backupFiles) != 0 || len(records) != 0 {
 		t.Fatalf("expected empty result, got live=%+v backup=%+v records=%+v", liveFiles, backupFiles, records)
+	}
+}
+
+func TestReloadPromotedServicesStopsLegacyCaddyBeforeStartingSingleton(t *testing.T) {
+	state := newManagementState(ServerInfo{Mode: "dev", ApplyRoot: t.TempDir()})
+	state.liveRoot = filepath.Join(state.applyRoot, "live")
+	state.settings = Settings{PanelAccess: "caddy"}
+	state.orphanedUnits = []string{"veil-caddy@legacy.service"}
+	client := &recordingPrivilegedClient{statusActiveState: "inactive"}
+	state.privileged = client
+	state.privilegedLocal = false
+
+	caddyPath := filepath.Join(state.liveRoot, "caddy", "config.json")
+	if err := os.MkdirAll(filepath.Dir(caddyPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(caddyPath, []byte(`{}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	oldLoader := caddyAdminLoader
+	caddyAdminLoader = func([]byte) error { return errors.New("admin unavailable") }
+	defer func() { caddyAdminLoader = oldLoader }()
+
+	ctx := NewManagementApplyContext(state)
+	ctx.reloadPromotedServicesLocked([]string{caddyPath})
+
+	var got []string
+	for _, action := range client.serviceActions {
+		got = append(got, action.Unit+":"+string(action.Action))
+	}
+	want := []string{
+		"veil-caddy@legacy.service:stop",
+		"veil-caddy@legacy.service:disable",
+		"veil-caddy.service:reload",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("service actions = %v, want %v", got, want)
 	}
 }
 

--- a/internal/api/management_config_renderer_test.go
+++ b/internal/api/management_config_renderer_test.go
@@ -10,7 +10,7 @@ func TestManagementConfigRendererBuildsGeneratedConfigSet(t *testing.T) {
 	root := t.TempDir()
 	renderer := NewManagementConfigRenderer(ManagementConfigInput{
 		ApplyRoot: root,
-		Settings:  Settings{Domain: "vpn.example.com", Email: "admin@example.com", NaiveUsername: "veil", NaivePassword: "naive-pass", Hysteria2Password: "hy2-pass"},
+		Settings:  Settings{Domain: "vpn.example.com", DefaultAcmeEmail: "admin@example.com", NaiveUsername: "veil", NaivePassword: "naive-pass", Hysteria2Password: "hy2-pass"},
 		Inbounds:  []Inbound{{Name: "naive", Protocol: "naiveproxy", Transport: "tcp", Port: 443, Enabled: true}},
 	})
 
@@ -18,9 +18,9 @@ func TestManagementConfigRendererBuildsGeneratedConfigSet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
-	body := configs[filepath.Join(root, "generated", "caddy", "naive.Caddyfile")]
-	if !strings.Contains(body, "vpn.example.com") {
-		t.Fatalf("Caddyfile missing domain: %s", body)
+	body := configs[filepath.Join(root, "generated", "caddy", "config.json")]
+	if !strings.Contains(body, "vpn.example.com") || !strings.Contains(body, "forward_proxy") {
+		t.Fatalf("Caddy JSON missing domain or forward_proxy: %s", body)
 	}
 }
 

--- a/internal/api/management_inbound_routes.go
+++ b/internal/api/management_inbound_routes.go
@@ -49,7 +49,7 @@ func (s *managementState) handleInbounds(w http.ResponseWriter, r *http.Request)
 	_ = s.withMutation(func(mutation managementstate.Mutation) error {
 		switch r.Method {
 		case http.MethodGet:
-			writeJSON(w, mutation.Inbounds())
+			writeJSON(w, redactInboundList(mutation.Inbounds()))
 		case http.MethodPost:
 			var inbound Inbound
 			if !decodeJSONRequest(w, r, &inbound) {
@@ -79,7 +79,7 @@ func (s *managementState) handleInbounds(w http.ResponseWriter, r *http.Request)
 				return nil
 			}
 			s.autoApplyLocked(r)
-			writeJSONStatus(w, http.StatusCreated, created)
+			writeJSONStatus(w, http.StatusCreated, redactInbound(created))
 		default:
 			methodNotAllowed(w, http.MethodGet, http.MethodPost)
 		}
@@ -157,7 +157,7 @@ func (s *managementState) handleInboundByName(w http.ResponseWriter, r *http.Req
 		}
 		switch r.Method {
 		case http.MethodGet:
-			writeJSON(w, inbound)
+			writeJSON(w, redactInbound(inbound))
 		case http.MethodPut:
 			var update Inbound
 			if !decodeJSONRequest(w, r, &update) {
@@ -181,7 +181,7 @@ func (s *managementState) handleInboundByName(w http.ResponseWriter, r *http.Req
 				return nil
 			}
 			s.autoApplyLocked(r)
-			writeJSON(w, updated)
+			writeJSON(w, redactInbound(updated))
 		case http.MethodDelete:
 			err := mutation.DeleteInbound(name)
 			s.logUserAction(r, "delete_inbound", name, err == nil, "")

--- a/internal/api/management_operational_routes.go
+++ b/internal/api/management_operational_routes.go
@@ -123,8 +123,8 @@ func (s *managementState) handleApply(w http.ResponseWriter, r *http.Request) {
 		defer s.serviceActionMu.Unlock()
 	}
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	response, status, err := NewApplyWorkflow(NewManagementApplyContext(s)).RunLocked(req)
+	s.mu.Unlock()
 	if status == http.StatusBadRequest && len(response.Plan.Issues) > 0 {
 		status = http.StatusUnprocessableEntity
 	}

--- a/internal/api/management_routing_routes.go
+++ b/internal/api/management_routing_routes.go
@@ -125,6 +125,7 @@ func (s *managementState) handleRoutingPresetByName(w http.ResponseWriter, r *ht
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	prevPreset, prevSource, prevRules := s.routingPreset, s.routingSource, s.rules
 	state := routing.RoutingPresetState{ActivePreset: s.routingPreset, Source: s.routingSource, Rules: s.rules}
 	routing.NewRoutingPresetApplication(&state).Apply(preset)
 	if s.warp.Enabled {
@@ -142,6 +143,7 @@ func (s *managementState) handleRoutingPresetByName(w http.ResponseWriter, r *ht
 	err := s.saveLocked()
 	s.logUserAction(r, "apply_routing_preset", name, err == nil, "")
 	if err != nil {
+		s.routingPreset, s.routingSource, s.rules = prevPreset, prevSource, prevRules
 		writeError(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/internal/api/management_service_validation_test.go
+++ b/internal/api/management_service_validation_test.go
@@ -21,15 +21,9 @@ func TestLivePathForStagedConfig(t *testing.T) {
 	}{
 		// Known live paths
 		{
-			name:       "caddy panel Caddyfile",
-			stagedPath: "/tmp/veil-test/generated/caddy/panel.Caddyfile",
-			wantPath:   "/tmp/veil-test/live/caddy/panel.Caddyfile",
-			wantOK:     true,
-		},
-		{
-			name:       "caddy per-inbound Caddyfile",
-			stagedPath: "/tmp/veil-test/generated/caddy/edge.Caddyfile",
-			wantPath:   "/tmp/veil-test/live/caddy/edge.Caddyfile",
+			name:       "caddy config json",
+			stagedPath: "/tmp/veil-test/generated/caddy/config.json",
+			wantPath:   "/tmp/veil-test/live/caddy/config.json",
 			wantOK:     true,
 		},
 		{
@@ -47,7 +41,7 @@ func TestLivePathForStagedConfig(t *testing.T) {
 		// Unknown generated paths (valid prefix but not a known config)
 		{
 			name:       "legacy caddy Caddyfile",
-			stagedPath: "/tmp/veil-test/generated/caddy/Caddyfile",
+			stagedPath: "/tmp/veil-test/generated/caddy/panel.Caddyfile",
 			wantPath:   "",
 			wantOK:     false,
 		},
@@ -79,13 +73,13 @@ func TestLivePathForStagedConfig(t *testing.T) {
 		// Paths without the generated prefix (under apply root but not in generated/)
 		{
 			name:       "staged directory instead of generated",
-			stagedPath: "/tmp/veil-test/staged/caddy/Caddyfile",
+			stagedPath: "/tmp/veil-test/staged/caddy/config.json",
 			wantPath:   "",
 			wantOK:     false,
 		},
 		{
 			name:       "live directory instead of generated",
-			stagedPath: "/tmp/veil-test/live/caddy/Caddyfile",
+			stagedPath: "/tmp/veil-test/live/caddy/config.json",
 			wantPath:   "",
 			wantOK:     false,
 		},
@@ -98,7 +92,7 @@ func TestLivePathForStagedConfig(t *testing.T) {
 		},
 		{
 			name:       "just generated prefix no root",
-			stagedPath: "generated/caddy/Caddyfile",
+			stagedPath: "generated/caddy/config.json",
 			wantPath:   "",
 			wantOK:     false,
 		},
@@ -124,9 +118,9 @@ func TestLivePathForStagedConfigTrailingSlashRoot(t *testing.T) {
 		applyRoot: "/tmp/veil-test/",
 	}
 
-	gotPath, gotOK := state.livePathForStagedConfig("/tmp/veil-test/generated/caddy/panel.Caddyfile")
+	gotPath, gotOK := state.livePathForStagedConfig("/tmp/veil-test/generated/caddy/config.json")
 	gotPath = filepath.ToSlash(gotPath)
-	wantPath := "/tmp/veil-test/live/caddy/panel.Caddyfile"
+	wantPath := "/tmp/veil-test/live/caddy/config.json"
 	if gotPath != wantPath {
 		t.Fatalf("path = %q, want %q", gotPath, wantPath)
 	}

--- a/internal/api/management_settings_test.go
+++ b/internal/api/management_settings_test.go
@@ -12,6 +12,10 @@ import (
 )
 
 func TestHandleSettingsRejectsInvalidDomain(t *testing.T) {
+	origAutoApply := autoApplyAfterMutation
+	autoApplyAfterMutation = false
+	defer func() { autoApplyAfterMutation = origAutoApply }()
+
 	tmpDir := t.TempDir()
 	keyPath := filepath.Join(tmpDir, "state.key")
 	cipher := newTestCipher(t)
@@ -49,6 +53,10 @@ func TestHandleSettingsRejectsInvalidDomain(t *testing.T) {
 }
 
 func TestHandleSettingsRejectsInvalidEmail(t *testing.T) {
+	origAutoApply := autoApplyAfterMutation
+	autoApplyAfterMutation = false
+	defer func() { autoApplyAfterMutation = origAutoApply }()
+
 	tmpDir := t.TempDir()
 	keyPath := filepath.Join(tmpDir, "state.key")
 	cipher := newTestCipher(t)
@@ -84,6 +92,10 @@ func TestHandleSettingsRejectsInvalidEmail(t *testing.T) {
 }
 
 func TestHandleSettingsRejectsInvalidPanelListen(t *testing.T) {
+	origAutoApply := autoApplyAfterMutation
+	autoApplyAfterMutation = false
+	defer func() { autoApplyAfterMutation = origAutoApply }()
+
 	tmpDir := t.TempDir()
 	keyPath := filepath.Join(tmpDir, "state.key")
 	cipher := newTestCipher(t)
@@ -119,6 +131,10 @@ func TestHandleSettingsRejectsInvalidPanelListen(t *testing.T) {
 }
 
 func TestHandleSettingsRejectsFallbackRootPathTraversal(t *testing.T) {
+	origAutoApply := autoApplyAfterMutation
+	autoApplyAfterMutation = false
+	defer func() { autoApplyAfterMutation = origAutoApply }()
+
 	tmpDir := t.TempDir()
 
 	// Create a key file so newManagementState can load it

--- a/internal/api/management_state_validation_test.go
+++ b/internal/api/management_state_validation_test.go
@@ -24,7 +24,7 @@ func TestManagementStateValidationUsesStrictStateCodec(t *testing.T) {
 
 func TestManagementStateValidationReusesApplyPlanIntent(t *testing.T) {
 	body := []byte(`{
-		"settings":{"panelListen":"127.0.0.1:2096","panelAccess":"caddy","webBasePath":"/panel/","mode":"dev","domain":"panel.example.com","email":"admin@example.com"},
+		"settings":{"panelListen":"127.0.0.1:2096","panelAccess":"caddy","webBasePath":"/panel/","mode":"dev","domain":"panel.example.com","defaultAcmeEmail":"admin@example.com","panelDomain":"panel.example.com","panelEmail":"admin@example.com"},
 		"inbounds":[{"name":"mieru-tcp","protocol":"mieru","transport":"tcp","port":443,"enabled":true,"password":"secret"}],
 		"routingRules":[],
 		"warp":{"enabled":false,"endpoint":"engage.cloudflareclient.com:2408"}
@@ -34,7 +34,7 @@ func TestManagementStateValidationReusesApplyPlanIntent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ValidateBytes: %v", err)
 	}
-	if result.Valid || !containsString(result.Errors, "panel caddy access uses 443/tcp; choose another TCP port for inbound mieru-tcp") {
+	if result.Valid || !containsString(result.Errors, "tcp 0.0.0.0:443 is claimed by multiple owners") {
 		t.Fatalf("expected Apply plan intent error, got %+v", result)
 	}
 }

--- a/internal/api/mutation_auto_apply_test.go
+++ b/internal/api/mutation_auto_apply_test.go
@@ -50,6 +50,7 @@ func hasServiceActionFor(calls [][]string, unit string) bool {
 // seedInboundForAutoApplyTests creates a hysteria2 inbound so that subsequent
 // mutations have a concrete service action in the auto-apply plan.
 func seedInboundForAutoApplyTests(r http.Handler, calls *[][]string) {
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPut, "/api/settings", strings.NewReader(`{"panelListen":"127.0.0.1:2096","mode":"dev","domain":"hy.example.com"}`)))
 	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/api/inbounds", strings.NewReader(`{"name":"hy2","protocol":"hysteria2","transport":"udp","port":9443,"enabled":true}`)))
 	if calls != nil {
 		*calls = (*calls)[:0]
@@ -64,7 +65,7 @@ func TestSettingsUpdateTriggersAutoApply(t *testing.T) {
 	r, _ := NewRouter(ServerInfo{Version: "test", Mode: "dev", ApplyRoot: applyRoot})
 	seedInboundForAutoApplyTests(r, calls)
 
-	update := httptest.NewRequest(http.MethodPut, "/api/settings", strings.NewReader(`{"panelListen":"127.0.0.1:8080","mode":"dev","fallbackRoot":"/var/lib/veil/www"}`))
+	update := httptest.NewRequest(http.MethodPut, "/api/settings", strings.NewReader(`{"panelListen":"127.0.0.1:8080","mode":"dev","fallbackRoot":"/var/lib/veil/www","domain":"hy2.example.com"}`))
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, update)
 

--- a/internal/api/observability_visible_catalog_test.go
+++ b/internal/api/observability_visible_catalog_test.go
@@ -22,7 +22,7 @@ func TestVisibleRuntimeCatalogUsesActiveStateScope(t *testing.T) {
 	if !hasString(units, "veil.service") || !hasString(units, "veil-hysteria2@edge.service") {
 		t.Fatalf("visible catalog missing active-state units: %v", units)
 	}
-	for _, broadUnit := range []string{"veil-hysteria2@.service", "veil-caddy@panel.service", "veil-mieru.service", "veil-warp.service"} {
+	for _, broadUnit := range []string{"veil-hysteria2@.service", "veil-caddy.service", "veil-mieru.service", "veil-warp.service"} {
 		if hasString(units, broadUnit) {
 			t.Fatalf("visible catalog leaked broad fallback unit %s: %v", broadUnit, units)
 		}
@@ -104,19 +104,19 @@ func TestLogsEndpointReturnsResolvedUnit(t *testing.T) {
 
 	routes := LogRoutes{State: state}
 	w := httptest.NewRecorder()
-	routes.handleLogs(w, httptest.NewRequest(http.MethodGet, "/api/logs?unit=caddy-panel&lines=25", nil))
+	routes.handleLogs(w, httptest.NewRequest(http.MethodGet, "/api/logs?unit=caddy&lines=25", nil))
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("logs status=%d body=%s", w.Code, w.Body.String())
 	}
-	if len(client.journals) != 1 || client.journals[0] != (privileged.JournalRequest{Unit: "veil-caddy@panel.service", Lines: 25}) {
+	if len(client.journals) != 1 || client.journals[0] != (privileged.JournalRequest{Unit: "veil-caddy.service", Lines: 25}) {
 		t.Fatalf("journal requests=%+v", client.journals)
 	}
 	var result map[string]string
 	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
 		t.Fatalf("decode logs response: %v", err)
 	}
-	if result["unit"] != "veil-caddy@panel.service" {
+	if result["unit"] != "veil-caddy.service" {
 		t.Fatalf("logs response should expose resolved unit, got %+v", result)
 	}
 }

--- a/internal/api/panel_caddy_naive_apply_test.go
+++ b/internal/api/panel_caddy_naive_apply_test.go
@@ -22,14 +22,14 @@ func TestGeneratedConfigSetRendersPanelCaddyAccessWithoutNaiveInbound(t *testing
 	if err != nil {
 		t.Fatalf("BuildGeneratedConfigSet: %v", err)
 	}
-	caddyfile := configs[filepath.Join(root, "generated", "caddy", "panel.Caddyfile")]
-	for _, want := range []string{"panel.example.com", "issuer acme", "issuer internal", "handle /panel-secret/*", "reverse_proxy 127.0.0.1:2096"} {
-		if !strings.Contains(caddyfile, want) {
-			t.Fatalf("Panel Caddyfile missing %q:\n%s", want, caddyfile)
+	caddyJSON := configs[filepath.Join(root, "generated", "caddy", "config.json")]
+	for _, want := range []string{"panel.example.com", "reverse_proxy", "/panel-secret/", "127.0.0.1:2096"} {
+		if !strings.Contains(caddyJSON, want) {
+			t.Fatalf("Panel Caddy JSON missing %q:\n%s", want, caddyJSON)
 		}
 	}
-	if strings.Contains(caddyfile, "forward_proxy") {
-		t.Fatalf("Panel-only Caddyfile should not include NaiveProxy forward_proxy:\n%s", caddyfile)
+	if strings.Contains(caddyJSON, "forward_proxy") {
+		t.Fatalf("Panel-only Caddy JSON should not include NaiveProxy forward_proxy:\n%s", caddyJSON)
 	}
 }
 
@@ -53,10 +53,10 @@ func TestNaiveGeneratedConfigPreservesPanelCaddyAccessRoute(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildGeneratedConfigSet: %v", err)
 	}
-	caddyfile := configs[filepath.Join(root, "generated", "caddy", "naive.Caddyfile")]
-	for _, want := range []string{"forward_proxy", "basic_auth veil naive-secret", "handle /panel-secret/*", "reverse_proxy 127.0.0.1:2096"} {
-		if !strings.Contains(caddyfile, want) {
-			t.Fatalf("Caddyfile missing %q:\n%s", want, caddyfile)
+	caddyJSON := configs[filepath.Join(root, "generated", "caddy", "config.json")]
+	for _, want := range []string{"forward_proxy", "auth_credentials", "/panel-secret/", "reverse_proxy", "127.0.0.1:2096"} {
+		if !strings.Contains(caddyJSON, want) {
+			t.Fatalf("Caddy JSON missing %q:\n%s", want, caddyJSON)
 		}
 	}
 }
@@ -71,8 +71,8 @@ func TestNaiveGeneratedConfigWithoutPanelCaddyDoesNotExposePanelRoute(t *testing
 	if err != nil {
 		t.Fatalf("BuildGeneratedConfigSet: %v", err)
 	}
-	caddyfile := configs[filepath.Join(root, "generated", "caddy", "naive.Caddyfile")]
-	if strings.Contains(caddyfile, "reverse_proxy 127.0.0.1:2096") || strings.Contains(caddyfile, "handle /panel-secret/*") {
-		t.Fatalf("Caddyfile should not include Panel Caddy access route:\n%s", caddyfile)
+	caddyJSON := configs[filepath.Join(root, "generated", "caddy", "config.json")]
+	if strings.Contains(caddyJSON, "127.0.0.1:2096") || strings.Contains(caddyJSON, "/panel-secret/") {
+		t.Fatalf("Caddy JSON should not include Panel Caddy access route:\n%s", caddyJSON)
 	}
 }

--- a/internal/api/panel_caddy_naive_apply_test.go
+++ b/internal/api/panel_caddy_naive_apply_test.go
@@ -65,7 +65,7 @@ func TestNaiveGeneratedConfigWithoutPanelCaddyDoesNotExposePanelRoute(t *testing
 	root := t.TempDir()
 	configs, err := BuildGeneratedConfigSet(GeneratedConfigInput{
 		ApplyRoot: root,
-		Settings:  Settings{PanelListen: "127.0.0.1:2096", Mode: "server", Domain: "vpn.example.com", Email: "admin@example.com", NaiveUsername: "veil", NaivePassword: "naive-secret", FallbackRoot: "/var/lib/veil/www"},
+		Settings:  Settings{PanelListen: "127.0.0.1:2096", Mode: "server", Domain: "vpn.example.com", DefaultAcmeEmail: "admin@example.com", NaiveUsername: "veil", NaivePassword: "naive-secret", FallbackRoot: "/var/lib/veil/www"},
 		Inbounds:  []Inbound{{Name: "naive", Protocol: "naiveproxy", Transport: "tcp", Port: 443, Enabled: true}},
 	})
 	if err != nil {

--- a/internal/api/privileged_routes_test.go
+++ b/internal/api/privileged_routes_test.go
@@ -39,7 +39,7 @@ func (c *recordingPrivilegedClient) Promote(_ context.Context, request privilege
 
 func TestPrivilegedApplyUsesLogicalArtifactIDsAndOpaqueRollback(t *testing.T) {
 	root := t.TempDir()
-	staged := filepath.Join(root, "generated", "caddy", "edge.Caddyfile")
+	staged := filepath.Join(root, "generated", "caddy", "config.json")
 	if err := os.MkdirAll(filepath.Dir(staged), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -50,7 +50,7 @@ func TestPrivilegedApplyUsesLogicalArtifactIDsAndOpaqueRollback(t *testing.T) {
 		statusActiveState: "inactive", // WARP is not running in this caddy-only scenario
 		promoteResult: privileged.PromoteResult{
 			BackupID:         "20260605T120000.000000000Z",
-			WrittenArtifacts: []string{"caddy/edge.Caddyfile"},
+			WrittenArtifacts: []string{"caddy/config.json"},
 		},
 	}
 	state := newManagementState(ServerInfo{Mode: "dev", ApplyRoot: root, Privileged: client})
@@ -60,11 +60,11 @@ func TestPrivilegedApplyUsesLogicalArtifactIDsAndOpaqueRollback(t *testing.T) {
 		t.Fatalf("promote staged configs: %v", err)
 	}
 	if !reflect.DeepEqual(client.promotions, []privileged.PromoteRequest{{
-		ArtifactIDs: []string{"caddy/edge.Caddyfile"},
+		ArtifactIDs: []string{"caddy/config.json"},
 	}}) {
 		t.Fatalf("promotion requests=%+v", client.promotions)
 	}
-	if !reflect.DeepEqual(liveFiles, []string{filepath.Join(root, "live", "caddy", "edge.Caddyfile")}) {
+	if !reflect.DeepEqual(liveFiles, []string{filepath.Join(root, "live", "caddy", "config.json")}) {
 		t.Fatalf("live files=%+v", liveFiles)
 	}
 	if len(records) != 1 || records[0].BackupID != "20260605T120000.000000000Z" {
@@ -73,7 +73,7 @@ func TestPrivilegedApplyUsesLogicalArtifactIDsAndOpaqueRollback(t *testing.T) {
 
 	client.promoteResult = privileged.PromoteResult{
 		BackupID:         "20260605T120000.000000000Z",
-		WrittenArtifacts: []string{"caddy/edge.Caddyfile"},
+		WrittenArtifacts: []string{"caddy/config.json"},
 	}
 	rollbackFiles, _ := context.rollbackPromotedConfigsLocked(records, liveFiles)
 	if len(client.promotions) != 2 || client.promotions[1].RestoreBackupID != "20260605T120000.000000000Z" {
@@ -88,10 +88,10 @@ func TestPrivilegedApplyHealthChecksUseHelperStatus(t *testing.T) {
 	client := &recordingPrivilegedClient{}
 	state := newManagementState(ServerInfo{Mode: "dev", Privileged: client})
 	results := NewManagementApplyContext(state).checkServiceHealthLocked([]ServiceActionResult{{
-		Name: "veil-caddy@panel.service", Success: true,
+		Name: "veil-caddy.service", Success: true,
 	}})
 	if !reflect.DeepEqual(client.statusRequests, []privileged.ServiceStatusRequest{{
-		Units: []string{"veil-caddy@panel.service"},
+		Units: []string{"veil-caddy.service"},
 	}}) {
 		t.Fatalf("status requests=%+v", client.statusRequests)
 	}
@@ -190,7 +190,7 @@ func TestPrivilegedServiceStatusAndLogsUseManagedUnits(t *testing.T) {
 	client := &recordingPrivilegedClient{}
 	router, _ := NewRouter(ServerInfo{Version: "test", Mode: "dev", Privileged: client})
 
-	restart := httptest.NewRequest(http.MethodPost, "/api/services/caddy-panel/restart", strings.NewReader(`{"confirm":true}`))
+	restart := httptest.NewRequest(http.MethodPost, "/api/services/caddy/restart", strings.NewReader(`{"confirm":true}`))
 	restart.Header.Set("Content-Type", "application/json")
 	restartResponse := httptest.NewRecorder()
 	router.ServeHTTP(restartResponse, restart)
@@ -198,7 +198,7 @@ func TestPrivilegedServiceStatusAndLogsUseManagedUnits(t *testing.T) {
 		t.Fatalf("restart status=%d body=%s", restartResponse.Code, restartResponse.Body.String())
 	}
 	wantAction := privileged.ServiceActionRequest{
-		Unit: "veil-caddy@panel.service", Action: privileged.ServiceActionRestart,
+		Unit: "veil-caddy.service", Action: privileged.ServiceActionRestart,
 	}
 	if !reflect.DeepEqual(client.serviceActions, []privileged.ServiceActionRequest{wantAction}) {
 		t.Fatalf("service actions=%+v", client.serviceActions)
@@ -216,12 +216,12 @@ func TestPrivilegedServiceStatusAndLogsUseManagedUnits(t *testing.T) {
 	}
 
 	logResponse := httptest.NewRecorder()
-	router.ServeHTTP(logResponse, httptest.NewRequest(http.MethodGet, "/api/logs?unit=caddy-panel&lines=500", nil))
+	router.ServeHTTP(logResponse, httptest.NewRequest(http.MethodGet, "/api/logs?unit=caddy&lines=500", nil))
 	if logResponse.Code != http.StatusOK {
 		t.Fatalf("logs status=%d body=%s", logResponse.Code, logResponse.Body.String())
 	}
 	if !reflect.DeepEqual(client.journals, []privileged.JournalRequest{{
-		Unit: "veil-caddy@panel.service", Lines: 500,
+		Unit: "veil-caddy.service", Lines: 500,
 	}}) {
 		t.Fatalf("journal requests=%+v", client.journals)
 	}

--- a/internal/api/privileged_routes_test.go
+++ b/internal/api/privileged_routes_test.go
@@ -88,7 +88,7 @@ func TestPrivilegedApplyHealthChecksUseHelperStatus(t *testing.T) {
 	client := &recordingPrivilegedClient{}
 	state := newManagementState(ServerInfo{Mode: "dev", Privileged: client})
 	results := NewManagementApplyContext(state).checkServiceHealthLocked([]ServiceActionResult{{
-		Name: "veil-caddy.service", Success: true,
+		Name: "veil-caddy.service", Command: []string{"systemctl", "reload", "veil-caddy.service"}, Success: true,
 	}})
 	if !reflect.DeepEqual(client.statusRequests, []privileged.ServiceStatusRequest{{
 		Units: []string{"veil-caddy.service"},
@@ -96,6 +96,24 @@ func TestPrivilegedApplyHealthChecksUseHelperStatus(t *testing.T) {
 		t.Fatalf("status requests=%+v", client.statusRequests)
 	}
 	if len(results) != 1 || !results[0].Healthy {
+		t.Fatalf("health results=%+v", results)
+	}
+}
+
+func TestPrivilegedApplyHealthChecksIgnoreStoppedOrphans(t *testing.T) {
+	client := &recordingPrivilegedClient{}
+	state := newManagementState(ServerInfo{Mode: "dev", Privileged: client})
+	results := NewManagementApplyContext(state).checkServiceHealthLocked([]ServiceActionResult{
+		{Name: "veil-hysteria2@new.service", Command: []string{"systemctl", "restart", "veil-hysteria2@new.service"}, Success: true},
+		{Name: "veil-hysteria2@old.service", Command: []string{"systemctl", "stop", "veil-hysteria2@old.service"}, Success: true},
+		{Name: "veil-hysteria2@old.service", Command: []string{"systemctl", "disable", "veil-hysteria2@old.service"}, Success: true},
+	})
+	if !reflect.DeepEqual(client.statusRequests, []privileged.ServiceStatusRequest{{
+		Units: []string{"veil-hysteria2@new.service"},
+	}}) {
+		t.Fatalf("status requests=%+v", client.statusRequests)
+	}
+	if len(results) != 1 || results[0].Name != "veil-hysteria2@new.service" || !results[0].Healthy {
 		t.Fatalf("health results=%+v", results)
 	}
 }

--- a/internal/api/profile_preview_routes.go
+++ b/internal/api/profile_preview_routes.go
@@ -18,7 +18,7 @@ type RURecommendedPreviewResponse struct {
 	Email       string `json:"email"`
 	PanelAccess string `json:"panelAccess"`
 	PanelURL    string `json:"panelUrl,omitempty"`
-	Caddyfile   string `json:"caddyfile,omitempty"`
+	CaddyJSON   string `json:"caddyJSON,omitempty"`
 }
 
 type ProfilePreviewRoutes struct{}
@@ -56,7 +56,7 @@ func (ProfilePreviewRoutes) handleRURecommendedPreview(w http.ResponseWriter, r 
 		Email:       profile.Email,
 		PanelAccess: req.PanelAccess,
 		PanelURL:    panelURL,
-		Caddyfile:   redactProfileSecrets(profile, profile.Caddyfile),
+		CaddyJSON:   redactProfileSecrets(profile, profile.CaddyJSON),
 	})
 }
 

--- a/internal/api/promoted_service_reload_test.go
+++ b/internal/api/promoted_service_reload_test.go
@@ -16,16 +16,16 @@ func TestPromotedServiceReloaderRunsExpectedReloads(t *testing.T) {
 	})
 
 	results := reloader.Reload([]string{
-		filepath.Join(root, "live", "caddy", "panel.Caddyfile"),
+		filepath.Join(root, "live", "caddy", "config.json"),
 		filepath.Join(root, "live", "hysteria2", "server.yaml"),
 	})
 	if len(results) != 2 || len(commands) != 2 {
 		t.Fatalf("results=%+v commands=%+v", results, commands)
 	}
-	if commands[0][2] != "veil-caddy@panel.service" || commands[1][2] != "veil-hysteria2@.service" {
+	if commands[0][2] != "veil-hysteria2@.service" || commands[1][2] != "veil-caddy.service" {
 		t.Fatalf("commands = %+v", commands)
 	}
-	if results[0].Name != "veil-caddy@panel.service" || results[1].Name != "veil-hysteria2@.service" {
+	if results[0].Name != "veil-hysteria2@.service" || results[1].Name != "veil-caddy.service" {
 		t.Fatalf("result names = %+v", results)
 	}
 }

--- a/internal/api/router_client_links_test.go
+++ b/internal/api/router_client_links_test.go
@@ -63,7 +63,7 @@ func TestClientLinksEndpointBuildsEnabledProxyLinks(t *testing.T) {
 	for _, link := range response.Links {
 		links[link.Name] = link
 	}
-	if links["naive"].Protocol != "naiveproxy" || links["naive"].Transport != "tcp" || links["naive"].Port != 443 || links["naive"].URI != "naive+https://veil:naive-secret@vpn.example.com:443" {
+	if links["naive"].Protocol != "naiveproxy" || links["naive"].Transport != "tcp" || links["naive"].Port != 443 || links["naive"].URI != "https://veil:naive-secret@vpn.example.com" {
 		t.Fatalf("unexpected naive link: %+v", links["naive"])
 	}
 	if links["hysteria2"].Protocol != "hysteria2" || links["hysteria2"].Transport != "udp" || links["hysteria2"].Port != 443 || !strings.HasPrefix(links["hysteria2"].URI, "hysteria2://hy2-secret@vpn.example.com:443/") || !strings.Contains(links["hysteria2"].URI, "sni=vpn.example.com") {
@@ -160,7 +160,7 @@ func TestClientLinksHysteria2InsecureFlag(t *testing.T) {
 	r, _ := NewRouter(ServerInfo{Version: "test", Mode: "dev", StatePath: statePath})
 
 	// Enable insecure mode globally.
-	body := strings.NewReader(`{"panelListen":"127.0.0.1:2096","mode":"dev","domain":"vpn.example.com","email":"admin@example.com","naiveUsername":"veil","naivePassword":"naive-secret","hysteria2Password":"hy2-secret","hysteria2Insecure":true}`)
+	body := strings.NewReader(`{"panelListen":"127.0.0.1:2096","mode":"dev","domain":"vpn.example.com","defaultAcmeEmail":"admin@example.com","naiveUsername":"veil","naivePassword":"naive-secret","hysteria2Password":"hy2-secret","hysteria2Insecure":true}`)
 	req := httptest.NewRequest(http.MethodPut, "/api/settings", body)
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()

--- a/internal/api/router_core_test.go
+++ b/internal/api/router_core_test.go
@@ -213,7 +213,7 @@ func TestStatusEndpointIncludesRuntimeServiceStates(t *testing.T) {
 		switch unit {
 		case "veil.service":
 			return ServiceRuntimeStatus{Unit: unit, LoadState: "loaded", ActiveState: "active", SubState: "running"}
-		case "veil-caddy@panel.service":
+		case "veil-caddy.service":
 			return ServiceRuntimeStatus{Unit: unit, LoadState: "loaded", ActiveState: "inactive", SubState: "dead"}
 		default:
 			return ServiceRuntimeStatus{Unit: unit, LoadState: "not-found", ActiveState: "unknown", SubState: "unknown", Error: "unit not found"}
@@ -221,7 +221,13 @@ func TestStatusEndpointIncludesRuntimeServiceStates(t *testing.T) {
 	}
 	t.Cleanup(func() { serviceStatusReader = old })
 
-	r, _ := NewRouter(ServerInfo{Version: "test", Mode: "dev"})
+	stateDir := t.TempDir()
+	statePath := filepath.Join(stateDir, "state.json")
+	stateBody := []byte(`{"schemaVersion":4,"setup":{"completed":false},"settings":{"panelListen":"127.0.0.1:2096","panelAccess":"caddy","webBasePath":"/panel/","mode":"dev","domain":"panel.example.com","email":"admin@example.com"},"inbounds":[{"name":"edge","protocol":"hysteria2","transport":"udp","port":443,"enabled":true}],"routingRules":[],"routingPreset":"","routingSource":{"repository":"","files":null},"warp":{"enabled":false,"endpoint":"engage.cloudflareclient.com:2408"},"users":[]}`)
+	if err := os.WriteFile(statePath, stateBody, 0o600); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	r, _ := NewRouter(ServerInfo{Version: "test", Mode: "dev", StatePath: statePath, KeyPath: filepath.Join(stateDir, "state.key")})
 	req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
 	w := httptest.NewRecorder()
 
@@ -253,11 +259,11 @@ func TestStatusEndpointIncludesRuntimeServiceStates(t *testing.T) {
 	if services["veil"].Unit != "veil.service" || services["veil"].ActiveState != "active" || services["veil"].SubState != "running" {
 		t.Fatalf("veil runtime status not included: %+v", services["veil"])
 	}
-	if services["caddy-panel"].Unit != "veil-caddy@panel.service" || services["caddy-panel"].ActiveState != "inactive" || services["caddy-panel"].SubState != "dead" {
-		t.Fatalf("naive/caddy runtime status not included: %+v", services["caddy-panel"])
+	if services["caddy"].Unit != "veil-caddy.service" || services["caddy"].ActiveState != "inactive" || services["caddy"].SubState != "dead" {
+		t.Fatalf("caddy runtime status not included: %+v", services["caddy"])
 	}
-	if services["hysteria2"].Unit != "veil-hysteria2@.service" || services["hysteria2"].ActiveState != "unknown" || services["hysteria2"].Error == "" {
-		t.Fatalf("hysteria2 runtime status error not included: %+v", services["hysteria2"])
+	if services["hysteria2-edge"].Unit != "veil-hysteria2@edge.service" || services["hysteria2-edge"].ActiveState != "unknown" || services["hysteria2-edge"].Error == "" {
+		t.Fatalf("hysteria2 runtime status error not included: %+v", services["hysteria2-edge"])
 	}
 }
 

--- a/internal/api/router_management_apply_json_test.go
+++ b/internal/api/router_management_apply_json_test.go
@@ -120,7 +120,7 @@ func TestManagementApplyStagesRenderedConfigsFromManagementState(t *testing.T) {
 			"panelListen":"127.0.0.1:2096",
 			"mode":"dev",
 			"domain":"vpn.example.com",
-			"email":"admin@example.com",
+			"defaultAcmeEmail":"admin@example.com",
 			"naiveUsername":"veil",
 			"naivePassword":"naive-secret",
 			"hysteria2Password":"hy2-secret",
@@ -149,7 +149,7 @@ func TestManagementApplyStagesRenderedConfigsFromManagementState(t *testing.T) {
 	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	caddyPath := filepath.Join(applyRoot, "generated", "caddy", "naive.Caddyfile")
+	caddyPath := filepath.Join(applyRoot, "generated", "caddy", "config.json")
 	hy2Path := filepath.Join(applyRoot, "generated", "hysteria2", "hysteria2.yaml")
 	if !containsString(response.WrittenFiles, caddyPath) || !containsString(response.WrittenFiles, hy2Path) {
 		t.Fatalf("apply response missing rendered configs: %+v", response.WrittenFiles)
@@ -158,7 +158,7 @@ func TestManagementApplyStagesRenderedConfigsFromManagementState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read caddy config: %v", err)
 	}
-	if !strings.Contains(string(caddyBody), "vpn.example.com") || !strings.Contains(string(caddyBody), "basic_auth veil naive-secret") || !strings.Contains(string(caddyBody), "protocols h1 h2") {
+	if !strings.Contains(string(caddyBody), "vpn.example.com") || !strings.Contains(string(caddyBody), "forward_proxy") || !strings.Contains(string(caddyBody), "auth_credentials") || !strings.Contains(string(caddyBody), "h1") || !strings.Contains(string(caddyBody), "h2") {
 		t.Fatalf("unexpected caddy config: %s", string(caddyBody))
 	}
 	hy2Body, err := os.ReadFile(hy2Path)
@@ -238,7 +238,7 @@ func TestManagementApplyRunsFixedValidatorsForStagedRenderedConfigs(t *testing.T
 			"panelListen":"127.0.0.1:2096",
 			"mode":"dev",
 			"domain":"vpn.example.com",
-			"email":"admin@example.com",
+			"defaultAcmeEmail":"admin@example.com",
 			"naiveUsername":"veil",
 			"naivePassword":"naive-secret",
 			"hysteria2Password":"hy2-secret"
@@ -257,7 +257,7 @@ func TestManagementApplyRunsFixedValidatorsForStagedRenderedConfigs(t *testing.T
 	defer func() { stagedConfigValidator = old }()
 	stagedConfigValidator = func(paths []string) []ConfigValidationResult {
 		return []ConfigValidationResult{
-			{Name: "caddy", Config: filepath.Join(applyRoot, "generated", "caddy", "naive.Caddyfile"), Command: []string{"caddy", "validate", "--config", filepath.Join(applyRoot, "generated", "caddy", "naive.Caddyfile")}, Valid: true},
+			{Name: "caddy", Config: filepath.Join(applyRoot, "generated", "caddy", "config.json"), Command: []string{"caddy", "validate", "--config", filepath.Join(applyRoot, "generated", "caddy", "config.json")}, Valid: true},
 		}
 	}
 	r, _ := NewRouter(ServerInfo{Version: "test", Mode: "dev", StatePath: statePath, ApplyRoot: applyRoot})
@@ -287,7 +287,7 @@ func TestManagementApplyReportsValidatorFailureWithoutSystemdSideEffects(t *test
 			"panelListen":"127.0.0.1:2096",
 			"mode":"dev",
 			"domain":"vpn.example.com",
-			"email":"admin@example.com",
+			"defaultAcmeEmail":"admin@example.com",
 			"naiveUsername":"veil",
 			"naivePassword":"naive-secret"
 		},

--- a/internal/api/router_management_apply_live_services_test.go
+++ b/internal/api/router_management_apply_live_services_test.go
@@ -388,10 +388,11 @@ func TestManagementApplyServicesStopsOnReloadFailure(t *testing.T) {
 		t.Fatalf("decode response: %v", err)
 	}
 	// The Caddy admin API load fails and the systemctl reload fallback also fails,
-	// so the apply stops and rolls back. The local privileged helper probes is-active
-	// before each reload, adding two calls per reload attempt.
-	if response.ServicesApplied || !response.RolledBack || len(response.ServiceActions) != 2 || len(serviceCalls) != 4 {
-		t.Fatalf("expected failed caddy reloads followed by rollback reload: response=%+v calls=%+v", response, serviceCalls)
+	// so the apply stops and rolls back. Each forward/rollback attempt reports one
+	// terminal Caddy result with both errors. The local privileged helper probes
+	// is-active before each reload, adding two calls per reload attempt.
+	if response.ServicesApplied || !response.RolledBack || len(response.ServiceActions) != 1 || len(serviceCalls) != 4 {
+		t.Fatalf("expected failed caddy fallback followed by rollback reload: response=%+v calls=%+v", response, serviceCalls)
 	}
 }
 

--- a/internal/api/router_management_apply_live_services_test.go
+++ b/internal/api/router_management_apply_live_services_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -45,7 +46,7 @@ func TestManagementApplyLiveRequiresExplicitFlagAndKeepsStagedOnlyByDefault(t *t
 	if len(response.LiveFiles) != 0 || len(response.BackupFiles) != 0 {
 		t.Fatalf("staged-only apply should not report live files/backups: %+v", response)
 	}
-	if _, err := os.Stat(filepath.Join(applyRoot, "live", "caddy", "naive.Caddyfile")); !os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(applyRoot, "live", "caddy", "config.json")); !os.IsNotExist(err) {
 		t.Fatalf("staged-only apply should not write live caddy config, stat err: %v", err)
 	}
 }
@@ -56,7 +57,7 @@ func TestManagementApplyLivePromotesValidatedConfigsAndBacksUpExistingFiles(t *t
 		t.Fatalf("write state: %v", err)
 	}
 	applyRoot := t.TempDir()
-	existingCaddy := filepath.Join(applyRoot, "live", "caddy", "naive.Caddyfile")
+	existingCaddy := filepath.Join(applyRoot, "live", "caddy", "config.json")
 	if err := atomicfile.Write(existingCaddy, []byte("old caddy\n"), 0o600, 0o700); err != nil {
 		t.Fatalf("write existing live caddy: %v", err)
 	}
@@ -81,7 +82,7 @@ func TestManagementApplyLivePromotesValidatedConfigsAndBacksUpExistingFiles(t *t
 	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	liveCaddy := filepath.Join(applyRoot, "live", "caddy", "naive.Caddyfile")
+	liveCaddy := filepath.Join(applyRoot, "live", "caddy", "config.json")
 	liveHysteria := filepath.Join(applyRoot, "live", "hysteria2", "hysteria2.yaml")
 	if !response.LiveApplied || !containsString(response.LiveFiles, liveCaddy) || !containsString(response.LiveFiles, liveHysteria) {
 		t.Fatalf("expected live files in response: %+v", response)
@@ -100,7 +101,7 @@ func TestManagementApplyLivePromotesValidatedConfigsAndBacksUpExistingFiles(t *t
 	if err != nil {
 		t.Fatalf("read live caddy: %v", err)
 	}
-	if !strings.Contains(string(caddyBody), "vpn.example.com") || !strings.Contains(string(caddyBody), "basic_auth veil naive-secret") {
+	if !strings.Contains(string(caddyBody), "vpn.example.com") || !strings.Contains(string(caddyBody), "forward_proxy") || !strings.Contains(string(caddyBody), "auth_credentials") {
 		t.Fatalf("unexpected live caddy config: %s", string(caddyBody))
 	}
 	if _, err := os.Stat(liveHysteria); err != nil {
@@ -114,7 +115,7 @@ func TestManagementApplyLiveRejectsFailedValidationBeforeReplacingLiveFiles(t *t
 		t.Fatalf("write state: %v", err)
 	}
 	applyRoot := t.TempDir()
-	liveCaddy := filepath.Join(applyRoot, "live", "caddy", "naive.Caddyfile")
+	liveCaddy := filepath.Join(applyRoot, "live", "caddy", "config.json")
 	if err := atomicfile.Write(liveCaddy, []byte("old caddy\n"), 0o600, 0o700); err != nil {
 		t.Fatalf("write existing live caddy: %v", err)
 	}
@@ -315,6 +316,9 @@ func TestManagementApplyServicesRunsAllowlistedReloadsAfterLivePromotion(t *test
 	serviceHealthChecker = func(service string) ServiceHealthResult {
 		return ServiceHealthResult{Name: service, Command: []string{"systemctl", "is-active", "--quiet", service}, Healthy: true}
 	}
+	oldCaddyLoader := caddyAdminLoader
+	defer func() { caddyAdminLoader = oldCaddyLoader }()
+	caddyAdminLoader = func(_ []byte) error { return nil }
 	r, _ := NewRouter(ServerInfo{Version: "test", Mode: "dev", StatePath: statePath, ApplyRoot: applyRoot})
 	w := httptest.NewRecorder()
 
@@ -327,13 +331,15 @@ func TestManagementApplyServicesRunsAllowlistedReloadsAfterLivePromotion(t *test
 	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	expectedNaiveProbe := []string{"systemctl", "is-active", "veil-caddy@naive.service"}
-	expectedNaiveReload := []string{"systemctl", "reload", "veil-caddy@naive.service"}
+	expectedCaddyAdminLoad := []string{"caddy", "admin", "load"}
 	expectedHy2 := []string{"systemctl", "restart", "veil-hysteria2@hysteria2.service"}
-	if !response.ServicesApplied || len(response.ServiceActions) != 2 || len(serviceCalls) != 3 {
-		t.Fatalf("expected two service actions and three calls (is-active probe + reload + restart): response=%+v calls=%+v", response, serviceCalls)
+	if !response.ServicesApplied || len(response.ServiceActions) != 2 || len(serviceCalls) != 1 {
+		t.Fatalf("expected caddy admin load + hysteria2 restart and one systemctl call: response=%+v calls=%+v", response, serviceCalls)
 	}
-	if !stringSlicesEqual(serviceCalls[0], expectedNaiveProbe) || !stringSlicesEqual(serviceCalls[1], expectedNaiveReload) || !stringSlicesEqual(serviceCalls[2], expectedHy2) {
+	if !stringSlicesEqual(response.ServiceActions[0].Command, expectedCaddyAdminLoad) {
+		t.Fatalf("expected caddy admin load action: %+v", response.ServiceActions)
+	}
+	if !stringSlicesEqual(serviceCalls[0], expectedHy2) {
 		t.Fatalf("unexpected service calls: %+v", serviceCalls)
 	}
 	if !response.ServiceActions[0].Success || !response.ServiceActions[1].Success {
@@ -364,11 +370,11 @@ func TestManagementApplyServicesStopsOnReloadFailure(t *testing.T) {
 	serviceCalls := [][]string{}
 	serviceActionRunner = func(command []string) ServiceActionResult {
 		serviceCalls = append(serviceCalls, append([]string(nil), command...))
-		if len(command) >= 2 && command[0] == "systemctl" && command[1] == "is-active" {
-			return ServiceActionResult{Name: command[len(command)-1], Command: command, Success: true, Output: "active"}
-		}
 		return ServiceActionResult{Name: command[len(command)-1], Command: command, Success: false, Error: "reload failed"}
 	}
+	oldCaddyLoader := caddyAdminLoader
+	defer func() { caddyAdminLoader = oldCaddyLoader }()
+	caddyAdminLoader = func(_ []byte) error { return fmt.Errorf("caddy admin api unavailable") }
 	r, _ := NewRouter(ServerInfo{Version: "test", Mode: "dev", StatePath: statePath, ApplyRoot: t.TempDir()})
 	w := httptest.NewRecorder()
 
@@ -381,10 +387,11 @@ func TestManagementApplyServicesStopsOnReloadFailure(t *testing.T) {
 	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	// With the inactive-unit fallback, reload first probes is-active (success), then fails.
-	// Rollback repeats the same probe + reload sequence.
-	if response.ServicesApplied || !response.RolledBack || len(response.ServiceActions) != 1 || response.ServiceActions[0].Error != "reload failed" || len(serviceCalls) != 4 {
-		t.Fatalf("expected failed service action followed by rollback reload: response=%+v calls=%+v", response, serviceCalls)
+	// The Caddy admin API load fails and the systemctl reload fallback also fails,
+	// so the apply stops and rolls back. The local privileged helper probes is-active
+	// before each reload, adding two calls per reload attempt.
+	if response.ServicesApplied || !response.RolledBack || len(response.ServiceActions) != 2 || len(serviceCalls) != 4 {
+		t.Fatalf("expected failed caddy reloads followed by rollback reload: response=%+v calls=%+v", response, serviceCalls)
 	}
 }
 
@@ -412,6 +419,9 @@ func TestManagementApplyServicesChecksHealthAfterReload(t *testing.T) {
 		healthCalls = append(healthCalls, []string{"systemctl", "is-active", "--quiet", service})
 		return ServiceHealthResult{Name: service, Command: []string{"systemctl", "is-active", "--quiet", service}, Healthy: true}
 	}
+	oldCaddyLoader := caddyAdminLoader
+	defer func() { caddyAdminLoader = oldCaddyLoader }()
+	caddyAdminLoader = func(_ []byte) error { return nil }
 	r, _ := NewRouter(ServerInfo{Version: "test", Mode: "dev", StatePath: statePath, ApplyRoot: t.TempDir()})
 	w := httptest.NewRecorder()
 
@@ -427,7 +437,7 @@ func TestManagementApplyServicesChecksHealthAfterReload(t *testing.T) {
 	if len(response.HealthChecks) != 1 || !response.HealthChecks[0].Healthy || len(healthCalls) != 1 {
 		t.Fatalf("expected one successful health check: response=%+v calls=%+v", response.HealthChecks, healthCalls)
 	}
-	if !stringSlicesEqual(healthCalls[0], []string{"systemctl", "is-active", "--quiet", "veil-caddy@naive.service"}) {
+	if !stringSlicesEqual(healthCalls[0], []string{"systemctl", "is-active", "--quiet", "veil-caddy.service"}) {
 		t.Fatalf("unexpected health command: %+v", healthCalls)
 	}
 }
@@ -438,7 +448,7 @@ func TestManagementApplyServicesRollsBackLiveConfigOnHealthFailure(t *testing.T)
 		t.Fatalf("write state: %v", err)
 	}
 	applyRoot := t.TempDir()
-	liveCaddy := filepath.Join(applyRoot, "live", "caddy", "naive.Caddyfile")
+	liveCaddy := filepath.Join(applyRoot, "live", "caddy", "config.json")
 	if err := atomicfile.Write(liveCaddy, []byte("old caddy\n"), 0o600, 0o700); err != nil {
 		t.Fatalf("write existing live caddy: %v", err)
 	}
@@ -461,6 +471,9 @@ func TestManagementApplyServicesRollsBackLiveConfigOnHealthFailure(t *testing.T)
 	serviceHealthChecker = func(service string) ServiceHealthResult {
 		return ServiceHealthResult{Name: service, Command: []string{"systemctl", "is-active", "--quiet", service}, Healthy: false, Error: "service unhealthy"}
 	}
+	oldCaddyLoader := caddyAdminLoader
+	defer func() { caddyAdminLoader = oldCaddyLoader }()
+	caddyAdminLoader = func(_ []byte) error { return nil }
 	r, _ := NewRouter(ServerInfo{Version: "test", Mode: "dev", StatePath: statePath, ApplyRoot: applyRoot})
 	w := httptest.NewRecorder()
 
@@ -483,19 +496,8 @@ func TestManagementApplyServicesRollsBackLiveConfigOnHealthFailure(t *testing.T)
 	if string(body) != "old caddy\n" {
 		t.Fatalf("expected rollback to restore old live config, got %q", string(body))
 	}
-	expected := [][]string{
-		{"systemctl", "is-active", "veil-caddy@naive.service"},
-		{"systemctl", "reload", "veil-caddy@naive.service"},
-		{"systemctl", "is-active", "veil-caddy@naive.service"},
-		{"systemctl", "reload", "veil-caddy@naive.service"},
-	}
-	if len(serviceCalls) != len(expected) {
-		t.Fatalf("expected %d calls, got %d: %+v", len(expected), len(serviceCalls), serviceCalls)
-	}
-	for i := range expected {
-		if !stringSlicesEqual(serviceCalls[i], expected[i]) {
-			t.Fatalf("expected reload before and after rollback: %+v", serviceCalls)
-		}
+	if len(serviceCalls) != 0 {
+		t.Fatalf("expected no systemctl service calls when caddy admin api succeeds: %+v", serviceCalls)
 	}
 }
 
@@ -522,6 +524,9 @@ func TestManagementApplyWritesAuditHistoryForSuccessfulServiceApply(t *testing.T
 	serviceHealthChecker = func(service string) ServiceHealthResult {
 		return ServiceHealthResult{Name: service, Command: []string{"systemctl", "is-active", "--quiet", service}, Healthy: true}
 	}
+	oldCaddyLoader := caddyAdminLoader
+	defer func() { caddyAdminLoader = oldCaddyLoader }()
+	caddyAdminLoader = func(_ []byte) error { return nil }
 	r, _ := NewRouter(ServerInfo{Version: "test", Mode: "dev", StatePath: statePath, ApplyRoot: applyRoot})
 	w := httptest.NewRecorder()
 
@@ -560,7 +565,7 @@ func TestManagementApplyWritesAuditHistoryForRollback(t *testing.T) {
 		t.Fatalf("write state: %v", err)
 	}
 	applyRoot := t.TempDir()
-	liveCaddy := filepath.Join(applyRoot, "live", "caddy", "naive.Caddyfile")
+	liveCaddy := filepath.Join(applyRoot, "live", "caddy", "config.json")
 	if err := atomicfile.Write(liveCaddy, []byte("old caddy\n"), 0o600, 0o700); err != nil {
 		t.Fatalf("write live caddy: %v", err)
 	}
@@ -581,6 +586,9 @@ func TestManagementApplyWritesAuditHistoryForRollback(t *testing.T) {
 	serviceHealthChecker = func(service string) ServiceHealthResult {
 		return ServiceHealthResult{Name: service, Command: []string{"systemctl", "is-active", "--quiet", service}, Healthy: false, Error: "service unhealthy"}
 	}
+	oldCaddyLoader := caddyAdminLoader
+	defer func() { caddyAdminLoader = oldCaddyLoader }()
+	caddyAdminLoader = func(_ []byte) error { return nil }
 	r, _ := NewRouter(ServerInfo{Version: "test", Mode: "dev", StatePath: statePath, ApplyRoot: applyRoot})
 	w := httptest.NewRecorder()
 
@@ -610,7 +618,7 @@ func TestManagementApplyServicesCleansOrphanedInstances(t *testing.T) {
 	applyRoot := t.TempDir()
 
 	// Write the orphan config files to the live directories
-	orphanCaddy := filepath.Join(applyRoot, "live", "caddy", "orphan.Caddyfile")
+	orphanCaddy := filepath.Join(applyRoot, "live", "caddy", "orphan.json")
 	orphanHysteria2 := filepath.Join(applyRoot, "live", "hysteria2", "orphan.yaml")
 	if err := atomicfile.Write(orphanCaddy, []byte("caddy config"), 0o600, 0o700); err != nil {
 		t.Fatalf("write orphan caddy: %v", err)
@@ -622,10 +630,12 @@ func TestManagementApplyServicesCleansOrphanedInstances(t *testing.T) {
 	oldValidator := stagedConfigValidator
 	oldRunner := serviceActionRunner
 	oldHealth := serviceHealthChecker
+	oldCaddyLoader := caddyAdminLoader
 	defer func() {
 		stagedConfigValidator = oldValidator
 		serviceActionRunner = oldRunner
 		serviceHealthChecker = oldHealth
+		caddyAdminLoader = oldCaddyLoader
 	}()
 
 	stagedConfigValidator = func(paths []string) []ConfigValidationResult {
@@ -646,6 +656,8 @@ func TestManagementApplyServicesCleansOrphanedInstances(t *testing.T) {
 		return ServiceHealthResult{Name: service, Command: []string{"systemctl", "is-active", "--quiet", service}, Healthy: true}
 	}
 
+	caddyAdminLoader = func(_ []byte) error { return nil }
+
 	r, _ := NewRouter(ServerInfo{Version: "test", Mode: "dev", StatePath: statePath, ApplyRoot: applyRoot})
 	w := httptest.NewRecorder()
 
@@ -663,10 +675,10 @@ func TestManagementApplyServicesCleansOrphanedInstances(t *testing.T) {
 		t.Fatalf("orphan hysteria2 config should be deleted, stat err: %v", err)
 	}
 
-	// Verify the service actions (stop/disable for orphans)
+	// Verify the service actions (stop/disable for hysteria2 orphan only; caddy is
+	// now a single consolidated unit, so leftover caddy configs have no per-instance
+	// service to stop).
 	expectedStopDisableCalls := [][]string{
-		{"systemctl", "stop", "veil-caddy@orphan.service"},
-		{"systemctl", "disable", "veil-caddy@orphan.service"},
 		{"systemctl", "stop", "veil-hysteria2@orphan.service"},
 		{"systemctl", "disable", "veil-hysteria2@orphan.service"},
 	}
@@ -693,7 +705,7 @@ func TestManagementApplyServicesRestoresOrphanedInstancesOnRollback(t *testing.T
 	applyRoot := t.TempDir()
 
 	// Write the orphan config files to the live directories
-	orphanCaddy := filepath.Join(applyRoot, "live", "caddy", "orphan.Caddyfile")
+	orphanCaddy := filepath.Join(applyRoot, "live", "caddy", "orphan.json")
 	orphanHysteria2 := filepath.Join(applyRoot, "live", "hysteria2", "orphan.yaml")
 	if err := atomicfile.Write(orphanCaddy, []byte("caddy config"), 0o600, 0o700); err != nil {
 		t.Fatalf("write orphan caddy: %v", err)
@@ -705,10 +717,12 @@ func TestManagementApplyServicesRestoresOrphanedInstancesOnRollback(t *testing.T
 	oldValidator := stagedConfigValidator
 	oldRunner := serviceActionRunner
 	oldHealth := serviceHealthChecker
+	oldCaddyLoader := caddyAdminLoader
 	defer func() {
 		stagedConfigValidator = oldValidator
 		serviceActionRunner = oldRunner
 		serviceHealthChecker = oldHealth
+		caddyAdminLoader = oldCaddyLoader
 	}()
 
 	stagedConfigValidator = func(paths []string) []ConfigValidationResult {
@@ -730,6 +744,8 @@ func TestManagementApplyServicesRestoresOrphanedInstancesOnRollback(t *testing.T
 		return ServiceHealthResult{Name: service, Command: []string{"systemctl", "is-active", "--quiet", service}, Healthy: false, Error: "forced reload failure"}
 	}
 
+	caddyAdminLoader = func(_ []byte) error { return nil }
+
 	r, _ := NewRouter(ServerInfo{Version: "test", Mode: "dev", StatePath: statePath, ApplyRoot: applyRoot})
 	w := httptest.NewRecorder()
 
@@ -743,10 +759,9 @@ func TestManagementApplyServicesRestoresOrphanedInstancesOnRollback(t *testing.T
 	assertFileBody(t, orphanCaddy, "caddy config")
 	assertFileBody(t, orphanHysteria2, "hysteria2 config")
 
-	// Verify the service actions on rollback (enable/start for orphans)
+	// Verify the service actions on rollback (enable/start for hysteria2 orphan only;
+	// caddy is a single consolidated unit with no per-instance orphan service).
 	expectedEnableStartCalls := [][]string{
-		{"systemctl", "enable", "veil-caddy@orphan.service"},
-		{"systemctl", "start", "veil-caddy@orphan.service"},
 		{"systemctl", "enable", "veil-hysteria2@orphan.service"},
 		{"systemctl", "start", "veil-hysteria2@orphan.service"},
 	}

--- a/internal/api/router_management_apply_plan_test.go
+++ b/internal/api/router_management_apply_plan_test.go
@@ -33,7 +33,7 @@ func TestManagementApplyPlanValidatesAndReturnsStagedActions(t *testing.T) {
 	if len(response.Configs) != 0 {
 		t.Fatalf("fresh Panel without Inbounds should not plan generated proxy configs: %+v", response.Configs)
 	}
-	if !containsString(response.Actions, "validate management state") || containsString(response.Actions, "reload veil-caddy@panel.service") || containsString(response.Actions, "reload veil-hysteria2@.service") {
+	if !containsString(response.Actions, "validate management state") || containsString(response.Actions, "reload veil-caddy.service") || containsString(response.Actions, "reload veil-hysteria2@.service") {
 		t.Fatalf("expected only management validation action for fresh Panel: %+v", response.Actions)
 	}
 }
@@ -72,7 +72,7 @@ func TestManagementApplyPlanRejectsInvalidEnabledInbound(t *testing.T) {
 func TestManagementApplyPlanUsesEnabledInboundsToSelectProtocols(t *testing.T) {
 	statePath := filepath.Join(t.TempDir(), "state.json")
 	if err := os.WriteFile(statePath, []byte(`{
-		"settings":{"panelListen":"127.0.0.1:2096","mode":"dev","domain":"vpn.example.com","email":"admin@example.com","naiveUsername":"veil","naivePassword":"p","hysteria2Password":"hy2"},
+		"settings":{"panelListen":"127.0.0.1:2096","mode":"dev","domain":"vpn.example.com","defaultAcmeEmail":"admin@example.com","naiveUsername":"veil","naivePassword":"p","hysteria2Password":"hy2"},
 		"inbounds":[
 			{"name":"naive","protocol":"naiveproxy","transport":"tcp","port":443,"enabled":true},
 			{"name":"hysteria2","protocol":"hysteria2","transport":"udp","port":443,"enabled":true}
@@ -94,13 +94,13 @@ func TestManagementApplyPlanUsesEnabledInboundsToSelectProtocols(t *testing.T) {
 	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if !containsString(response.Configs, "/etc/veil/generated/caddy/naive.Caddyfile") || !containsString(response.Configs, "/etc/veil/generated/hysteria2/hysteria2.yaml") {
+	if !containsString(response.Configs, "/etc/veil/generated/caddy/config.json") || !containsString(response.Configs, "/etc/veil/generated/hysteria2/hysteria2.yaml") {
 		t.Fatalf("expected all enabled Inbound configs in apply plan: %+v", response.Configs)
 	}
 	if containsString(response.Configs, "/etc/veil/generated/caddy/panel.Caddyfile") || containsString(response.Configs, "/etc/veil/generated/hysteria2/server.yaml") {
 		t.Fatalf("apply plan should not target fallback configs for enabled inbounds: %+v", response.Configs)
 	}
-	if !containsString(response.Actions, "reload veil-caddy@naive.service") || !containsString(response.Actions, "restart veil-hysteria2@hysteria2.service") {
+	if !containsString(response.Actions, "reload veil-caddy.service") || !containsString(response.Actions, "restart veil-hysteria2@hysteria2.service") {
 		t.Fatalf("expected all enabled Inbound actions: %+v", response.Actions)
 	}
 	if containsString(response.Actions, "reload veil-caddy@.service") || containsString(response.Actions, "restart veil-hysteria2@.service") {
@@ -130,8 +130,8 @@ func TestManagementApplyPlanRejectsMissingRenderSettingsForEnabledInbound(t *tes
 	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if response.Valid || len(response.Errors) == 0 || !strings.Contains(strings.Join(response.Errors, ";"), "naive username and password are required") {
-		t.Fatalf("expected missing naive credentials validation error: %+v", response)
+	if response.Valid || len(response.Errors) == 0 || !strings.Contains(strings.Join(response.Errors, ";"), "naive inbound \"naive\" is missing") {
+		t.Fatalf("expected missing naive settings validation error: %+v", response)
 	}
 }
 

--- a/internal/api/router_management_apply_plan_test.go
+++ b/internal/api/router_management_apply_plan_test.go
@@ -54,8 +54,8 @@ func TestManagementApplyPlanRejectsInvalidEnabledInbound(t *testing.T) {
 
 	r.ServeHTTP(w, req)
 
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d: %s", w.Code, w.Body.String())
 	}
 	var response ApplyPlanResponse
 	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
@@ -64,8 +64,23 @@ func TestManagementApplyPlanRejectsInvalidEnabledInbound(t *testing.T) {
 	if response.Valid {
 		t.Fatalf("expected invalid plan: %+v", response)
 	}
-	if len(response.Errors) == 0 || !strings.Contains(response.Errors[0], "positive port") {
+	foundPort := false
+	foundDomain := false
+	for _, err := range response.Errors {
+		if strings.Contains(err, "positive port") {
+			foundPort = true
+		}
+	}
+	for _, issue := range response.Issues {
+		if issue.Code == "hysteria2_domain_required" {
+			foundDomain = true
+		}
+	}
+	if !foundPort {
 		t.Fatalf("expected positive port validation error: %+v", response.Errors)
+	}
+	if !foundDomain {
+		t.Fatalf("expected hysteria2 domain required issue: %+v", response.Issues)
 	}
 }
 
@@ -123,15 +138,25 @@ func TestManagementApplyPlanRejectsMissingRenderSettingsForEnabledInbound(t *tes
 
 	r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/api/apply/plan", nil))
 
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d: %s", w.Code, w.Body.String())
 	}
 	var response ApplyPlanResponse
 	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if response.Valid || len(response.Errors) == 0 || !strings.Contains(strings.Join(response.Errors, ";"), "naive inbound \"naive\" is missing") {
-		t.Fatalf("expected missing naive settings validation error: %+v", response)
+	if response.Valid {
+		t.Fatalf("expected invalid plan: %+v", response)
+	}
+	found := false
+	for _, issue := range response.Issues {
+		if issue.Code == "naive_email_required" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected naive_email_required issue: %+v", response)
 	}
 }
 
@@ -151,8 +176,8 @@ func TestManagementApplyRejectsInvalidPlanWithoutWritingFiles(t *testing.T) {
 
 	r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/api/apply", strings.NewReader(`{"confirm":true}`)))
 
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d: %s", w.Code, w.Body.String())
 	}
 	if _, err := os.Stat(filepath.Join(applyRoot, "generated", "veil", "apply-plan.json")); !os.IsNotExist(err) {
 		t.Fatalf("invalid apply should not write files, stat err: %v", err)

--- a/internal/api/router_management_resources_inbounds_test.go
+++ b/internal/api/router_management_resources_inbounds_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	veilsettings "github.com/mikkelchokolate/Veil/internal/settings"
 )
 
 func TestManagementAPICreatesInbound(t *testing.T) {
@@ -246,9 +248,9 @@ func TestManagementAPIInboundProtocolOverrides(t *testing.T) {
 	}
 
 	if response.NaiveUsername != "custom-naive-user" ||
-		response.NaivePassword != "custom-naive-password" ||
+		response.NaivePassword != veilsettings.RedactedSecret ||
 		response.FallbackRoot != "/custom/fallback/root" ||
-		response.Hysteria2Password != "custom-hy2-pass" ||
+		response.Hysteria2Password != veilsettings.RedactedSecret ||
 		response.MasqueradeURL != "https://custom-masquerade.com" ||
 		response.OlcrtcAuth != "livekit" ||
 		response.OlcrtcTransport != "websocket" ||
@@ -271,9 +273,9 @@ func TestManagementAPIInboundProtocolOverrides(t *testing.T) {
 	}
 
 	if reloaded.NaiveUsername != "custom-naive-user" ||
-		reloaded.NaivePassword != "custom-naive-password" ||
+		reloaded.NaivePassword != veilsettings.RedactedSecret ||
 		reloaded.FallbackRoot != "/custom/fallback/root" ||
-		reloaded.Hysteria2Password != "custom-hy2-pass" ||
+		reloaded.Hysteria2Password != veilsettings.RedactedSecret ||
 		reloaded.MasqueradeURL != "https://custom-masquerade.com" ||
 		reloaded.OlcrtcAuth != "livekit" ||
 		reloaded.OlcrtcTransport != "websocket" ||

--- a/internal/api/router_management_resources_routing_test.go
+++ b/internal/api/router_management_resources_routing_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -176,6 +177,41 @@ func TestManagementAPIAppliesRoutingPresetAndPersistsRules(t *testing.T) {
 	restarted.ServeHTTP(read, httptest.NewRequest(http.MethodGet, "/api/routing/rules", nil))
 	if !strings.Contains(read.Body.String(), "preset-all-except-russia") || !strings.Contains(read.Body.String(), "geosite:category-ru") {
 		t.Fatalf("persisted preset routing rules missing: %s", read.Body.String())
+	}
+}
+
+func TestManagementAPIRollsBackRoutingPresetOnSaveFailure(t *testing.T) {
+	dir := t.TempDir()
+	// Valid state path for startup; we break saves afterwards by replacing the
+	// state file's parent with a non-directory.
+	statePath := filepath.Join(dir, "state", "state.json")
+	r, _ := NewRouter(ServerInfo{Version: "test", Mode: "dev", StatePath: statePath})
+
+	// Baseline: no preset active.
+	get := httptest.NewRecorder()
+	r.ServeHTTP(get, httptest.NewRequest(http.MethodGet, "/api/routing/presets", nil))
+	before := get.Body.String()
+
+	// Break persistence: remove the state dir and put a file in its place.
+	stateDir := filepath.Dir(statePath)
+	if err := os.RemoveAll(stateDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(stateDir, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/api/routing/presets/all-except-Russia", nil))
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 on save failure, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// In-memory state must be rolled back — not left holding the preset rules.
+	get2 := httptest.NewRecorder()
+	r.ServeHTTP(get2, httptest.NewRequest(http.MethodGet, "/api/routing/presets", nil))
+	if get2.Body.String() != before {
+		t.Fatalf("preset state not rolled back after save failure:\nbefore: %s\nafter:  %s", before, get2.Body.String())
 	}
 }
 

--- a/internal/api/router_panel_preview_tools_preview_test.go
+++ b/internal/api/router_panel_preview_tools_preview_test.go
@@ -53,7 +53,7 @@ func TestRURecommendedPreviewEndpointDefaultsToPanelOnly(t *testing.T) {
 	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if response.Domain != "example.com" || response.Email != "admin@example.com" || response.Caddyfile != "" {
+	if response.Domain != "example.com" || response.Email != "admin@example.com" || response.CaddyJSON != "" {
 		t.Fatalf("preview should default to Panel-only: %+v", response)
 	}
 }
@@ -73,11 +73,11 @@ func TestRURecommendedPreviewEndpointRendersPanelCaddyAccess(t *testing.T) {
 	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if response.PanelAccess != "caddy" || response.PanelURL == "" || response.Caddyfile == "" {
+	if response.PanelAccess != "caddy" || response.PanelURL == "" || response.CaddyJSON == "" {
 		t.Fatalf("expected Panel Caddy preview: %+v", response)
 	}
-	if strings.Contains(response.Caddyfile, "forward_proxy") || !strings.Contains(response.Caddyfile, "reverse_proxy 127.0.0.1:") {
-		t.Fatalf("unexpected Panel Caddyfile:\n%s", response.Caddyfile)
+	if !strings.Contains(response.CaddyJSON, "example.com") || !strings.Contains(response.CaddyJSON, "127.0.0.1:2096") {
+		t.Fatalf("unexpected Panel Caddy JSON:\n%s", response.CaddyJSON)
 	}
 }
 

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -26,7 +26,7 @@ func assertClientSubscriptionLines(t *testing.T, body string) {
 	if len(lines) != 2 {
 		t.Fatalf("expected 2 subscription links, got %q", body)
 	}
-	if lines[0] != "naive+https://veil:naive-secret@vpn.example.com:443" {
+	if lines[0] != "https://veil:naive-secret@vpn.example.com" {
 		t.Fatalf("unexpected first subscription link: %q", lines[0])
 	}
 	if !strings.HasPrefix(lines[1], "hysteria2://hy2-secret@vpn.example.com:443/") || !strings.Contains(lines[1], "sni=vpn.example.com") {
@@ -73,7 +73,7 @@ func writeRenderableManagementState(path string, inboundSet string) error {
 			"panelListen":"127.0.0.1:2096",
 			"mode":"dev",
 			"domain":"vpn.example.com",
-			"email":"admin@example.com",
+			"defaultAcmeEmail":"admin@example.com",
 			"naiveUsername":"veil",
 			"naivePassword":"naive-secret",
 			"hysteria2Password":"hy2-secret",

--- a/internal/api/router_utility_security_logs_test.go
+++ b/internal/api/router_utility_security_logs_test.go
@@ -78,7 +78,7 @@ func TestIsAllowedHealthService(t *testing.T) {
 		service string
 		want    bool
 	}{
-		{"veil-caddy@panel.service", true},
+		{"veil-caddy.service", true},
 		{"veil-hysteria2@default.service", true},
 		{"veil-hysteria2@.service", true},
 		{"veil-warp.service", true},
@@ -86,8 +86,8 @@ func TestIsAllowedHealthService(t *testing.T) {
 		{"caddy.service", false},
 		{"hysteria2.service", false},
 		{"", false},
-		{"veil-caddy@panel", false},
-		{"veil-caddy@panel.service.evil", false},
+		{"veil-caddy.service.evil", false},
+		{"veil-caddy@panel.service", false},
 	}
 	for _, tt := range tests {
 		got := service.NewCommandPolicy(NewManagedRuntimeCatalog()).AllowsHealth(tt.service)
@@ -104,13 +104,13 @@ func TestIsAllowedServiceCommand(t *testing.T) {
 		want    bool
 	}{
 		{
-			name:    "reload caddy panel",
-			command: []string{"systemctl", "reload", "veil-caddy@panel.service"},
+			name:    "reload caddy",
+			command: []string{"systemctl", "reload", "veil-caddy.service"},
 			want:    true,
 		},
 		{
-			name:    "restart caddy panel disallowed",
-			command: []string{"systemctl", "restart", "veil-caddy@panel.service"},
+			name:    "restart caddy disallowed",
+			command: []string{"systemctl", "restart", "veil-caddy.service"},
 			want:    false,
 		},
 		{

--- a/internal/api/service_action_guard_test.go
+++ b/internal/api/service_action_guard_test.go
@@ -12,7 +12,7 @@ func TestServiceActionRejectsConcurrentMutation(t *testing.T) {
 	state.serviceActionMu.Lock()
 	defer state.serviceActionMu.Unlock()
 
-	request := httptest.NewRequest(http.MethodPost, "/api/services/caddy-panel/restart", strings.NewReader(`{"confirm":true}`))
+	request := httptest.NewRequest(http.MethodPost, "/api/services/caddy/restart", strings.NewReader(`{"confirm":true}`))
 	request.Header.Set("Content-Type", "application/json")
 	response := httptest.NewRecorder()
 

--- a/internal/api/service_command_policy_test.go
+++ b/internal/api/service_command_policy_test.go
@@ -8,14 +8,14 @@ import (
 
 func TestServiceCommandPolicyAllowsOnlyManagedPromotedActionsAndHealthServices(t *testing.T) {
 	policy := service.NewCommandPolicy(NewManagedRuntimeCatalog())
-	if !policy.AllowsAction([]string{"systemctl", "reload", "veil-caddy@panel.service"}) {
-		t.Fatalf("expected veil-caddy@panel reload to be allowed")
+	if !policy.AllowsAction([]string{"systemctl", "reload", "veil-caddy.service"}) {
+		t.Fatalf("expected veil-caddy reload to be allowed")
 	}
 	if !policy.AllowsAction([]string{"systemctl", "restart", "veil-mieru.service"}) {
 		t.Fatalf("expected veil-mieru restart to be allowed")
 	}
-	if policy.AllowsAction([]string{"systemctl", "restart", "veil-caddy@panel.service"}) {
-		t.Fatalf("restart must not be allowed for Caddy panel")
+	if policy.AllowsAction([]string{"systemctl", "restart", "veil-caddy.service"}) {
+		t.Fatalf("restart must not be allowed for Caddy")
 	}
 	if policy.AllowsAction([]string{"systemctl", "reload", "veil-mieru.service"}) {
 		t.Fatalf("reload must not be allowed for Mieru")

--- a/internal/api/services_test.go
+++ b/internal/api/services_test.go
@@ -47,7 +47,7 @@ func TestServicesRestartSuccess(t *testing.T) {
 	defer func() { serviceActionRunner = orig }()
 
 	r, _ := NewRouter(ServerInfo{Version: "test"})
-	req := httptest.NewRequest(http.MethodPost, "/api/services/caddy-panel/restart", strings.NewReader(`{"confirm":true}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/services/caddy/restart", strings.NewReader(`{"confirm":true}`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)

--- a/internal/applyflow/workflow.go
+++ b/internal/applyflow/workflow.go
@@ -61,7 +61,9 @@ func (w Workflow) RunLocked(req model.ApplyRequest) (model.ApplyResponse, int, e
 		if err != nil {
 			return model.ApplyResponse{}, http.StatusInternalServerError, err
 		}
-		response.LiveApplied = true
+		// Report LiveApplied only when at least one file was actually promoted;
+		// an idempotent no-op apply must not claim a live change happened.
+		response.LiveApplied = len(liveFiles) > 0
 		response.LiveFiles = liveFiles
 		response.BackupFiles = backupFiles
 		if req.ApplyServices {

--- a/internal/applyplan/planner_test.go
+++ b/internal/applyplan/planner_test.go
@@ -15,8 +15,8 @@ func TestPlannerBuildsStructuredOperationsDeterministically(t *testing.T) {
 		GeneratedRoot: "/var/lib/veil/staging",
 		LiveRoot:      "/etc/veil/generated",
 		PanelAccess: Material{
-			Configs: []string{"/etc/veil/generated/caddy/edge.Caddyfile"},
-			Actions: []string{"reload veil-caddy@edge.service"},
+			Configs: []string{"/etc/veil/generated/caddy/config.json"},
+			Actions: []string{"reload veil-caddy.service"},
 		},
 		Inbounds: []model.Inbound{{
 			Name: "edge", Protocol: "mieru", Transport: "tcp", Port: 443, Enabled: true,
@@ -32,8 +32,8 @@ func TestPlannerBuildsStructuredOperationsDeterministically(t *testing.T) {
 	want := []model.ApplyOperation{
 		{
 			Type:              "promote_file",
-			Source:            "/var/lib/veil/staging/caddy/edge.Caddyfile",
-			Destination:       "/etc/veil/generated/caddy/edge.Caddyfile",
+			Source:            "/var/lib/veil/staging/caddy/config.json",
+			Destination:       "/etc/veil/generated/caddy/config.json",
 			InterruptionRisk:  "reload",
 			RollbackAvailable: true,
 			ValidationSource:  "render-and-live-host",
@@ -48,7 +48,7 @@ func TestPlannerBuildsStructuredOperationsDeterministically(t *testing.T) {
 		},
 		{
 			Type:              "reload_service",
-			Unit:              "veil-caddy@edge.service",
+			Unit:              "veil-caddy.service",
 			InterruptionRisk:  "reload",
 			RollbackAvailable: true,
 			ValidationSource:  "managed-unit-catalog",
@@ -96,7 +96,7 @@ func TestPlannerStructuredPreviewDoesNotContainSecrets(t *testing.T) {
 
 func TestPlannerBuildsManagementApplyIntentFromPanelProtocolsWarpAndRouting(t *testing.T) {
 	plan := Build(Input{
-		PanelAccess: Material{Configs: []string{"/etc/veil/generated/caddy/panel.Caddyfile"}, Actions: []string{"reload veil-caddy@panel.service"}, Runtimes: []string{"veil-caddy@panel.service"}},
+		PanelAccess: Material{Configs: []string{"/etc/veil/generated/caddy/config.json"}, Actions: []string{"reload veil-caddy.service"}, Runtimes: []string{"veil-caddy.service"}},
 		Settings:    model.Settings{Domain: "vpn.example.com"},
 		Inbounds: []model.Inbound{
 			{Name: "mieru", Protocol: "mieru", Transport: "tcp", Port: 443, Enabled: true},
@@ -116,17 +116,17 @@ func TestPlannerBuildsManagementApplyIntentFromPanelProtocolsWarpAndRouting(t *t
 	if !plan.Valid {
 		t.Fatalf("plan errors = %+v", plan.Errors)
 	}
-	for _, want := range []string{"/etc/veil/generated/caddy/panel.Caddyfile", "/etc/veil/generated/mieru/server_config.json", "/etc/veil/generated/sing-box/warp.json", "/etc/veil/generated/rules/geoip.dat"} {
+	for _, want := range []string{"/etc/veil/generated/caddy/config.json", "/etc/veil/generated/mieru/server_config.json", "/etc/veil/generated/sing-box/warp.json", "/etc/veil/generated/rules/geoip.dat"} {
 		if !contains(plan.Configs, want) {
 			t.Fatalf("configs missing %q: %+v", want, plan.Configs)
 		}
 	}
-	for _, want := range []string{"validate management state", "stage generated configs", "reload veil-caddy@panel.service", "restart veil-mieru.service", "restart veil-warp.service"} {
+	for _, want := range []string{"validate management state", "stage generated configs", "reload veil-caddy.service", "restart veil-mieru.service", "restart veil-warp.service"} {
 		if !contains(plan.Actions, want) {
 			t.Fatalf("actions missing %q: %+v", want, plan.Actions)
 		}
 	}
-	for _, want := range []string{"veil-caddy@panel.service", "veil-mieru.service", "veil-warp.service"} {
+	for _, want := range []string{"veil-caddy.service", "veil-mieru.service", "veil-warp.service"} {
 		if !contains(plan.Runtimes, want) {
 			t.Fatalf("runtimes missing %q: %+v", want, plan.Runtimes)
 		}

--- a/internal/bindregistry/bindkey.go
+++ b/internal/bindregistry/bindkey.go
@@ -1,0 +1,65 @@
+package bindregistry
+
+import "strings"
+
+type ListenNetwork string
+
+const (
+	ListenTCP ListenNetwork = "tcp"
+	ListenUDP ListenNetwork = "udp"
+)
+
+type BindKey struct {
+	Address string
+	Port    int
+	Network ListenNetwork
+}
+
+type BindOwnerKind string
+
+const (
+	BindOwnerPanelDirect   BindOwnerKind = "panel_direct"
+	BindOwnerPanelCaddy    BindOwnerKind = "panel_caddy"
+	BindOwnerNaive         BindOwnerKind = "naive"
+	BindOwnerHysteria2     BindOwnerKind = "hysteria2"
+	BindOwnerInbound       BindOwnerKind = "inbound"
+	BindOwnerLegacyCaddy   BindOwnerKind = "legacy_caddy"
+	BindOwnerAcmeChallenge BindOwnerKind = "acme_challenge"
+)
+
+type BindOwner struct {
+	Kind        BindOwnerKind
+	ServiceName string
+	InboundName string
+}
+
+func NormalizeAddress(addr string) string {
+	addr = strings.TrimSpace(addr)
+	if addr == "" {
+		return "0.0.0.0"
+	}
+	return addr
+}
+
+func IsWildcard(addr string) bool {
+	return addr == "0.0.0.0" || addr == "::" || addr == ""
+}
+
+func (k BindKey) Canonical() BindKey {
+	return BindKey{Address: NormalizeAddress(k.Address), Port: k.Port, Network: k.Network}
+}
+
+func (k BindKey) Overlaps(other BindKey) bool {
+	a := k.Canonical()
+	b := other.Canonical()
+	if a.Port != b.Port || a.Network != b.Network {
+		return false
+	}
+	if a.Address == b.Address {
+		return true
+	}
+	if IsWildcard(a.Address) || IsWildcard(b.Address) {
+		return true
+	}
+	return false
+}

--- a/internal/bindregistry/bindkey_test.go
+++ b/internal/bindregistry/bindkey_test.go
@@ -1,0 +1,36 @@
+package bindregistry
+
+import "testing"
+
+func TestNormalizeAddress(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"0.0.0.0", "0.0.0.0"},
+		{"", "0.0.0.0"},
+		{"::", "::"},
+		{" 0.0.0.0 ", "0.0.0.0"},
+	}
+	for _, c := range cases {
+		got := NormalizeAddress(c.in)
+		if got != c.want {
+			t.Errorf("NormalizeAddress(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestBindKeyOverlap(t *testing.T) {
+	wildcardTCP443 := BindKey{Address: "0.0.0.0", Port: 443, Network: ListenTCP}
+	specificTCP443 := BindKey{Address: "192.168.1.10", Port: 443, Network: ListenTCP}
+	if !wildcardTCP443.Overlaps(specificTCP443) {
+		t.Error("wildcard IPv4 must overlap specific IPv4 on same port/protocol")
+	}
+	udp443 := BindKey{Address: "0.0.0.0", Port: 443, Network: ListenUDP}
+	if wildcardTCP443.Overlaps(udp443) {
+		t.Error("TCP and UDP on same port must not conflict")
+	}
+	otherPort := BindKey{Address: "192.168.1.10", Port: 8443, Network: ListenTCP}
+	if specificTCP443.Overlaps(otherPort) {
+		t.Error("different ports must not conflict")
+	}
+}

--- a/internal/bindregistry/conflicts.go
+++ b/internal/bindregistry/conflicts.go
@@ -1,0 +1,51 @@
+package bindregistry
+
+import (
+	"fmt"
+	"sort"
+)
+
+type Conflict struct {
+	Key     BindKey
+	Owners  []BindOwner
+	Message string
+}
+
+func ValidateNoConflicts(owners map[BindKey]BindOwner) []Conflict {
+	canonical := make(map[BindKey]BindOwner, len(owners))
+	for k, o := range owners {
+		canonical[k.Canonical()] = o
+	}
+
+	keys := make([]BindKey, 0, len(canonical))
+	for k := range canonical {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].Network != keys[j].Network {
+			return keys[i].Network < keys[j].Network
+		}
+		if keys[i].Address != keys[j].Address {
+			return keys[i].Address < keys[j].Address
+		}
+		return keys[i].Port < keys[j].Port
+	})
+
+	var conflicts []Conflict
+	for i, k := range keys {
+		var overlapping []BindOwner
+		for _, otherK := range keys[i+1:] {
+			if k.Overlaps(otherK) {
+				overlapping = append(overlapping, canonical[otherK])
+			}
+		}
+		if len(overlapping) > 0 {
+			conflicts = append(conflicts, Conflict{
+				Key:     k,
+				Owners:  append([]BindOwner{canonical[k]}, overlapping...),
+				Message: fmt.Sprintf("%s %s:%d is claimed by multiple owners", k.Network, k.Address, k.Port),
+			})
+		}
+	}
+	return conflicts
+}

--- a/internal/bindregistry/conflicts_test.go
+++ b/internal/bindregistry/conflicts_test.go
@@ -1,0 +1,27 @@
+package bindregistry
+
+import "testing"
+
+func TestValidateNoConflicts(t *testing.T) {
+	owners := map[BindKey]BindOwner{
+		{Address: "0.0.0.0", Port: 443, Network: ListenTCP}: {Kind: BindOwnerPanelCaddy},
+		{Address: "192.168.1.10", Port: 443, Network: ListenTCP}: {Kind: BindOwnerNaive, InboundName: "naive-1"},
+	}
+	conflicts := ValidateNoConflicts(owners)
+	if len(conflicts) == 0 {
+		t.Fatal("expected conflict between wildcard Panel and specific naive on TCP 443")
+	}
+	if conflicts[0].Owners[0].Kind != BindOwnerPanelCaddy {
+		t.Error("first owner should be Panel Caddy")
+	}
+}
+
+func TestValidateNoConflictsNoCollision(t *testing.T) {
+	owners := map[BindKey]BindOwner{
+		{Address: "0.0.0.0", Port: 443, Network: ListenTCP}: {Kind: BindOwnerPanelCaddy},
+		{Address: "0.0.0.0", Port: 443, Network: ListenUDP}: {Kind: BindOwnerHysteria2},
+	}
+	if conflicts := ValidateNoConflicts(owners); len(conflicts) != 0 {
+		t.Fatalf("expected no TCP/UDP conflict, got %v", conflicts)
+	}
+}

--- a/internal/bindregistry/conflicts_test.go
+++ b/internal/bindregistry/conflicts_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestValidateNoConflicts(t *testing.T) {
 	owners := map[BindKey]BindOwner{
-		{Address: "0.0.0.0", Port: 443, Network: ListenTCP}: {Kind: BindOwnerPanelCaddy},
+		{Address: "0.0.0.0", Port: 443, Network: ListenTCP}:      {Kind: BindOwnerPanelCaddy},
 		{Address: "192.168.1.10", Port: 443, Network: ListenTCP}: {Kind: BindOwnerNaive, InboundName: "naive-1"},
 	}
 	conflicts := ValidateNoConflicts(owners)

--- a/internal/caddyadmin/client.go
+++ b/internal/caddyadmin/client.go
@@ -1,0 +1,35 @@
+package caddyadmin
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const defaultAdminTimeout = 30 * time.Second
+
+type Client struct {
+	AdminEndpoint string
+	HTTPClient    *http.Client
+}
+
+func NewClient(endpoint string) Client {
+	if endpoint == "" {
+		endpoint = "http://127.0.0.1:2019"
+	}
+	return Client{AdminEndpoint: endpoint, HTTPClient: &http.Client{Timeout: defaultAdminTimeout}}
+}
+
+func (c Client) LoadConfig(json []byte) error {
+	url := c.AdminEndpoint + "/load"
+	resp, err := c.HTTPClient.Post(url, "application/json", bytes.NewReader(json))
+	if err != nil {
+		return fmt.Errorf("caddy admin POST failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("caddy admin returned %s", resp.Status)
+	}
+	return nil
+}

--- a/internal/caddyadmin/client_test.go
+++ b/internal/caddyadmin/client_test.go
@@ -1,0 +1,32 @@
+package caddyadmin
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestLoadConfigPostsJSON(t *testing.T) {
+	var received string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s", r.Method)
+		}
+		if r.URL.Path != "/load" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		buf := make([]byte, r.ContentLength)
+		r.Body.Read(buf)
+		received = string(buf)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	if err := c.LoadConfig([]byte(`{"apps":{}}`)); err != nil {
+		t.Fatal(err)
+	}
+	if received == "" {
+		t.Error("server received empty body")
+	}
+}

--- a/internal/caddyassembly/challenge.go
+++ b/internal/caddyassembly/challenge.go
@@ -1,0 +1,69 @@
+package caddyassembly
+
+import (
+	"github.com/mikkelchokolate/Veil/internal/bindregistry"
+	"github.com/mikkelchokolate/Veil/internal/model"
+)
+
+type AcmeChallengeOwner struct {
+	ChallengeMode string
+	Domains       []string
+}
+
+func PlanAcmeChallengeBinds(
+	challengeMode string,
+	domains map[string]CaddyDomainCertSpec,
+	owners map[bindregistry.BindKey]bindregistry.BindOwner,
+) (map[bindregistry.BindKey]AcmeChallengeOwner, []model.ValidationIssue) {
+	result := make(map[bindregistry.BindKey]AcmeChallengeOwner)
+	var issues []model.ValidationIssue
+
+	add := func(key bindregistry.BindKey, domain string) {
+		owner := result[key]
+		owner.ChallengeMode = challengeMode
+		owner.Domains = append(owner.Domains, domain)
+		result[key] = owner
+	}
+
+	for _, spec := range domains {
+		switch challengeMode {
+		case "http-01":
+			key := bindregistry.BindKey{Address: "0.0.0.0", Port: 80, Network: bindregistry.ListenTCP}
+			if existing, ok := owners[key]; ok && existing.Kind != bindregistry.BindOwnerAcmeChallenge {
+				// A compatible Caddy listener (Panel or Naive) can answer HTTP-01 on :80.
+				if existing.Kind == bindregistry.BindOwnerPanelCaddy || existing.Kind == bindregistry.BindOwnerNaive {
+					continue
+				}
+				issues = append(issues, model.ValidationIssue{
+					Code:     "acme_http01_port_in_use",
+					Severity: "error",
+					Message:  "TCP :80 is required for http-01 but is owned by a non-Caddy service",
+					Source:   "caddyassembly",
+				})
+				continue
+			}
+			add(key, spec.Domain)
+		case "tls-alpn-01":
+			key := bindregistry.BindKey{Address: "0.0.0.0", Port: 443, Network: bindregistry.ListenTCP}
+			if existing, ok := owners[key]; ok && existing.Kind != bindregistry.BindOwnerAcmeChallenge {
+				// TLS-ALPN-01 can reuse a compatible Caddy TCP :443 listener; if owner is not Caddy, reject.
+				if existing.Kind != bindregistry.BindOwnerPanelCaddy && existing.Kind != bindregistry.BindOwnerNaive {
+					issues = append(issues, model.ValidationIssue{
+						Code:     "acme_tlsalpn_port_in_use",
+						Severity: "error",
+						Message:  "TCP :443 is required for tls-alpn-01 but is owned by a non-Caddy service",
+						Source:   "caddyassembly",
+					})
+					continue
+				}
+				// A compatible Caddy owner already answers TLS-ALPN-01 on :443; do not
+				// add a challenge-only bind that would replace it.
+				continue
+			}
+			add(key, spec.Domain)
+		case "dns-01":
+			// no bind
+		}
+	}
+	return result, issues
+}

--- a/internal/caddyassembly/challenge_test.go
+++ b/internal/caddyassembly/challenge_test.go
@@ -1,0 +1,142 @@
+package caddyassembly
+
+import (
+	"testing"
+
+	"github.com/mikkelchokolate/Veil/internal/bindregistry"
+)
+
+func TestPlanAcmeChallengeBindsHTTP01(t *testing.T) {
+	domains := map[string]CaddyDomainCertSpec{
+		"x.com": {Domain: "x.com", Email: "a@x.com"},
+	}
+	owners := map[bindregistry.BindKey]bindregistry.BindOwner{}
+	planned, issues := PlanAcmeChallengeBinds("http-01", domains, owners)
+	if len(issues) > 0 {
+		t.Fatalf("unexpected issues: %v", issues)
+	}
+	key := bindregistry.BindKey{Address: "0.0.0.0", Port: 80, Network: bindregistry.ListenTCP}
+	if _, ok := planned[key]; !ok {
+		t.Fatal("expected TCP :80 challenge bind")
+	}
+}
+
+func TestPlanAcmeChallengeBindsDNS01NoBind(t *testing.T) {
+	domains := map[string]CaddyDomainCertSpec{
+		"x.com": {Domain: "x.com", Email: "a@x.com"},
+	}
+	owners := map[bindregistry.BindKey]bindregistry.BindOwner{}
+	planned, issues := PlanAcmeChallengeBinds("dns-01", domains, owners)
+	if len(issues) > 0 {
+		t.Fatalf("unexpected issues: %v", issues)
+	}
+	if len(planned) != 0 {
+		t.Fatalf("dns-01 should add no binds, got %v", planned)
+	}
+}
+
+func TestPlanAcmeChallengeBindsTLSALPN01(t *testing.T) {
+	domains := map[string]CaddyDomainCertSpec{
+		"x.com": {Domain: "x.com", Email: "a@x.com"},
+	}
+	owners := map[bindregistry.BindKey]bindregistry.BindOwner{}
+	planned, issues := PlanAcmeChallengeBinds("tls-alpn-01", domains, owners)
+	if len(issues) > 0 {
+		t.Fatalf("unexpected issues: %v", issues)
+	}
+	key := bindregistry.BindKey{Address: "0.0.0.0", Port: 443, Network: bindregistry.ListenTCP}
+	if _, ok := planned[key]; !ok {
+		t.Fatal("expected TCP :443 challenge bind")
+	}
+}
+
+func TestPlanAcmeChallengeBindsHTTP01Conflict(t *testing.T) {
+	domains := map[string]CaddyDomainCertSpec{
+		"x.com": {Domain: "x.com", Email: "a@x.com"},
+	}
+	key := bindregistry.BindKey{Address: "0.0.0.0", Port: 80, Network: bindregistry.ListenTCP}
+	owners := map[bindregistry.BindKey]bindregistry.BindOwner{
+		key: {Kind: bindregistry.BindOwnerPanelDirect},
+	}
+	planned, issues := PlanAcmeChallengeBinds("http-01", domains, owners)
+	if len(planned) != 0 {
+		t.Fatalf("expected no planned binds on conflict, got %v", planned)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("expected one issue, got %v", issues)
+	}
+	if issues[0].Code != "acme_http01_port_in_use" {
+		t.Fatalf("expected acme_http01_port_in_use issue, got %v", issues[0])
+	}
+}
+
+func TestPlanAcmeChallengeBindsTLSALPN01Conflict(t *testing.T) {
+	domains := map[string]CaddyDomainCertSpec{
+		"x.com": {Domain: "x.com", Email: "a@x.com"},
+	}
+	key := bindregistry.BindKey{Address: "0.0.0.0", Port: 443, Network: bindregistry.ListenTCP}
+	owners := map[bindregistry.BindKey]bindregistry.BindOwner{
+		key: {Kind: bindregistry.BindOwnerPanelDirect},
+	}
+	planned, issues := PlanAcmeChallengeBinds("tls-alpn-01", domains, owners)
+	if len(planned) != 0 {
+		t.Fatalf("expected no planned binds on conflict, got %v", planned)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("expected one issue, got %v", issues)
+	}
+	if issues[0].Code != "acme_tlsalpn_port_in_use" {
+		t.Fatalf("expected acme_tlsalpn_port_in_use issue, got %v", issues[0])
+	}
+}
+
+func TestPlanAcmeChallengeBindsHTTP01ReusesPanelCaddyListener(t *testing.T) {
+	domains := map[string]CaddyDomainCertSpec{
+		"x.com": {Domain: "x.com", Email: "a@x.com"},
+	}
+	key := bindregistry.BindKey{Address: "0.0.0.0", Port: 80, Network: bindregistry.ListenTCP}
+	owners := map[bindregistry.BindKey]bindregistry.BindOwner{
+		key: {Kind: bindregistry.BindOwnerPanelCaddy},
+	}
+	planned, issues := PlanAcmeChallengeBinds("http-01", domains, owners)
+	if len(issues) > 0 {
+		t.Fatalf("unexpected issues: %v", issues)
+	}
+	if _, ok := planned[key]; ok {
+		t.Fatal("expected no TCP :80 challenge bind when Panel Caddy already owns the port")
+	}
+}
+
+func TestPlanAcmeChallengeBindsHTTP01ReusesNaiveListener(t *testing.T) {
+	domains := map[string]CaddyDomainCertSpec{
+		"x.com": {Domain: "x.com", Email: "a@x.com"},
+	}
+	key := bindregistry.BindKey{Address: "0.0.0.0", Port: 80, Network: bindregistry.ListenTCP}
+	owners := map[bindregistry.BindKey]bindregistry.BindOwner{
+		key: {Kind: bindregistry.BindOwnerNaive},
+	}
+	planned, issues := PlanAcmeChallengeBinds("http-01", domains, owners)
+	if len(issues) > 0 {
+		t.Fatalf("unexpected issues: %v", issues)
+	}
+	if _, ok := planned[key]; ok {
+		t.Fatal("expected no TCP :80 challenge bind when a naive inbound already owns the port")
+	}
+}
+
+func TestPlanAcmeChallengeBindsTLSALPN01ReusesCaddyListener(t *testing.T) {
+	domains := map[string]CaddyDomainCertSpec{
+		"x.com": {Domain: "x.com", Email: "a@x.com"},
+	}
+	key := bindregistry.BindKey{Address: "0.0.0.0", Port: 443, Network: bindregistry.ListenTCP}
+	owners := map[bindregistry.BindKey]bindregistry.BindOwner{
+		key: {Kind: bindregistry.BindOwnerPanelCaddy},
+	}
+	planned, issues := PlanAcmeChallengeBinds("tls-alpn-01", domains, owners)
+	if len(issues) > 0 {
+		t.Fatalf("unexpected issues: %v", issues)
+	}
+	if _, ok := planned[key]; ok {
+		t.Fatal("expected no TCP :443 challenge bind when a compatible Caddy listener already owns the port")
+	}
+}

--- a/internal/caddyassembly/domain.go
+++ b/internal/caddyassembly/domain.go
@@ -56,7 +56,7 @@ func ResolveDomainCertSpecs(settings model.Settings, inbounds []model.Inbound) (
 
 	specs := make(map[string]CaddyDomainCertSpec, len(owners))
 	for domain, o := range owners {
-		resolved, err := resolveEmail(domain, emails[domain], settings)
+		resolved, err := resolveEmail(domain, emails[domain], settings, o)
 		if err != nil {
 			return nil, err
 		}
@@ -83,7 +83,7 @@ func addEmail(m map[string]map[string]struct{}, domain, email string) {
 	m[domain][email] = struct{}{}
 }
 
-func resolveEmail(domain string, explicit map[string]struct{}, settings model.Settings) (string, error) {
+func resolveEmail(domain string, explicit map[string]struct{}, settings model.Settings, owner *CaddyDomainOwners) (string, error) {
 	if len(explicit) > 1 {
 		return "", fmt.Errorf("domain %s has conflicting ACME emails", domain)
 	}
@@ -96,7 +96,11 @@ func resolveEmail(domain string, explicit map[string]struct{}, settings model.Se
 	if settings.PanelEmail != "" {
 		return settings.PanelEmail, nil
 	}
-	if settings.Email != "" {
+	// The legacy global settings.Email is only used as a last-resort fallback
+	// for the Panel's own domain. Inbound-specific domains must provide an
+	// explicit or default ACME email so a single stale email does not silently
+	// issue certificates for unrelated inbound domains.
+	if owner != nil && owner.Panel && settings.Email != "" {
 		return settings.Email, nil
 	}
 	return "", errors.New("no ACME email resolved for domain " + domain)

--- a/internal/caddyassembly/domain.go
+++ b/internal/caddyassembly/domain.go
@@ -42,7 +42,7 @@ func ResolveDomainCertSpecs(settings model.Settings, inbounds []model.Inbound) (
 				continue
 			}
 			ensureOwner(owners, domain).NaiveInboundNames = append(ensureOwner(owners, domain).NaiveInboundNames, inb.Name)
-			addEmail(emails, domain, naiveEmailWithFallback(inb, settings))
+			addEmail(emails, domain, naiveInboundEmail(inb))
 		}
 		if inb.Protocol == "hysteria2" {
 			domain := model.InboundDomain(inb)
@@ -121,6 +121,6 @@ func naiveDomainWithFallback(inb model.Inbound, settings model.Settings) string 
 	return model.ResolveInboundDomain(inb, settings)
 }
 
-func naiveEmailWithFallback(inb model.Inbound, _ model.Settings) string {
+func naiveInboundEmail(inb model.Inbound) string {
 	return model.InboundEmail(inb)
 }

--- a/internal/caddyassembly/domain.go
+++ b/internal/caddyassembly/domain.go
@@ -1,0 +1,125 @@
+package caddyassembly
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/mikkelchokolate/Veil/internal/model"
+)
+
+type CaddyDomainOwners struct {
+	Panel                bool
+	NaiveInboundNames    []string
+	HysteriaInboundNames []string
+}
+
+type CaddyDomainCertSpec struct {
+	Domain string
+	Email  string
+	Owners CaddyDomainOwners
+}
+
+func ResolveDomainCertSpecs(settings model.Settings, inbounds []model.Inbound) (map[string]CaddyDomainCertSpec, error) {
+	owners := make(map[string]*CaddyDomainOwners)
+	emails := make(map[string]map[string]struct{})
+
+	if settings.PanelAccess == "caddy" {
+		panelDomain := strings.ToLower(strings.TrimSpace(settings.PanelDomain))
+		if panelDomain == "" {
+			panelDomain = strings.ToLower(strings.TrimSpace(settings.Domain))
+		}
+		if panelDomain != "" {
+			ensureOwner(owners, panelDomain).Panel = true
+			addEmail(emails, panelDomain, settings.PanelEmail)
+		}
+	}
+
+	for _, inb := range inbounds {
+		if inb.Protocol == "naiveproxy" {
+			domain := strings.ToLower(naiveDomainWithFallback(inb, settings))
+			if domain == "" {
+				continue
+			}
+			ensureOwner(owners, domain).NaiveInboundNames = append(ensureOwner(owners, domain).NaiveInboundNames, inb.Name)
+			addEmail(emails, domain, naiveEmailWithFallback(inb, settings))
+		}
+		if inb.Protocol == "hysteria2" {
+			domain := strings.ToLower(stringField(inb.ProtocolFields, "domain"))
+			if domain == "" {
+				continue
+			}
+			ensureOwner(owners, domain).HysteriaInboundNames = append(ensureOwner(owners, domain).HysteriaInboundNames, inb.Name)
+			addEmail(emails, domain, stringField(inb.ProtocolFields, "email"))
+		}
+	}
+
+	specs := make(map[string]CaddyDomainCertSpec, len(owners))
+	for domain, o := range owners {
+		resolved, err := resolveEmail(domain, emails[domain], settings)
+		if err != nil {
+			return nil, err
+		}
+		specs[domain] = CaddyDomainCertSpec{Domain: domain, Email: resolved, Owners: *o}
+	}
+	return specs, nil
+}
+
+func ensureOwner(m map[string]*CaddyDomainOwners, domain string) *CaddyDomainOwners {
+	if m[domain] == nil {
+		m[domain] = &CaddyDomainOwners{}
+	}
+	return m[domain]
+}
+
+func addEmail(m map[string]map[string]struct{}, domain, email string) {
+	email = strings.TrimSpace(email)
+	if email == "" {
+		return
+	}
+	if m[domain] == nil {
+		m[domain] = make(map[string]struct{})
+	}
+	m[domain][email] = struct{}{}
+}
+
+func resolveEmail(domain string, explicit map[string]struct{}, settings model.Settings) (string, error) {
+	if len(explicit) > 1 {
+		return "", fmt.Errorf("domain %s has conflicting ACME emails", domain)
+	}
+	for e := range explicit {
+		return e, nil
+	}
+	if settings.DefaultAcmeEmail != "" {
+		return settings.DefaultAcmeEmail, nil
+	}
+	if settings.PanelEmail != "" {
+		return settings.PanelEmail, nil
+	}
+	if settings.Email != "" {
+		return settings.Email, nil
+	}
+	return "", errors.New("no ACME email resolved for domain " + domain)
+}
+
+func stringField(m map[string]any, key string) string {
+	if m == nil {
+		return ""
+	}
+	v, ok := m[key].(string)
+	if !ok {
+		return ""
+	}
+	return v
+}
+
+func naiveDomainWithFallback(inb model.Inbound, settings model.Settings) string {
+	if d := stringField(inb.ProtocolFields, "domain"); d != "" {
+		return d
+	}
+	return settings.Domain
+}
+
+func naiveEmailWithFallback(inb model.Inbound, settings model.Settings) string {
+	return stringField(inb.ProtocolFields, "email")
+}

--- a/internal/caddyassembly/domain.go
+++ b/internal/caddyassembly/domain.go
@@ -37,7 +37,7 @@ func ResolveDomainCertSpecs(settings model.Settings, inbounds []model.Inbound) (
 
 	for _, inb := range inbounds {
 		if inb.Protocol == "naiveproxy" {
-			domain := strings.ToLower(naiveDomainWithFallback(inb, settings))
+			domain := naiveDomainWithFallback(inb, settings)
 			if domain == "" {
 				continue
 			}
@@ -45,12 +45,12 @@ func ResolveDomainCertSpecs(settings model.Settings, inbounds []model.Inbound) (
 			addEmail(emails, domain, naiveEmailWithFallback(inb, settings))
 		}
 		if inb.Protocol == "hysteria2" {
-			domain := strings.ToLower(stringField(inb.ProtocolFields, "domain"))
+			domain := model.InboundDomain(inb)
 			if domain == "" {
 				continue
 			}
 			ensureOwner(owners, domain).HysteriaInboundNames = append(ensureOwner(owners, domain).HysteriaInboundNames, inb.Name)
-			addEmail(emails, domain, stringField(inb.ProtocolFields, "email"))
+			addEmail(emails, domain, model.InboundEmail(inb))
 		}
 	}
 
@@ -118,12 +118,9 @@ func stringField(m map[string]any, key string) string {
 }
 
 func naiveDomainWithFallback(inb model.Inbound, settings model.Settings) string {
-	if d := stringField(inb.ProtocolFields, "domain"); d != "" {
-		return d
-	}
-	return settings.Domain
+	return model.ResolveInboundDomain(inb, settings)
 }
 
-func naiveEmailWithFallback(inb model.Inbound, settings model.Settings) string {
-	return stringField(inb.ProtocolFields, "email")
+func naiveEmailWithFallback(inb model.Inbound, _ model.Settings) string {
+	return model.InboundEmail(inb)
 }

--- a/internal/caddyassembly/domain_test.go
+++ b/internal/caddyassembly/domain_test.go
@@ -1,0 +1,65 @@
+package caddyassembly
+
+import (
+	"testing"
+
+	"github.com/mikkelchokolate/Veil/internal/model"
+)
+
+func TestResolveDomainCertSpecsConflictingEmail(t *testing.T) {
+	settings := model.Settings{PanelAccess: "direct"}
+	inbounds := []model.Inbound{
+		{Name: "n1", Protocol: "naiveproxy", ProtocolFields: map[string]any{"domain": "x.com", "email": "a@x.com"}},
+		{Name: "n2", Protocol: "naiveproxy", ProtocolFields: map[string]any{"domain": "x.com", "email": "b@x.com"}},
+	}
+	_, err := ResolveDomainCertSpecs(settings, inbounds)
+	if err == nil {
+		t.Fatal("expected conflicting email error")
+	}
+}
+
+func TestResolveDomainCertSpecsFallback(t *testing.T) {
+	settings := model.Settings{PanelAccess: "direct", DefaultAcmeEmail: "admin@x.com"}
+	inbounds := []model.Inbound{
+		{Name: "n1", Protocol: "naiveproxy", ProtocolFields: map[string]any{"domain": "x.com"}},
+	}
+	specs, err := ResolveDomainCertSpecs(settings, inbounds)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if specs["x.com"].Email != "admin@x.com" {
+		t.Errorf("expected fallback email, got %q", specs["x.com"].Email)
+	}
+}
+
+func TestResolveDomainCertSpecsIncludesHysteria2OnlyDomain(t *testing.T) {
+	settings := model.Settings{PanelAccess: "direct", DefaultAcmeEmail: "admin@x.com"}
+	inbounds := []model.Inbound{
+		{Name: "hy2", Protocol: "hysteria2", ProtocolFields: map[string]any{"domain": "hy.example.com"}},
+	}
+	specs, err := ResolveDomainCertSpecs(settings, inbounds)
+	if err != nil {
+		t.Fatal(err)
+	}
+	spec, ok := specs["hy.example.com"]
+	if !ok {
+		t.Fatalf("expected hysteria2-only domain in specs, got %+v", specs)
+	}
+	if spec.Email != "admin@x.com" {
+		t.Errorf("expected email admin@x.com, got %q", spec.Email)
+	}
+	if len(spec.Owners.HysteriaInboundNames) != 1 || spec.Owners.HysteriaInboundNames[0] != "hy2" {
+		t.Errorf("expected hysteria2 owner hy2, got %+v", spec.Owners.HysteriaInboundNames)
+	}
+}
+
+func TestResolveDomainCertSpecsIgnoresLegacyGlobalEmailForNaive(t *testing.T) {
+	settings := model.Settings{PanelAccess: "direct", Email: "legacy@x.com"}
+	inbounds := []model.Inbound{
+		{Name: "n1", Protocol: "naiveproxy", ProtocolFields: map[string]any{"domain": "x.com"}},
+	}
+	_, err := ResolveDomainCertSpecs(settings, inbounds)
+	if err == nil {
+		t.Fatal("expected error when no explicit/default/panel email is available")
+	}
+}

--- a/internal/caddyassembly/hdd_happy_path_test.go
+++ b/internal/caddyassembly/hdd_happy_path_test.go
@@ -1,7 +1,6 @@
 package caddyassembly_test
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/mikkelchokolate/Veil/internal/bindregistry"
@@ -83,10 +82,10 @@ func TestBuildFinalRenderPlan_NaiveTCP443HappyPath(t *testing.T) {
 	}
 }
 
-// TestBuildFinalRenderPlan_NaiveTCP443ConflictsWithPanelCaddy verifies that a
-// naive inbound on TCP :443 conflicts with the Panel caddy endpoint on the same
-// bind key.
-func TestBuildFinalRenderPlan_NaiveTCP443ConflictsWithPanelCaddy(t *testing.T) {
+// TestBuildFinalRenderPlan_NaiveTCP443MergesWithPanelCaddy verifies that a
+// naive inbound on TCP :443 shares the Panel caddy listener: the naive inbound
+// owns the bind and Panel routes are merged into the same server.
+func TestBuildFinalRenderPlan_NaiveTCP443MergesWithPanelCaddy(t *testing.T) {
 	settings := model.Settings{
 		PanelAccess:       "caddy",
 		PanelDomain:       "panel.hy.flow2go.ru",
@@ -100,12 +99,22 @@ func TestBuildFinalRenderPlan_NaiveTCP443ConflictsWithPanelCaddy(t *testing.T) {
 			model.ClientProfile{Name: "default", Username: "user", Password: "pass", Enabled: true}),
 	}
 
-	_, _, _, err := caddyassembly.BuildFinalRenderPlan(settings, inbounds)
-	if err == nil {
-		t.Fatal("expected bind conflict between Panel caddy and naive inbound on TCP :443")
+	plan, owners, _, err := caddyassembly.BuildFinalRenderPlan(settings, inbounds)
+	if err != nil {
+		t.Fatalf("BuildFinalRenderPlan error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "already owned") {
-		t.Fatalf("expected ownership conflict error, got %v", err)
+
+	key := bindregistry.BindKey{Address: "0.0.0.0", Port: 443, Network: bindregistry.ListenTCP}
+	owner := owners[key]
+	if owner.Kind != bindregistry.BindOwnerNaive || owner.InboundName != "test" {
+		t.Fatalf("expected naive owner on TCP :443, got %+v", owner)
+	}
+	server := plan.Servers[key]
+	if server.Kind != caddyassembly.CaddyOwnerNaive {
+		t.Fatalf("expected naive server, got %+v", server)
+	}
+	if server.PanelDomain != "panel.hy.flow2go.ru" {
+		t.Errorf("server.PanelDomain = %q, want panel.hy.flow2go.ru", server.PanelDomain)
 	}
 }
 

--- a/internal/caddyassembly/hdd_happy_path_test.go
+++ b/internal/caddyassembly/hdd_happy_path_test.go
@@ -1,0 +1,199 @@
+package caddyassembly_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mikkelchokolate/Veil/internal/bindregistry"
+	"github.com/mikkelchokolate/Veil/internal/caddyassembly"
+	"github.com/mikkelchokolate/Veil/internal/model"
+)
+
+func naiveInbound(name, domain string, publicPort int, transport string, profiles ...model.ClientProfile) model.Inbound {
+	return model.Inbound{
+		Name:     name,
+		Protocol: "naiveproxy",
+		Enabled:  true,
+		Profiles: profiles,
+		ProtocolFields: map[string]any{
+			"domain":     domain,
+			"transport":  transport,
+			"publicPort": publicPort,
+		},
+	}
+}
+
+// TestBuildFinalRenderPlan_NaiveTCP443HappyPath verifies the happy path for a
+// single naiveproxy inbound on the default public port.
+func TestBuildFinalRenderPlan_NaiveTCP443HappyPath(t *testing.T) {
+	settings := model.Settings{
+		PanelAccess:              "direct",
+		DefaultInboundPublicPort: 443,
+		DefaultAcmeEmail:         "admin@hy.flow2go.ru",
+		AcmeChallengeMode:        "tls-alpn-01",
+	}
+	inbounds := []model.Inbound{
+		naiveInbound("test", "hy.flow2go.ru", 443, "tcp",
+			model.ClientProfile{Name: "default", Username: "user", Password: "pass", Enabled: true}),
+	}
+
+	plan, owners, issues, err := caddyassembly.BuildFinalRenderPlan(settings, inbounds)
+	if err != nil {
+		t.Fatalf("BuildFinalRenderPlan error: %v", err)
+	}
+	if len(issues) > 0 {
+		t.Fatalf("unexpected validation issues: %+v", issues)
+	}
+
+	naiveKey := bindregistry.BindKey{Address: "0.0.0.0", Port: 443, Network: bindregistry.ListenTCP}
+	owner := owners[naiveKey]
+	if owner.Kind != bindregistry.BindOwnerNaive {
+		t.Fatalf("expected naive owner on TCP :443, got %+v", owner)
+	}
+	if owner.InboundName != "test" {
+		t.Errorf("owner.InboundName = %q, want test", owner.InboundName)
+	}
+
+	server := plan.Servers[naiveKey]
+	if server.Kind != caddyassembly.CaddyOwnerNaive {
+		t.Fatalf("expected naive server, got %+v", server)
+	}
+	if server.Domain != "hy.flow2go.ru" {
+		t.Errorf("server.Domain = %q, want hy.flow2go.ru", server.Domain)
+	}
+	if server.Transport != "tcp" {
+		t.Errorf("server.Transport = %q, want tcp", server.Transport)
+	}
+	if len(server.NaiveUsers) != 1 {
+		t.Fatalf("expected 1 naive user, got %d", len(server.NaiveUsers))
+	}
+	if server.NaiveUsers[0].Username != "user" || server.NaiveUsers[0].Password != "pass" {
+		t.Errorf("unexpected credentials: %+v", server.NaiveUsers[0])
+	}
+
+	spec, ok := plan.Domains["hy.flow2go.ru"]
+	if !ok {
+		t.Fatal("expected domain cert spec for hy.flow2go.ru")
+	}
+	if spec.Email != "admin@hy.flow2go.ru" {
+		t.Errorf("spec.Email = %q, want admin@hy.flow2go.ru", spec.Email)
+	}
+	if len(spec.Owners.NaiveInboundNames) != 1 || spec.Owners.NaiveInboundNames[0] != "test" {
+		t.Errorf("unexpected domain owners: %+v", spec.Owners)
+	}
+}
+
+// TestBuildFinalRenderPlan_NaiveTCP443ConflictsWithPanelCaddy verifies that a
+// naive inbound on TCP :443 conflicts with the Panel caddy endpoint on the same
+// bind key.
+func TestBuildFinalRenderPlan_NaiveTCP443ConflictsWithPanelCaddy(t *testing.T) {
+	settings := model.Settings{
+		PanelAccess:       "caddy",
+		PanelDomain:       "panel.hy.flow2go.ru",
+		PanelPublicPort:   443,
+		PanelEmail:        "admin@hy.flow2go.ru",
+		DefaultAcmeEmail:  "admin@hy.flow2go.ru",
+		AcmeChallengeMode: "tls-alpn-01",
+	}
+	inbounds := []model.Inbound{
+		naiveInbound("test", "hy.flow2go.ru", 443, "tcp",
+			model.ClientProfile{Name: "default", Username: "user", Password: "pass", Enabled: true}),
+	}
+
+	_, _, _, err := caddyassembly.BuildFinalRenderPlan(settings, inbounds)
+	if err == nil {
+		t.Fatal("expected bind conflict between Panel caddy and naive inbound on TCP :443")
+	}
+	if !strings.Contains(err.Error(), "already owned") {
+		t.Fatalf("expected ownership conflict error, got %v", err)
+	}
+}
+
+// TestBuildFinalRenderPlan_NaiveFlatCredentialFallback verifies that
+// inbound.NaiveUsername / inbound.NaivePassword are used as credentials when no
+// profiles are present, matching the validation logic in apply_plan_builder.go
+// and the naiveproxy plugin fallback chain.
+func TestBuildFinalRenderPlan_NaiveFlatCredentialFallback(t *testing.T) {
+	settings := model.Settings{
+		PanelAccess:              "direct",
+		DefaultInboundPublicPort: 443,
+		DefaultAcmeEmail:         "admin@hy.flow2go.ru",
+		AcmeChallengeMode:        "tls-alpn-01",
+	}
+	inbounds := []model.Inbound{{
+		Name:         "test",
+		Protocol:     "naiveproxy",
+		Enabled:      true,
+		NaiveUsername: "flat-user",
+		NaivePassword: "flat-pass",
+		ProtocolFields: map[string]any{
+			"domain":    "hy.flow2go.ru",
+			"transport": "tcp",
+			"publicPort": 443,
+		},
+	}}
+
+	plan, _, _, err := caddyassembly.BuildFinalRenderPlan(settings, inbounds)
+	if err != nil {
+		t.Fatalf("BuildFinalRenderPlan error: %v", err)
+	}
+	server := plan.Servers[bindregistry.BindKey{Address: "0.0.0.0", Port: 443, Network: bindregistry.ListenTCP}]
+	if len(server.NaiveUsers) != 1 {
+		t.Fatalf("expected 1 naive user, got %d", len(server.NaiveUsers))
+	}
+	if server.NaiveUsers[0].Username != "flat-user" || server.NaiveUsers[0].Password != "flat-pass" {
+		t.Errorf("unexpected credentials: %+v", server.NaiveUsers[0])
+	}
+}
+
+// TestBuildFinalRenderPlan_SameDomainDifferentPortsSharedCert verifies that two
+// naive inbounds using the same domain on different public ports share domain
+// certificate ownership while owning distinct bind keys.
+func TestBuildFinalRenderPlan_SameDomainDifferentPortsSharedCert(t *testing.T) {
+	settings := model.Settings{
+		PanelAccess:              "direct",
+		DefaultInboundPublicPort: 443,
+		DefaultAcmeEmail:         "admin@hy.flow2go.ru",
+		AcmeChallengeMode:        "tls-alpn-01",
+	}
+	inbounds := []model.Inbound{
+		naiveInbound("test-a", "hy.flow2go.ru", 443, "tcp",
+			model.ClientProfile{Name: "default", Username: "user-a", Password: "pass-a", Enabled: true}),
+		naiveInbound("test-b", "hy.flow2go.ru", 8443, "tcp",
+			model.ClientProfile{Name: "default", Username: "user-b", Password: "pass-b", Enabled: true}),
+	}
+
+	plan, owners, _, err := caddyassembly.BuildFinalRenderPlan(settings, inbounds)
+	if err != nil {
+		t.Fatalf("BuildFinalRenderPlan error: %v", err)
+	}
+
+	conflicts := bindregistry.ValidateNoConflicts(owners)
+	if len(conflicts) != 0 {
+		t.Fatalf("unexpected bind conflicts: %+v", conflicts)
+	}
+
+	tcp443 := bindregistry.BindKey{Address: "0.0.0.0", Port: 443, Network: bindregistry.ListenTCP}
+	tcp8443 := bindregistry.BindKey{Address: "0.0.0.0", Port: 8443, Network: bindregistry.ListenTCP}
+	if owners[tcp443].InboundName != "test-a" {
+		t.Errorf("TCP :443 owner = %+v, want test-a", owners[tcp443])
+	}
+	if owners[tcp8443].InboundName != "test-b" {
+		t.Errorf("TCP :8443 owner = %+v, want test-b", owners[tcp8443])
+	}
+
+	spec, ok := plan.Domains["hy.flow2go.ru"]
+	if !ok {
+		t.Fatal("expected shared domain cert spec for hy.flow2go.ru")
+	}
+	if len(spec.Owners.NaiveInboundNames) != 2 {
+		t.Fatalf("expected 2 naive owners, got %d: %+v", len(spec.Owners.NaiveInboundNames), spec.Owners.NaiveInboundNames)
+	}
+	if spec.Email != "admin@hy.flow2go.ru" {
+		t.Errorf("spec.Email = %q, want admin@hy.flow2go.ru", spec.Email)
+	}
+
+	if len(plan.Servers) != 2 {
+		t.Fatalf("expected 2 servers, got %d", len(plan.Servers))
+	}
+}

--- a/internal/caddyassembly/hdd_happy_path_test.go
+++ b/internal/caddyassembly/hdd_happy_path_test.go
@@ -130,14 +130,14 @@ func TestBuildFinalRenderPlan_NaiveFlatCredentialFallback(t *testing.T) {
 		AcmeChallengeMode:        "tls-alpn-01",
 	}
 	inbounds := []model.Inbound{{
-		Name:         "test",
-		Protocol:     "naiveproxy",
-		Enabled:      true,
+		Name:          "test",
+		Protocol:      "naiveproxy",
+		Enabled:       true,
 		NaiveUsername: "flat-user",
 		NaivePassword: "flat-pass",
 		ProtocolFields: map[string]any{
-			"domain":    "hy.flow2go.ru",
-			"transport": "tcp",
+			"domain":     "hy.flow2go.ru",
+			"transport":  "tcp",
 			"publicPort": 443,
 		},
 	}}

--- a/internal/caddyassembly/plan.go
+++ b/internal/caddyassembly/plan.go
@@ -208,10 +208,7 @@ func naivePublicPort(settings model.Settings, inbound model.Inbound) int {
 // settings domain so existing state that stores the domain at the top level
 // continues to render.
 func naiveDomain(inbound model.Inbound, settings model.Settings) string {
-	if d := stringField(inbound.ProtocolFields, "domain"); d != "" {
-		return d
-	}
-	return settings.Domain
+	return model.ResolveInboundDomain(inbound, settings)
 }
 
 // naiveFallbackRoot mirrors the naiveproxy plugin helper to avoid an import

--- a/internal/caddyassembly/plan.go
+++ b/internal/caddyassembly/plan.go
@@ -21,7 +21,7 @@ const (
 type CaddyBindOwner struct {
 	Kind         CaddyBindOwnerKind
 	Domain       string
-	PanelDomain  string           // Set when a naive inbound shares the bind with panel access
+	PanelDomain  string // Set when a naive inbound shares the bind with panel access
 	InboundName  string
 	Transport    string           // Inbound transport; used only for Naive owner
 	BackendPort  int              // Panel backend port parsed from PanelListen; used only for Panel owner (or merged naive owner)

--- a/internal/caddyassembly/plan.go
+++ b/internal/caddyassembly/plan.go
@@ -1,0 +1,300 @@
+package caddyassembly
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/mikkelchokolate/Veil/internal/bindregistry"
+	"github.com/mikkelchokolate/Veil/internal/model"
+	veilsettings "github.com/mikkelchokolate/Veil/internal/settings"
+)
+
+type CaddyBindOwnerKind string
+
+const (
+	CaddyOwnerPanel CaddyBindOwnerKind = "panel"
+	CaddyOwnerNaive CaddyBindOwnerKind = "naive"
+)
+
+type CaddyBindOwner struct {
+	Kind         CaddyBindOwnerKind
+	Domain       string
+	PanelDomain  string           // Set when a naive inbound shares the bind with panel access
+	InboundName  string
+	Transport    string           // Inbound transport; used only for Naive owner
+	BackendPort  int              // Panel backend port parsed from PanelListen; used only for Panel owner (or merged naive owner)
+	WebBasePath  string           // Normalized panel web base path; used only for Panel owner (or merged naive owner)
+	NaiveUsers   []CaddyNaiveUser // Only for naive owner
+	FallbackRoot string           // Only for naive owner
+}
+
+// CaddyNaiveUser is a minimal credential pair for the forward_proxy handler.
+type CaddyNaiveUser struct {
+	Username string
+	Password string
+}
+
+type CaddyRenderPlan struct {
+	Servers              map[bindregistry.BindKey]CaddyBindOwner
+	ACMEChallenges       map[bindregistry.BindKey]AcmeChallengeOwner
+	Domains              map[string]CaddyDomainCertSpec
+	DefaultChallengeMode string
+}
+
+func BuildRenderPlan(
+	settings model.Settings,
+	inbounds []model.Inbound,
+	challengeBinds map[bindregistry.BindKey]AcmeChallengeOwner,
+) (CaddyRenderPlan, map[bindregistry.BindKey]bindregistry.BindOwner, error) {
+	owners := make(map[bindregistry.BindKey]bindregistry.BindOwner)
+	servers := make(map[bindregistry.BindKey]CaddyBindOwner)
+
+	if settings.PanelAccess == "caddy" {
+		panelDomain := settings.PanelDomain
+		if panelDomain == "" {
+			panelDomain = settings.Domain
+		}
+		panelPublicPort := settings.PanelPublicPort
+		if panelPublicPort == 0 {
+			panelPublicPort = 443
+		}
+		if panelDomain != "" {
+			key := bindregistry.BindKey{Address: "0.0.0.0", Port: panelPublicPort, Network: bindregistry.ListenTCP}
+			if err := setOwner(owners, key, bindregistry.BindOwner{Kind: bindregistry.BindOwnerPanelCaddy, ServiceName: "veil-caddy.service"}); err != nil {
+				return CaddyRenderPlan{}, nil, err
+			}
+			if err := setServer(servers, key, CaddyBindOwner{
+				Kind:        CaddyOwnerPanel,
+				Domain:      panelDomain,
+				BackendPort: panelBackendPort(settings.PanelListen),
+				WebBasePath: veilsettings.NormalizeWebBasePath(settings.WebBasePath),
+			}); err != nil {
+				return CaddyRenderPlan{}, nil, err
+			}
+		}
+	}
+
+	for _, inb := range inbounds {
+		if inb.Protocol != "naiveproxy" || !inb.Enabled {
+			continue
+		}
+		transport := naiveTransport(inb)
+		if transport != "tcp" {
+			return CaddyRenderPlan{}, nil, fmt.Errorf("naive inbound %q uses unsupported transport %q (only tcp is supported)", inb.Name, transport)
+		}
+		port := naivePublicPort(settings, inb)
+		domain := naiveDomain(inb, settings)
+		users := naiveUsers(inb, settings)
+		fallbackRoot := naiveFallbackRoot(inb, settings)
+		if err := addNaiveBinds(transport, port, domain, inb.Name, users, fallbackRoot, owners, servers); err != nil {
+			return CaddyRenderPlan{}, nil, err
+		}
+	}
+
+	domains, err := ResolveDomainCertSpecs(settings, inbounds)
+	if err != nil {
+		return CaddyRenderPlan{}, nil, err
+	}
+
+	return CaddyRenderPlan{
+		Servers:              servers,
+		ACMEChallenges:       challengeBinds,
+		Domains:              domains,
+		DefaultChallengeMode: settings.AcmeChallengeMode,
+	}, owners, nil
+}
+
+// BuildFinalRenderPlan constructs the complete Caddy render plan including ACME
+// challenge binds. It first builds the server-owner map, plans challenge binds
+// based on those owners, merges challenge owners into the global owner map, and
+// returns the final plan along with any validation issues raised by challenge
+// planning.
+func BuildFinalRenderPlan(
+	settings model.Settings,
+	inbounds []model.Inbound,
+) (CaddyRenderPlan, map[bindregistry.BindKey]bindregistry.BindOwner, []model.ValidationIssue, error) {
+	plan, owners, err := BuildRenderPlan(settings, inbounds, nil)
+	if err != nil {
+		return CaddyRenderPlan{}, nil, nil, err
+	}
+
+	challengeBinds, issues := PlanAcmeChallengeBinds(settings.AcmeChallengeMode, plan.Domains, owners)
+	for key := range challengeBinds {
+		owners[key] = bindregistry.BindOwner{Kind: bindregistry.BindOwnerAcmeChallenge, ServiceName: "veil-caddy.service"}
+	}
+	plan.ACMEChallenges = challengeBinds
+	return plan, owners, issues, nil
+}
+
+func addNaiveBinds(transport string, port int, domain, name string, users []CaddyNaiveUser, fallbackRoot string, owners map[bindregistry.BindKey]bindregistry.BindOwner, servers map[bindregistry.BindKey]CaddyBindOwner) error {
+	if transport == "tcp" || transport == "dual" {
+		key := bindregistry.BindKey{Address: "0.0.0.0", Port: port, Network: bindregistry.ListenTCP}
+		if err := mergeNaiveBind(key, domain, name, transport, users, fallbackRoot, owners, servers); err != nil {
+			return err
+		}
+	}
+	if transport == "quic" || transport == "dual" {
+		key := bindregistry.BindKey{Address: "0.0.0.0", Port: port, Network: bindregistry.ListenUDP}
+		if err := setOwner(owners, key, bindregistry.BindOwner{Kind: bindregistry.BindOwnerNaive, ServiceName: "veil-caddy.service", InboundName: name}); err != nil {
+			return err
+		}
+		if err := setServer(servers, key, CaddyBindOwner{Kind: CaddyOwnerNaive, Domain: domain, InboundName: name, Transport: transport, NaiveUsers: users, FallbackRoot: fallbackRoot}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func mergeNaiveBind(key bindregistry.BindKey, domain, name, transport string, users []CaddyNaiveUser, fallbackRoot string, owners map[bindregistry.BindKey]bindregistry.BindOwner, servers map[bindregistry.BindKey]CaddyBindOwner) error {
+	newOwner := bindregistry.BindOwner{Kind: bindregistry.BindOwnerNaive, ServiceName: "veil-caddy.service", InboundName: name}
+	newServer := CaddyBindOwner{Kind: CaddyOwnerNaive, Domain: domain, InboundName: name, Transport: transport, NaiveUsers: users, FallbackRoot: fallbackRoot}
+
+	existingOwner, ownerExists := owners[key]
+	existingServer, serverExists := servers[key]
+	if !ownerExists {
+		owners[key] = newOwner
+		servers[key] = newServer
+		return nil
+	}
+
+	if existingOwner.Kind == bindregistry.BindOwnerPanelCaddy && serverExists && existingServer.Kind == CaddyOwnerPanel {
+		newServer.PanelDomain = existingServer.Domain
+		newServer.BackendPort = existingServer.BackendPort
+		newServer.WebBasePath = existingServer.WebBasePath
+		owners[key] = newOwner
+		servers[key] = newServer
+		return nil
+	}
+
+	if existingOwner == newOwner {
+		return nil
+	}
+	return fmt.Errorf("%s %s:%d is already owned by %s %s", key.Network, key.Address, key.Port, existingOwner.Kind, existingOwner.InboundName)
+}
+
+// naiveTransport mirrors the behavior of the naiveproxy plugin helper so that
+// caddyassembly can remain independent of the protocol package and avoid an
+// import cycle with the renderer.
+func naiveTransport(inbound model.Inbound) string {
+	t := stringField(inbound.ProtocolFields, "transport")
+	if t == "" {
+		return "tcp"
+	}
+	return t
+}
+
+// naivePublicPort mirrors the naiveproxy plugin helper.
+func naivePublicPort(settings model.Settings, inbound model.Inbound) int {
+	if v, ok := inbound.ProtocolFields["publicPort"]; ok {
+		if n, ok := v.(float64); ok {
+			return int(n)
+		}
+		if n, ok := v.(int); ok {
+			return n
+		}
+	}
+	if inbound.Port != 0 {
+		return inbound.Port
+	}
+	if settings.DefaultInboundPublicPort != 0 {
+		return settings.DefaultInboundPublicPort
+	}
+	return 443
+}
+
+// naiveDomain mirrors the naiveproxy plugin helper, falling back to the global
+// settings domain so existing state that stores the domain at the top level
+// continues to render.
+func naiveDomain(inbound model.Inbound, settings model.Settings) string {
+	if d := stringField(inbound.ProtocolFields, "domain"); d != "" {
+		return d
+	}
+	return settings.Domain
+}
+
+// naiveFallbackRoot mirrors the naiveproxy plugin helper to avoid an import
+// cycle with the renderer. It falls back to the built-in default web root.
+func naiveFallbackRoot(inbound model.Inbound, settings model.Settings) string {
+	if root := stringField(inbound.ProtocolFields, "fallbackRoot"); root != "" {
+		return root
+	}
+	if inbound.FallbackRoot != "" {
+		return inbound.FallbackRoot
+	}
+	if settings.FallbackRoot != "" {
+		return settings.FallbackRoot
+	}
+	return "/var/lib/veil/www"
+}
+
+func naiveUsers(inbound model.Inbound, settings model.Settings) []CaddyNaiveUser {
+	var users []CaddyNaiveUser
+	for _, p := range inbound.Profiles {
+		if !p.Enabled || strings.TrimSpace(p.Username) == "" || strings.TrimSpace(p.Password) == "" {
+			continue
+		}
+		users = append(users, CaddyNaiveUser{Username: p.Username, Password: p.Password})
+	}
+	if len(users) > 0 {
+		return users
+	}
+	username := stringField(inbound.ProtocolFields, "naiveUsername")
+	if username == "" {
+		username = strings.TrimSpace(inbound.NaiveUsername)
+	}
+	if username == "" {
+		username = stringField(settings.ProtocolFields, "naiveUsername")
+	}
+	if username == "" {
+		username = settings.NaiveUsername
+	}
+	password := strings.TrimSpace(inbound.Password)
+	if password == "" {
+		password = stringField(inbound.ProtocolFields, "naivePassword")
+	}
+	if password == "" {
+		password = strings.TrimSpace(inbound.NaivePassword)
+	}
+	if password == "" {
+		password = stringField(settings.ProtocolFields, "naivePassword")
+	}
+	if password == "" {
+		password = settings.NaivePassword
+	}
+	if username != "" && password != "" {
+		return []CaddyNaiveUser{{Username: username, Password: password}}
+	}
+	return nil
+}
+
+func setOwner(owners map[bindregistry.BindKey]bindregistry.BindOwner, key bindregistry.BindKey, owner bindregistry.BindOwner) error {
+	if existing, ok := owners[key]; ok && existing != owner {
+		return fmt.Errorf("%s %s:%d is already owned by %s %s", key.Network, key.Address, key.Port, existing.Kind, existing.InboundName)
+	}
+	owners[key] = owner
+	return nil
+}
+
+func setServer(servers map[bindregistry.BindKey]CaddyBindOwner, key bindregistry.BindKey, server CaddyBindOwner) error {
+	if existing, ok := servers[key]; ok {
+		if existing.Kind != server.Kind || existing.InboundName != server.InboundName {
+			return fmt.Errorf("%s %s:%d already has a %s server", key.Network, key.Address, key.Port, existing.Kind)
+		}
+	}
+	servers[key] = server
+	return nil
+}
+
+func panelBackendPort(panelListen string) int {
+	_, portText, err := net.SplitHostPort(panelListen)
+	if err != nil {
+		return 0
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil || port <= 0 || port > 65535 {
+		return 0
+	}
+	return port
+}

--- a/internal/caddyassembly/plan_test.go
+++ b/internal/caddyassembly/plan_test.go
@@ -1,0 +1,68 @@
+package caddyassembly
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mikkelchokolate/Veil/internal/bindregistry"
+	"github.com/mikkelchokolate/Veil/internal/model"
+)
+
+func TestBuildRenderPlanPanelAndNaive(t *testing.T) {
+	settings := model.Settings{
+		PanelAccess:     "caddy",
+		PanelDomain:     "panel.example.com",
+		PanelPublicPort: 443,
+		PanelEmail:      "admin@example.com",
+	}
+	inbounds := []model.Inbound{
+		{
+			Name:     "naive-1",
+			Protocol: "naiveproxy",
+			Enabled:  true,
+			ProtocolFields: map[string]any{
+				"domain":     "proxy.example.com",
+				"transport":  "tcp",
+				"publicPort": 8443,
+			},
+		},
+	}
+	plan, owners, err := BuildRenderPlan(settings, inbounds, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	panelKey := bindregistry.BindKey{Address: "0.0.0.0", Port: 443, Network: bindregistry.ListenTCP}
+	if owners[panelKey].Kind != bindregistry.BindOwnerPanelCaddy {
+		t.Error("expected Panel Caddy owner on TCP 443")
+	}
+	if plan.Servers[panelKey].Kind != CaddyOwnerPanel {
+		t.Error("expected Panel server in render plan")
+	}
+	naiveKey := bindregistry.BindKey{Address: "0.0.0.0", Port: 8443, Network: bindregistry.ListenTCP}
+	if owners[naiveKey].Kind != bindregistry.BindOwnerNaive {
+		t.Error("expected naive owner on TCP 8443")
+	}
+}
+
+func TestBuildRenderPlanRejectsNaiveNonTCPTransport(t *testing.T) {
+	settings := model.Settings{}
+	inbounds := []model.Inbound{
+		{
+			Name:     "naive-quic",
+			Protocol: "naiveproxy",
+			Enabled:  true,
+			ProtocolFields: map[string]any{
+				"domain":     "proxy.example.com",
+				"transport":  "quic",
+				"publicPort": 8443,
+			},
+		},
+	}
+	_, _, err := BuildRenderPlan(settings, inbounds, nil)
+	if err == nil {
+		t.Fatal("expected error for non-tcp naive transport")
+	}
+	if !strings.Contains(err.Error(), "only tcp is supported") {
+		t.Fatalf("expected unsupported transport error, got %v", err)
+	}
+}

--- a/internal/caddycapabilities/capabilities.go
+++ b/internal/caddycapabilities/capabilities.go
@@ -1,0 +1,73 @@
+package caddycapabilities
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+)
+
+type CaddyCapabilities struct {
+	ForwardProxy bool
+	HTTP3        bool
+	H3Only       bool
+}
+
+type caddyModule struct {
+	Name string `json:"module_name"`
+}
+
+func Probe(binaryPath string) (CaddyCapabilities, error) {
+	if binaryPath == "" {
+		binaryPath = "caddy"
+	}
+	out, err := exec.Command(binaryPath, "list-modules", "--json").Output()
+	if err != nil {
+		return CaddyCapabilities{}, fmt.Errorf("caddy list-modules failed: %w", err)
+	}
+	modules, err := parseModules(out)
+	if err != nil {
+		return CaddyCapabilities{}, err
+	}
+	caps := CaddyCapabilities{
+		ForwardProxy: hasModule(modules, "http.handlers.forward_proxy"),
+	}
+	// HTTP3 is available in standard Caddy builds; this flag is set true when
+	// the base http app module is present. H3Only is intentionally left false
+	// here and verified behaviorally before `quic` transport is accepted.
+	caps.HTTP3 = hasModule(modules, "http")
+	return caps, nil
+}
+
+func hasModule(modules []caddyModule, name string) bool {
+	for _, m := range modules {
+		if m.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func parseModules(data []byte) ([]caddyModule, error) {
+	var modules []caddyModule
+	if err := json.Unmarshal(data, &modules); err != nil {
+		return nil, err
+	}
+	return modules, nil
+}
+
+func parseModuleList(data []byte) (CaddyCapabilities, error) {
+	modules, err := parseModules(data)
+	if err != nil {
+		return CaddyCapabilities{}, err
+	}
+	var caps CaddyCapabilities
+	for _, m := range modules {
+		switch m.Name {
+		case "http.handlers.forward_proxy":
+			caps.ForwardProxy = true
+		case "http":
+			// HTTP base present
+		}
+	}
+	return caps, nil
+}

--- a/internal/caddycapabilities/capabilities_test.go
+++ b/internal/caddycapabilities/capabilities_test.go
@@ -1,0 +1,19 @@
+package caddycapabilities
+
+import "testing"
+
+func TestProbeParsesModuleList(t *testing.T) {
+	// A mock binary that prints a module list matching Caddy's `caddy list-modules --json` shape.
+	// For the plan we test parsing of a known JSON fragment.
+	input := `[
+	  {"module_name":"http.handlers.forward_proxy"},
+	  {"module_name":"http"}
+	]`
+	caps, err := parseModuleList([]byte(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !caps.ForwardProxy {
+		t.Error("expected ForwardProxy=true")
+	}
+}

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -16,7 +16,7 @@ func TestConfigValidateValidState(t *testing.T) {
     "panelListen": "127.0.0.1:2096",
     "mode": "server",
     "domain": "vpn.example.com",
-    "email": "admin@example.com",
+    "defaultAcmeEmail": "admin@example.com",
     "naiveUsername": "veil",
     "naivePassword": "secret"
   },
@@ -184,7 +184,7 @@ func TestConfigValidateRejectsPanelCaddyTCP443Conflict(t *testing.T) {
 	tmpDir := t.TempDir()
 	statePath := filepath.Join(tmpDir, "state.json")
 	state := `{
-  "settings": {"panelListen": "127.0.0.1:2096", "panelAccess":"caddy", "webBasePath":"/panel/", "mode": "server", "domain":"panel.example.com", "email":"admin@example.com"},
+  "settings": {"panelListen": "127.0.0.1:2096", "panelAccess":"caddy", "webBasePath":"/panel/", "mode": "server", "panelDomain":"panel.example.com", "panelEmail":"admin@example.com"},
   "inbounds": [
     {"name": "mieru-tcp", "protocol": "mieru", "transport": "tcp", "port": 443, "enabled": true, "password":"secret"}
   ],
@@ -204,7 +204,7 @@ func TestConfigValidateRejectsPanelCaddyTCP443Conflict(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for Panel Caddy TCP/443 conflict")
 	}
-	if !strings.Contains(out.String(), "panel caddy access uses 443/tcp") {
+	if !strings.Contains(out.String(), "is claimed by multiple owners") {
 		t.Fatalf("expected Panel Caddy TCP/443 conflict error, got: %s", out.String())
 	}
 }

--- a/internal/cli/install_apply.go
+++ b/internal/cli/install_apply.go
@@ -118,8 +118,8 @@ func applyRURecommendedInstall(cmd *cobra.Command, profile installer.RURecommend
 			// the reused base path so Caddy routes the same path the panel actually
 			// serves (VEIL_WEB_BASE_PATH); otherwise an in-place switch to caddy
 			// mode 404s.
-			if profile.Caddyfile != "" && profile.WebBasePath != "" {
-				profile.Caddyfile = strings.ReplaceAll(profile.Caddyfile, profile.WebBasePath, snapshot.Settings.WebBasePath)
+			if profile.CaddyJSON != "" && profile.WebBasePath != "" {
+				profile.CaddyJSON = strings.ReplaceAll(profile.CaddyJSON, profile.WebBasePath, snapshot.Settings.WebBasePath)
 			}
 			profile.WebBasePath = snapshot.Settings.WebBasePath
 		}

--- a/internal/cli/install_apply_audit_backup_test.go
+++ b/internal/cli/install_apply_audit_backup_test.go
@@ -44,7 +44,7 @@ func TestInstallRURecommendedApplyWritesFilesWhenConfirmed(t *testing.T) {
 		t.Fatalf("unexpected error: %v\n%s", err, out.String())
 	}
 	got := out.String()
-	for _, want := range []string{"Written files:", "Caddyfile", "index.html", "veil.service", "veil-caddy@.service", "Panel port: 2096 (user selected)", "Panel URL: https://example.com/"} {
+	for _, want := range []string{"Written files:", "config.json", "index.html", "veil.service", "veil-caddy.service", "Panel port: 2096 (user selected)", "Panel URL: https://example.com/"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("output missing %q:\n%s", want, got)
 		}
@@ -54,14 +54,14 @@ func TestInstallRURecommendedApplyWritesFilesWhenConfirmed(t *testing.T) {
 			t.Fatalf("Panel Caddy install should not write %q:\n%s", unwanted, got)
 		}
 	}
-	// Caddyfile must include reverse_proxy to panel port
-	caddyPath := filepath.Join(dir, "etc/veil/generated/caddy/panel.Caddyfile")
+	// Caddy JSON must include panel backend port
+	caddyPath := filepath.Join(dir, "etc/veil/generated/caddy/config.json")
 	body, err := os.ReadFile(caddyPath)
 	if err != nil {
-		t.Fatalf("read Caddyfile: %v", err)
+		t.Fatalf("read Caddy JSON: %v", err)
 	}
-	if !strings.Contains(string(body), "reverse_proxy 127.0.0.1:2096") {
-		t.Fatalf("Caddyfile missing reverse_proxy:\n%s", string(body))
+	if !strings.Contains(string(body), "127.0.0.1:2096") {
+		t.Fatalf("Caddy JSON missing panel backend:\n%s", string(body))
 	}
 }
 

--- a/internal/cli/install_default_panel_only_test.go
+++ b/internal/cli/install_default_panel_only_test.go
@@ -16,7 +16,7 @@ func TestInstallCommandDefaultsToPanelOnlyProfile(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("default install dry-run should be panel-only: %v\n%s", err, out.String())
 	}
-	if !strings.Contains(out.String(), "Panel port: 2096 (default)") || !strings.Contains(out.String(), "Panel access: https://127.0.0.1:2096/") || strings.Contains(out.String(), "Generated Caddyfile") {
+	if !strings.Contains(out.String(), "Panel port: 2096 (default)") || !strings.Contains(out.String(), "Panel access: https://127.0.0.1:2096/") || strings.Contains(out.String(), "Generated Caddy JSON") {
 		t.Fatalf("unexpected default install output:\n%s", out.String())
 	}
 }

--- a/internal/cli/install_panel_caddy_test.go
+++ b/internal/cli/install_panel_caddy_test.go
@@ -21,7 +21,7 @@ func TestInstallPanelCaddyAccessPrintsPanelURLWithoutProxyStack(t *testing.T) {
 		t.Fatalf("install dry-run: %v\n%s", err, out.String())
 	}
 	got := out.String()
-	for _, want := range []string{"Install scope: Panel", "Panel URL: https://panel.example.com/", "Generated Caddyfile", "reverse_proxy 127.0.0.1:2096"} {
+	for _, want := range []string{"Install scope: Panel", "Panel URL: https://panel.example.com/", "Generated Caddy JSON", "127.0.0.1:2096"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("output missing %q:\n%s", want, got)
 		}
@@ -65,7 +65,7 @@ func TestInstallPanelCaddyAccessUsesResolvedCaddyBinaryInSystemdUnit(t *testing.
 	var gotPaths installer.ApplyPaths
 	installApplyFunc = func(profile installer.RURecommendedProfile, paths installer.ApplyPaths) (installer.ApplyResult, error) {
 		gotPaths = paths
-		return installer.ApplyResult{WrittenFiles: []string{"/etc/systemd/system/veil-caddy@.service"}}, nil
+		return installer.ApplyResult{WrittenFiles: []string{"/etc/systemd/system/veil-caddy.service"}}, nil
 	}
 	commandLookPath = func(name string) (string, error) {
 		if name == "caddy" {

--- a/internal/cli/install_panel_only_test.go
+++ b/internal/cli/install_panel_only_test.go
@@ -17,7 +17,7 @@ func TestInstallDryRunPanelOnlyDoesNotRequireDomainEmailOrProxyPort(t *testing.T
 		t.Fatalf("panel-only dry-run should not require domain/email/port: %v\n%s", err, out.String())
 	}
 	got := out.String()
-	if !strings.Contains(got, "Panel access: https://") || strings.Contains(got, "Generated Caddyfile") || strings.Contains(got, "Generated Hysteria2 server.yaml") {
+	if !strings.Contains(got, "Panel access: https://") || strings.Contains(got, "Generated Caddy JSON") || strings.Contains(got, "Generated Hysteria2 server.yaml") {
 		t.Fatalf("unexpected panel-only dry-run output:\n%s", got)
 	}
 }

--- a/internal/cli/packaging_docs_test.go
+++ b/internal/cli/packaging_docs_test.go
@@ -77,7 +77,7 @@ func TestGitHubActionsArePinnedAndSecurityScanned(t *testing.T) {
 		t.Fatal(err)
 	}
 	ciWorkflow := strings.ReplaceAll(string(ci), "\r\n", "\n")
-	for _, want := range []string{"docker-build:", "Docker image build", "docker build --pull --tag veil:ci ."} {
+	for _, want := range []string{"docker-build:", "Docker image build", "docker build", "veil:ci"} {
 		if !strings.Contains(ciWorkflow, want) {
 			t.Fatalf("ci.yml missing Docker build verification %q", want)
 		}
@@ -127,7 +127,7 @@ func TestNfpmConfigShipsBinaryAndUnits(t *testing.T) {
 		"veil.service",
 		"veil-backup.service",
 		"veil-backup.timer",
-		"veil-caddy@.service",
+		"veil-caddy.service",
 		"veil-hysteria2@.service",
 		"veil-olcrtc@.service",
 		"veil-mieru.service",
@@ -162,7 +162,7 @@ func TestPackageScriptsExist(t *testing.T) {
 
 func TestSystemdUnitsShipHardenedByDefault(t *testing.T) {
 	runtimeUnits := []string{
-		"../../packaging/systemd/veil-caddy@.service",
+		"../../packaging/systemd/veil-caddy.service",
 		"../../packaging/systemd/veil-hysteria2@.service",
 		"../../packaging/systemd/veil-olcrtc@.service",
 		"../../packaging/systemd/veil-mieru.service",

--- a/internal/cli/uninstall_test.go
+++ b/internal/cli/uninstall_test.go
@@ -113,7 +113,7 @@ func TestUninstallYesExecutesUninstall(t *testing.T) {
 	}
 
 	// Verify services are stopped
-	for _, svc := range []string{"veil.service", "veil-caddy@.service", "veil-hysteria2@.service", "veil-olcrtc@.service", "veil-warp.service", "veil-mieru.service"} {
+	for _, svc := range []string{"veil.service", "veil-caddy.service", "veil-hysteria2@.service", "veil-olcrtc@.service", "veil-warp.service", "veil-mieru.service"} {
 		found := false
 		for _, s := range stopped {
 			if s == svc {

--- a/internal/clientaccess/client_access_mieru_aggregation_test.go
+++ b/internal/clientaccess/client_access_mieru_aggregation_test.go
@@ -5,6 +5,18 @@ import (
 	"testing"
 )
 
+func TestBuildClientLinksMieruIgnoresInboundDomain(t *testing.T) {
+	response, err := BuildClientLinks(Settings{}, []Inbound{
+		{Name: "mieru-tcp", Protocol: "mieru", Transport: "tcp", Port: 443, Enabled: true, Password: "mieru-pass", ProtocolFields: map[string]any{"domain": "inbound.example.com"}},
+	})
+	if err != nil {
+		t.Fatalf("BuildClientLinks: %v", err)
+	}
+	if response.Count != 0 {
+		t.Fatalf("expected no mieru links when only inbound domain is set, got %+v", response)
+	}
+}
+
 func TestBuildClientLinksAggregatesMieruTransportBindingsForClientProfile(t *testing.T) {
 	response, err := BuildClientLinks(Settings{Domain: "vpn.example.com"}, []Inbound{
 		{Name: "mieru-tcp", Protocol: "mieru", Transport: "tcp", Port: 443, Enabled: true, Profiles: []ClientProfile{{Name: "alice", Password: "alice-pass", Enabled: true}}},

--- a/internal/clientaccess/client_access_protocol_registry.go
+++ b/internal/clientaccess/client_access_protocol_registry.go
@@ -144,16 +144,16 @@ func newProtocolClientLink(input ClientAccessLinkInput) ClientLink {
 }
 
 func naiveProfileClientLink(input ClientAccessLinkInput) (ClientLink, bool) {
-	if !hasClientEndpoint(input.Settings) {
+	if !hasClientEndpoint(input) {
 		return ClientLink{}, false
 	}
 	link := newProtocolClientLink(input)
-	link.URI = NaiveClientURI(clientEndpoint(input.Settings), input.Inbound.Port, input.Credential.Username, input.Credential.Password)
+	link.URI = NaiveClientURI(clientEndpointFor(input), input.Inbound.Port, input.Credential.Username, input.Credential.Password)
 	return link, true
 }
 
 func naiveFallbackClientLink(input ClientAccessLinkInput) (ClientLink, bool) {
-	if !hasClientEndpoint(input.Settings) {
+	if !hasClientEndpoint(input) {
 		return ClientLink{}, false
 	}
 	link := newProtocolClientLink(input)
@@ -168,7 +168,7 @@ func naiveFallbackClientLink(input ClientAccessLinkInput) (ClientLink, bool) {
 	if username == "" {
 		username = protocolString(input.Settings.ProtocolFields, "naiveUsername", input.Settings.NaiveUsername)
 	}
-	link.URI = NaiveClientURI(clientEndpoint(input.Settings), input.Inbound.Port, username, password)
+	link.URI = NaiveClientURI(clientEndpointFor(input), input.Inbound.Port, username, password)
 	return link, true
 }
 
@@ -186,16 +186,16 @@ func hysteria2Insecure(input ClientAccessLinkInput) bool {
 }
 
 func hysteria2ProfileClientLink(input ClientAccessLinkInput) (ClientLink, bool) {
-	if !hasClientEndpoint(input.Settings) {
+	if !hasClientEndpoint(input) {
 		return ClientLink{}, false
 	}
 	link := newProtocolClientLink(input)
-	link.URI = Hysteria2UserPassClientURI(clientEndpoint(input.Settings), input.Inbound.Port, input.Credential.Username, input.Credential.Password, link.Name, hysteria2Insecure(input))
+	link.URI = Hysteria2UserPassClientURI(clientEndpointFor(input), input.Inbound.Port, input.Credential.Username, input.Credential.Password, link.Name, hysteria2Insecure(input))
 	return link, true
 }
 
 func hysteria2FallbackClientLink(input ClientAccessLinkInput) (ClientLink, bool) {
-	if !hasClientEndpoint(input.Settings) {
+	if !hasClientEndpoint(input) {
 		return ClientLink{}, false
 	}
 	link := newProtocolClientLink(input)
@@ -206,12 +206,12 @@ func hysteria2FallbackClientLink(input ClientAccessLinkInput) (ClientLink, bool)
 			password = protocolString(input.Settings.ProtocolFields, "hysteria2Password", input.Settings.Hysteria2Password)
 		}
 	}
-	link.URI = Hysteria2ClientURI(clientEndpoint(input.Settings), input.Inbound.Port, password, input.Inbound.Name, hysteria2Insecure(input))
+	link.URI = Hysteria2ClientURI(clientEndpointFor(input), input.Inbound.Port, password, input.Inbound.Name, hysteria2Insecure(input))
 	return link, true
 }
 
 func mieruClientConfigLink(input ClientAccessLinkInput) (ClientLink, bool) {
-	if !hasClientEndpoint(input.Settings) {
+	if clientEndpoint(input.Settings) == "" {
 		return ClientLink{}, false
 	}
 	link := newProtocolClientLink(input)
@@ -228,10 +228,23 @@ func mieruFallbackClientLink(input ClientAccessLinkInput) (ClientLink, bool) {
 	return mieruClientConfigLink(input)
 }
 
-func hasClientEndpoint(settings Settings) bool {
-	return clientEndpoint(settings) != ""
+func hasClientEndpoint(input ClientAccessLinkInput) bool {
+	return clientEndpointFor(input) != ""
 }
 
+func clientEndpointFor(input ClientAccessLinkInput) string {
+	if input.Inbound.ProtocolFields != nil {
+		if d, ok := input.Inbound.ProtocolFields["domain"].(string); ok {
+			if v := strings.TrimSpace(d); v != "" {
+				return v
+			}
+		}
+	}
+	return strings.TrimSpace(input.Settings.Domain)
+}
+
+// clientEndpoint returns the global settings domain. Kept for callers that only
+// have settings and no inbound context (e.g. mieru aggregation).
 func clientEndpoint(settings Settings) string {
 	return strings.TrimSpace(settings.Domain)
 }

--- a/internal/clientaccess/client_access_protocol_registry.go
+++ b/internal/clientaccess/client_access_protocol_registry.go
@@ -1,6 +1,10 @@
 package clientaccess
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/mikkelchokolate/Veil/internal/model"
+)
 
 func protocolString(m map[string]any, key, fallback string) string {
 	if m == nil {
@@ -148,7 +152,7 @@ func naiveProfileClientLink(input ClientAccessLinkInput) (ClientLink, bool) {
 		return ClientLink{}, false
 	}
 	link := newProtocolClientLink(input)
-	link.URI = NaiveClientURI(clientEndpointFor(input), input.Inbound.Port, input.Credential.Username, input.Credential.Password)
+	link.URI = NaiveClientURI(model.ResolveInboundDomain(input.Inbound, input.Settings), input.Inbound.Port, input.Credential.Username, input.Credential.Password)
 	return link, true
 }
 
@@ -168,7 +172,7 @@ func naiveFallbackClientLink(input ClientAccessLinkInput) (ClientLink, bool) {
 	if username == "" {
 		username = protocolString(input.Settings.ProtocolFields, "naiveUsername", input.Settings.NaiveUsername)
 	}
-	link.URI = NaiveClientURI(clientEndpointFor(input), input.Inbound.Port, username, password)
+	link.URI = NaiveClientURI(model.ResolveInboundDomain(input.Inbound, input.Settings), input.Inbound.Port, username, password)
 	return link, true
 }
 
@@ -190,7 +194,7 @@ func hysteria2ProfileClientLink(input ClientAccessLinkInput) (ClientLink, bool) 
 		return ClientLink{}, false
 	}
 	link := newProtocolClientLink(input)
-	link.URI = Hysteria2UserPassClientURI(clientEndpointFor(input), input.Inbound.Port, input.Credential.Username, input.Credential.Password, link.Name, hysteria2Insecure(input))
+	link.URI = Hysteria2UserPassClientURI(model.ResolveInboundDomain(input.Inbound, input.Settings), input.Inbound.Port, input.Credential.Username, input.Credential.Password, link.Name, hysteria2Insecure(input))
 	return link, true
 }
 
@@ -206,7 +210,7 @@ func hysteria2FallbackClientLink(input ClientAccessLinkInput) (ClientLink, bool)
 			password = protocolString(input.Settings.ProtocolFields, "hysteria2Password", input.Settings.Hysteria2Password)
 		}
 	}
-	link.URI = Hysteria2ClientURI(clientEndpointFor(input), input.Inbound.Port, password, input.Inbound.Name, hysteria2Insecure(input))
+	link.URI = Hysteria2ClientURI(model.ResolveInboundDomain(input.Inbound, input.Settings), input.Inbound.Port, password, input.Inbound.Name, hysteria2Insecure(input))
 	return link, true
 }
 
@@ -229,18 +233,7 @@ func mieruFallbackClientLink(input ClientAccessLinkInput) (ClientLink, bool) {
 }
 
 func hasClientEndpoint(input ClientAccessLinkInput) bool {
-	return clientEndpointFor(input) != ""
-}
-
-func clientEndpointFor(input ClientAccessLinkInput) string {
-	if input.Inbound.ProtocolFields != nil {
-		if d, ok := input.Inbound.ProtocolFields["domain"].(string); ok {
-			if v := strings.TrimSpace(d); v != "" {
-				return v
-			}
-		}
-	}
-	return strings.TrimSpace(input.Settings.Domain)
+	return model.ResolveInboundDomain(input.Inbound, input.Settings) != ""
 }
 
 // clientEndpoint returns the global settings domain. Kept for callers that only

--- a/internal/clientaccess/client_access_protocol_registry.go
+++ b/internal/clientaccess/client_access_protocol_registry.go
@@ -236,10 +236,11 @@ func hasClientEndpoint(input ClientAccessLinkInput) bool {
 	return model.ResolveInboundDomain(input.Inbound, input.Settings) != ""
 }
 
-// clientEndpoint returns the global settings domain. Kept for callers that only
-// have settings and no inbound context (e.g. mieru aggregation).
+// clientEndpoint returns the global settings domain, lowercased for
+// consistency with model.ResolveInboundDomain. Kept for callers that only have
+// settings and no inbound context (e.g. mieru aggregation).
 func clientEndpoint(settings Settings) string {
-	return strings.TrimSpace(settings.Domain)
+	return strings.ToLower(strings.TrimSpace(settings.Domain))
 }
 
 func olcrtcProfileClientLink(input ClientAccessLinkInput) (ClientLink, bool) {

--- a/internal/clientaccess/client_access_protocol_registry_more_test.go
+++ b/internal/clientaccess/client_access_protocol_registry_more_test.go
@@ -3,6 +3,8 @@ package clientaccess
 import (
 	"strings"
 	"testing"
+
+	"github.com/mikkelchokolate/Veil/internal/model"
 )
 
 func TestProtocolStringBranches(t *testing.T) {
@@ -142,7 +144,7 @@ func TestMieruClientConfigLinkRequiresDomain(t *testing.T) {
 	}
 }
 
-func TestClientEndpointForUsesInboundDomainWithFallback(t *testing.T) {
+func TestResolveInboundDomainViaModelHelper(t *testing.T) {
 	cases := []struct {
 		name     string
 		settings Settings
@@ -176,8 +178,8 @@ func TestClientEndpointForUsesInboundDomainWithFallback(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			input := ClientAccessLinkInput{Settings: tc.settings, Inbound: tc.inbound}
-			if got := clientEndpointFor(input); got != tc.want {
+			got := model.ResolveInboundDomain(tc.inbound, tc.settings)
+			if got != tc.want {
 				t.Fatalf("got %q, want %q", got, tc.want)
 			}
 		})
@@ -211,6 +213,36 @@ func TestHysteria2ProfileLinkUsesInboundDomain(t *testing.T) {
 		t.Fatal("expected link")
 	}
 	wantPrefix := "hysteria2://alice:pass@inbound.example.com:8443/"
+	if !strings.HasPrefix(link.URI, wantPrefix) {
+		t.Fatalf("URI = %q, want prefix %q", link.URI, wantPrefix)
+	}
+}
+
+func TestNaiveFallbackLinkUsesInboundDomain(t *testing.T) {
+	link, ok := naiveFallbackClientLink(ClientAccessLinkInput{
+		Settings: Settings{Domain: "global.example.com", NaiveUsername: "veil", NaivePassword: "global"},
+		Inbound:  Inbound{Name: "naive", Protocol: "naiveproxy", Transport: "tcp", Port: 8443, Enabled: true, ProtocolFields: map[string]any{"domain": "inbound.example.com"}},
+		LinkName: "naive",
+	})
+	if !ok {
+		t.Fatal("expected link")
+	}
+	want := "naive+https://veil:global@inbound.example.com:8443"
+	if link.URI != want {
+		t.Fatalf("URI = %q, want %q", link.URI, want)
+	}
+}
+
+func TestHysteria2FallbackLinkUsesInboundDomain(t *testing.T) {
+	link, ok := hysteria2FallbackClientLink(ClientAccessLinkInput{
+		Settings: Settings{Domain: "global.example.com", Hysteria2Password: "global"},
+		Inbound:  Inbound{Name: "hy2", Protocol: "hysteria2", Transport: "udp", Port: 8443, Enabled: true, ProtocolFields: map[string]any{"domain": "inbound.example.com"}},
+		LinkName: "hy2",
+	})
+	if !ok {
+		t.Fatal("expected link")
+	}
+	wantPrefix := "hysteria2://global@inbound.example.com:8443/"
 	if !strings.HasPrefix(link.URI, wantPrefix) {
 		t.Fatalf("URI = %q, want prefix %q", link.URI, wantPrefix)
 	}

--- a/internal/clientaccess/client_access_protocol_registry_more_test.go
+++ b/internal/clientaccess/client_access_protocol_registry_more_test.go
@@ -1,6 +1,9 @@
 package clientaccess
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestProtocolStringBranches(t *testing.T) {
 	cases := []struct {
@@ -136,5 +139,79 @@ func TestMieruClientConfigLinkRequiresDomain(t *testing.T) {
 	})
 	if ok {
 		t.Fatalf("expected no link without domain, got %+v", link)
+	}
+}
+
+func TestClientEndpointForUsesInboundDomainWithFallback(t *testing.T) {
+	cases := []struct {
+		name     string
+		settings Settings
+		inbound  Inbound
+		want     string
+	}{
+		{
+			name:     "inbound domain wins",
+			settings: Settings{Domain: "global.example.com"},
+			inbound:  Inbound{ProtocolFields: map[string]any{"domain": "inbound.example.com"}},
+			want:     "inbound.example.com",
+		},
+		{
+			name:     "fallback to settings domain",
+			settings: Settings{Domain: "global.example.com"},
+			inbound:  Inbound{},
+			want:     "global.example.com",
+		},
+		{
+			name:     "inbound domain works without global domain",
+			settings: Settings{},
+			inbound:  Inbound{ProtocolFields: map[string]any{"domain": "inbound.example.com"}},
+			want:     "inbound.example.com",
+		},
+		{
+			name:     "empty inbound domain falls back",
+			settings: Settings{Domain: "global.example.com"},
+			inbound:  Inbound{ProtocolFields: map[string]any{"domain": "  "}},
+			want:     "global.example.com",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			input := ClientAccessLinkInput{Settings: tc.settings, Inbound: tc.inbound}
+			if got := clientEndpointFor(input); got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNaiveProfileLinkUsesInboundDomain(t *testing.T) {
+	link, ok := naiveProfileClientLink(ClientAccessLinkInput{
+		Settings:   Settings{Domain: "global.example.com"},
+		Inbound:    Inbound{Name: "naive", Protocol: "naiveproxy", Transport: "tcp", Port: 8443, Enabled: true, ProtocolFields: map[string]any{"domain": "inbound.example.com"}},
+		LinkName:   "naive/alice",
+		Credential: ClientCredential{Name: "alice", Username: "alice", Password: "pass"},
+	})
+	if !ok {
+		t.Fatal("expected link")
+	}
+	want := "naive+https://alice:pass@inbound.example.com:8443"
+	if link.URI != want {
+		t.Fatalf("URI = %q, want %q", link.URI, want)
+	}
+}
+
+func TestHysteria2ProfileLinkUsesInboundDomain(t *testing.T) {
+	link, ok := hysteria2ProfileClientLink(ClientAccessLinkInput{
+		Settings:   Settings{Domain: "global.example.com"},
+		Inbound:    Inbound{Name: "hy2", Protocol: "hysteria2", Transport: "udp", Port: 8443, Enabled: true, ProtocolFields: map[string]any{"domain": "inbound.example.com"}},
+		LinkName:   "hy2/alice",
+		Credential: ClientCredential{Name: "alice", Username: "alice", Password: "pass"},
+	})
+	if !ok {
+		t.Fatal("expected link")
+	}
+	wantPrefix := "hysteria2://alice:pass@inbound.example.com:8443/"
+	if !strings.HasPrefix(link.URI, wantPrefix) {
+		t.Fatalf("URI = %q, want prefix %q", link.URI, wantPrefix)
 	}
 }

--- a/internal/clientaccess/client_access_protocol_registry_test.go
+++ b/internal/clientaccess/client_access_protocol_registry_test.go
@@ -45,3 +45,10 @@ func TestClientAccessProtocolRegistrySkipsUnknownProtocols(t *testing.T) {
 		t.Fatalf("unknown protocol links = %+v", links)
 	}
 }
+
+func TestClientEndpointLowercasesGlobalDomain(t *testing.T) {
+	settings := Settings{Domain: "  VPN.EXAMPLE.COM  "}
+	if got := clientEndpoint(settings); got != "vpn.example.com" {
+		t.Fatalf("clientEndpoint(%q) = %q, want lowercased trimmed domain", settings.Domain, got)
+	}
+}

--- a/internal/clientaccess/client_links_response_metadata_test.go
+++ b/internal/clientaccess/client_links_response_metadata_test.go
@@ -14,3 +14,17 @@ func TestClientLinksResponseMetadataBuildsStableSubscriptionFields(t *testing.T)
 		t.Fatalf("formats = %+v", response.SubscriptionFormats)
 	}
 }
+
+func TestClientLinksResponseMetadataDomainMirrorsSettings(t *testing.T) {
+	// ClientLinksResponse.Domain intentionally reflects the global settings
+	// domain, not a per-inbound domain. Individual links carry their own
+	// resolved domains, so this top-level field remains stable metadata.
+	response := NewClientLinksResponseMetadata(Settings{}).Build()
+	if response.Domain != "" {
+		t.Fatalf("empty settings should yield empty response.Domain, got %q", response.Domain)
+	}
+	response = NewClientLinksResponseMetadata(Settings{Domain: "vpn.example.com"}).Build()
+	if response.Domain != "vpn.example.com" {
+		t.Fatalf("response.Domain = %q, want vpn.example.com", response.Domain)
+	}
+}

--- a/internal/clientaccess/mieru_client_access_aggregation.go
+++ b/internal/clientaccess/mieru_client_access_aggregation.go
@@ -15,7 +15,7 @@ func NewMieruClientAccessAggregator() MieruClientAccessAggregator {
 }
 
 func (MieruClientAccessAggregator) Build(settings Settings, inbounds []Inbound) ([]ClientLink, error) {
-	if !hasClientEndpoint(settings) {
+	if clientEndpoint(settings) == "" {
 		return nil, nil
 	}
 	groups := map[string]*mieruClientAccessGroup{}

--- a/internal/cliflow/install/presentation.go
+++ b/internal/cliflow/install/presentation.go
@@ -45,9 +45,9 @@ func (p Presentation) PrintRURecommended(profile installer.RURecommendedProfile,
 	fmt.Fprintln(p.out, "Install scope: Panel")
 	fmt.Fprintln(p.out, "")
 	if profile.InstallPanelCaddy {
-		fmt.Fprintln(p.out, "Generated Caddyfile")
+		fmt.Fprintln(p.out, "Generated Caddy JSON")
 		fmt.Fprintln(p.out, strings.Repeat("-", 24))
-		fmt.Fprintln(p.out, p.RedactProfileSecrets(profile, profile.Caddyfile))
+		fmt.Fprintln(p.out, p.RedactProfileSecrets(profile, profile.CaddyJSON))
 	}
 }
 

--- a/internal/cliflow/install/presentation_more_test.go
+++ b/internal/cliflow/install/presentation_more_test.go
@@ -61,7 +61,7 @@ func TestPresentationMore(t *testing.T) {
 				"Email: admin@app.example.com",
 				"Install scope: Panel",
 			},
-			notWant: []string{"Generated Caddyfile"},
+			notWant: []string{"Generated Caddy JSON"},
 		},
 	}
 

--- a/internal/cliflow/install/presentation_test.go
+++ b/internal/cliflow/install/presentation_test.go
@@ -13,7 +13,7 @@ func TestInstallPresentationPrintsRedactedRURecommendedProfile(t *testing.T) {
 		Domain:            "example.com",
 		Email:             "admin@example.com",
 		InstallPanelCaddy: true,
-		Caddyfile:         "reverse_proxy 127.0.0.1:2096 # panel-secret",
+		CaddyJSON:         "{\"upstream\":\"127.0.0.1:2096\",\"token\":\"panel-secret\"}",
 		PanelAuthToken:    "panel-secret",
 	}
 	var out bytes.Buffer

--- a/internal/cliflow/repair/panel_state_material_test.go
+++ b/internal/cliflow/repair/panel_state_material_test.go
@@ -28,7 +28,7 @@ func TestPanelStateRepairMaterialAddsGeneratedConfigsAndRuntimeUnits(t *testing.
 	}
 	for _, want := range []string{
 		filepath.Join(opts.EtcDir, "veil.env"),
-		filepath.Join(opts.EtcDir, "generated", "caddy", "panel.Caddyfile"),
+		filepath.Join(opts.EtcDir, "generated", "caddy", "config.json"),
 		filepath.Join(opts.EtcDir, "generated", "mieru", "server_config.json"),
 		filepath.Join(opts.SystemdDir, renderer.UnitCaddy),
 		filepath.Join(opts.SystemdDir, renderer.UnitMieru),

--- a/internal/cliflow/repair/plan_builder.go
+++ b/internal/cliflow/repair/plan_builder.go
@@ -12,9 +12,12 @@ import (
 
 	"github.com/mikkelchokolate/Veil/internal/acmeip"
 	"github.com/mikkelchokolate/Veil/internal/api"
+	"github.com/mikkelchokolate/Veil/internal/caddyassembly"
+	"github.com/mikkelchokolate/Veil/internal/caddycapabilities"
 	"github.com/mikkelchokolate/Veil/internal/hostenv"
 	"github.com/mikkelchokolate/Veil/internal/installer"
 	"github.com/mikkelchokolate/Veil/internal/managementstate"
+	"github.com/mikkelchokolate/Veil/internal/model"
 	"github.com/mikkelchokolate/Veil/internal/panelmaterial"
 	"github.com/mikkelchokolate/Veil/internal/renderer"
 	"github.com/mikkelchokolate/Veil/internal/runtime"
@@ -200,9 +203,26 @@ func preserveExistingPanelRepairMaterial(profile *installer.RURecommendedProfile
 		profile.PanelTLSCertPEM = ""
 		profile.PanelTLSKeyPEM = ""
 		profile.InstallPanelCaddy = true
-		caddyfile, err := renderer.RenderPanelCaddyfile(renderer.PanelCaddyConfig{Domain: profile.Domain, Email: profile.Email, PanelPort: panelPortFromListen(profile.PanelListen), WebBasePath: profile.WebBasePath})
+		settings := model.Settings{
+			PanelAccess:       "caddy",
+			PanelListen:       profile.PanelListen,
+			WebBasePath:       profile.WebBasePath,
+			Domain:            profile.Domain,
+			Email:             profile.Email,
+			PanelDomain:       profile.Domain,
+			PanelEmail:        profile.Email,
+			PanelPublicPort:   443,
+			AcmeChallengeMode: "tls-alpn-01",
+		}
+		plan, _, _, err := caddyassembly.BuildFinalRenderPlan(settings, nil)
 		if err == nil {
-			profile.Caddyfile = caddyfile
+			caps, capErr := caddycapabilities.Probe("")
+			if capErr == nil {
+				body, renderErr := renderer.RenderCaddyJSON(plan, caps)
+				if renderErr == nil {
+					profile.CaddyJSON = string(body)
+				}
+			}
 		}
 		return
 	}

--- a/internal/cliflow/repair/plan_builder_test.go
+++ b/internal/cliflow/repair/plan_builder_test.go
@@ -110,8 +110,8 @@ func TestBuildRepairPlanFromOptionsRepairsExistingPanelCaddyAccess(t *testing.T)
 	if _, err := installer.ApplyRURecommendedProfile(profile, installer.ApplyPaths{EtcDir: etcDir, VarDir: varDir, SystemdDir: systemdDir}); err != nil {
 		t.Fatalf("ApplyRURecommendedProfile: %v", err)
 	}
-	if err := os.Remove(filepath.Join(etcDir, "generated", "caddy", "panel.Caddyfile")); err != nil {
-		t.Fatalf("remove panel.Caddyfile: %v", err)
+	if err := os.Remove(filepath.Join(etcDir, "generated", "caddy", "config.json")); err != nil {
+		t.Fatalf("remove config.json: %v", err)
 	}
 	if err := os.Remove(filepath.Join(systemdDir, "veil-caddy.service")); err != nil {
 		t.Fatalf("remove veil-caddy.service: %v", err)
@@ -122,7 +122,7 @@ func TestBuildRepairPlanFromOptionsRepairsExistingPanelCaddyAccess(t *testing.T)
 		t.Fatalf("buildRepairPlanFromOptions: %v", err)
 	}
 	summary := plan.Summary()
-	for _, want := range []string{"generated/caddy/panel.Caddyfile", "veil-caddy.service"} {
+	for _, want := range []string{"generated/caddy/config.json", "veil-caddy.service"} {
 		if !strings.Contains(summary, want) {
 			t.Fatalf("Panel Caddy repair summary missing %q:\n%s", want, summary)
 		}

--- a/internal/cliflow/repair/plan_builder_test.go
+++ b/internal/cliflow/repair/plan_builder_test.go
@@ -113,8 +113,8 @@ func TestBuildRepairPlanFromOptionsRepairsExistingPanelCaddyAccess(t *testing.T)
 	if err := os.Remove(filepath.Join(etcDir, "generated", "caddy", "panel.Caddyfile")); err != nil {
 		t.Fatalf("remove panel.Caddyfile: %v", err)
 	}
-	if err := os.Remove(filepath.Join(systemdDir, "veil-caddy@.service")); err != nil {
-		t.Fatalf("remove veil-caddy@.service: %v", err)
+	if err := os.Remove(filepath.Join(systemdDir, "veil-caddy.service")); err != nil {
+		t.Fatalf("remove veil-caddy.service: %v", err)
 	}
 
 	plan, err := buildRepairPlanFromOptions(Options{Profile: "ru-recommended", EtcDir: etcDir, VarDir: varDir, SystemdDir: systemdDir})
@@ -122,7 +122,7 @@ func TestBuildRepairPlanFromOptionsRepairsExistingPanelCaddyAccess(t *testing.T)
 		t.Fatalf("buildRepairPlanFromOptions: %v", err)
 	}
 	summary := plan.Summary()
-	for _, want := range []string{"generated/caddy/panel.Caddyfile", "veil-caddy@.service"} {
+	for _, want := range []string{"generated/caddy/panel.Caddyfile", "veil-caddy.service"} {
 		if !strings.Contains(summary, want) {
 			t.Fatalf("Panel Caddy repair summary missing %q:\n%s", want, summary)
 		}

--- a/internal/cliflow/repair/state_plan_test.go
+++ b/internal/cliflow/repair/state_plan_test.go
@@ -74,14 +74,14 @@ func TestBuildRepairPlanFromOptionsUsesPanelStateCaddyAccess(t *testing.T) {
 		t.Fatalf("buildRepairPlanFromOptions: %v", err)
 	}
 	summary := plan.Summary()
-	for _, want := range []string{"generated/caddy/panel.Caddyfile", "veil-caddy.service"} {
+	for _, want := range []string{"generated/caddy/config.json", "veil-caddy.service"} {
 		if !strings.Contains(summary, want) {
 			t.Fatalf("Panel state Caddy access repair missing %q:\n%s", want, summary)
 		}
 	}
-	caddyfile := repairActionContent(plan, "panel.Caddyfile")
-	if !strings.Contains(caddyfile, "handle /panel-secret/*") || !strings.Contains(caddyfile, "reverse_proxy 127.0.0.1:2096") {
-		t.Fatalf("Panel state Caddyfile not repaired from settings:\n%s", caddyfile)
+	caddyJSON := repairActionContent(plan, "config.json")
+	if !strings.Contains(caddyJSON, "panel.example.com") || !strings.Contains(caddyJSON, "127.0.0.1:2096") || !strings.Contains(caddyJSON, "panel-secret") {
+		t.Fatalf("Panel state Caddy JSON not repaired from settings:\n%s", caddyJSON)
 	}
 	env := repairActionContent(plan, "veil.env")
 	if !strings.Contains(env, "VEIL_PANEL_ACCESS=caddy") || strings.Contains(env, "VEIL_TLS_CERT") {

--- a/internal/cliflow/repair/state_plan_test.go
+++ b/internal/cliflow/repair/state_plan_test.go
@@ -74,7 +74,7 @@ func TestBuildRepairPlanFromOptionsUsesPanelStateCaddyAccess(t *testing.T) {
 		t.Fatalf("buildRepairPlanFromOptions: %v", err)
 	}
 	summary := plan.Summary()
-	for _, want := range []string{"generated/caddy/panel.Caddyfile", "veil-caddy@.service"} {
+	for _, want := range []string{"generated/caddy/panel.Caddyfile", "veil-caddy.service"} {
 		if !strings.Contains(summary, want) {
 			t.Fatalf("Panel state Caddy access repair missing %q:\n%s", want, summary)
 		}
@@ -106,7 +106,7 @@ func TestBuildRepairPlanFromOptionsUsesResolvedCaddyBinaryForNaiveRuntime(t *tes
 		t.Fatalf("mkdir state dir: %v", err)
 	}
 	state := `{
-  "settings": {"panelListen":"127.0.0.1:2096","mode":"server","domain":"vpn.example.com","email":"admin@example.com","naiveUsername":"veil","naivePassword":"naive-secret"},
+  "settings": {"panelListen":"127.0.0.1:2096","mode":"server","domain":"vpn.example.com","defaultAcmeEmail":"admin@example.com","naiveUsername":"veil","naivePassword":"naive-secret"},
   "inbounds": [
     {"name":"naive","protocol":"naiveproxy","transport":"tcp","port":443,"enabled":true}
   ],
@@ -121,9 +121,9 @@ func TestBuildRepairPlanFromOptionsUsesResolvedCaddyBinaryForNaiveRuntime(t *tes
 	if err != nil {
 		t.Fatalf("buildRepairPlanFromOptions: %v", err)
 	}
-	unit := repairActionContent(plan, "veil-caddy@.service")
+	unit := repairActionContent(plan, "veil-caddy.service")
 	if !strings.Contains(unit, "ExecStart=/usr/sbin/caddy run --config") {
-		t.Fatalf("repair should render veil-caddy@.service with resolved caddy path:\n%s", unit)
+		t.Fatalf("repair should render veil-caddy.service with resolved caddy path:\n%s", unit)
 	}
 }
 

--- a/internal/generatedconfig/artifact_catalog.go
+++ b/internal/generatedconfig/artifact_catalog.go
@@ -7,6 +7,7 @@ import (
 
 const (
 	CaddyfileSubpath       = "caddy/panel.Caddyfile"
+	CaddyJSONConfigSubpath = "caddy/config.json"
 	Hysteria2ConfigSubpath = "hysteria2/server.yaml"
 	MieruConfigSubpath     = "mieru/server_config.json"
 	WarpConfigSubpath      = "sing-box/warp.json"

--- a/internal/generatedconfig/artifact_catalog.go
+++ b/internal/generatedconfig/artifact_catalog.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	CaddyfileSubpath       = "caddy/panel.Caddyfile"
+	CaddyfileSubpath       = "caddy/config.json"
 	CaddyJSONConfigSubpath = "caddy/config.json"
 	Hysteria2ConfigSubpath = "hysteria2/server.yaml"
 	MieruConfigSubpath     = "mieru/server_config.json"

--- a/internal/generatedconfig/inbound_renderer.go
+++ b/internal/generatedconfig/inbound_renderer.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/mikkelchokolate/Veil/internal/clientaccess"
+	"github.com/mikkelchokolate/Veil/internal/model"
 	"github.com/mikkelchokolate/Veil/internal/renderer"
 	veilsettings "github.com/mikkelchokolate/Veil/internal/settings"
 )
@@ -38,8 +39,8 @@ func (r InboundRenderer) RenderNaive(inbound Inbound, includePanel bool) (string
 	username := naiveUsername(r.settings, inbound)
 	root := fallbackRoot(r.settings, inbound)
 	naiveConfig := renderer.NaiveConfig{
-		Domain:       r.settings.Domain,
-		Email:        r.settings.Email,
+		Domain:       model.ResolveInboundDomain(inbound, r.settings),
+		Email:        model.ResolveInboundEmail(inbound, r.settings),
 		ListenPort:   inbound.Port,
 		Username:     username,
 		Password:     password,
@@ -105,16 +106,17 @@ func (r InboundRenderer) RenderHysteria2(inbound Inbound) (string, error) {
 		return "", err
 	}
 	url := masqueradeURL(r.settings, inbound)
+	domain := model.ResolveInboundDomain(inbound, r.settings)
 	hystConfig := renderer.Hysteria2Config{
 		ListenPort:    inbound.Port,
-		Domain:        r.settings.Domain,
+		Domain:        domain,
 		Password:      password,
 		Users:         access.Hysteria2Users(),
 		MasqueradeURL: url,
 	}
-	if r.settings.PanelAccess == "caddy" && r.settings.Domain != "" {
-		hystConfig.CertPath = r.paths.CertPath(r.settings.Domain)
-		hystConfig.KeyPath = r.paths.KeyPath(r.settings.Domain)
+	if domain != "" && (r.settings.PanelAccess == "caddy" || model.InboundDomain(inbound) != "") {
+		hystConfig.CertPath = r.paths.CertPath(domain)
+		hystConfig.KeyPath = r.paths.KeyPath(domain)
 	} else {
 		hystConfig.CertPath = r.paths.PanelCertPath()
 		hystConfig.KeyPath = r.paths.PanelKeyPath()

--- a/internal/generatedconfig/paths.go
+++ b/internal/generatedconfig/paths.go
@@ -38,6 +38,10 @@ func (p Paths) Caddyfile() string {
 	return p.Generated(CaddyfileSubpath)
 }
 
+func (p Paths) CaddyJSON() string {
+	return p.Generated(CaddyJSONConfigSubpath)
+}
+
 func (p Paths) Hysteria2() string {
 	return p.Generated(Hysteria2ConfigSubpath)
 }

--- a/internal/generatedconfig/paths_test.go
+++ b/internal/generatedconfig/paths_test.go
@@ -8,7 +8,7 @@ import (
 func TestGeneratedConfigPathsBuildsKnownGeneratedPaths(t *testing.T) {
 	paths := NewPaths("/apply")
 	cases := map[string]string{
-		paths.Caddyfile(): filepath.Join("/apply", "generated", "caddy", "panel.Caddyfile"),
+		paths.Caddyfile(): filepath.Join("/apply", "generated", "caddy", "config.json"),
 		paths.Hysteria2(): filepath.Join("/apply", "generated", "hysteria2", "server.yaml"),
 		paths.Warp():      filepath.Join("/apply", "generated", "sing-box", "warp.json"),
 	}

--- a/internal/generatedconfig/set.go
+++ b/internal/generatedconfig/set.go
@@ -34,7 +34,7 @@ func (b SetBuilder) Build() (map[string]string, error) {
 		return nil, err
 	}
 	paths := NewPathsWithLiveRoot(input.ApplyRoot, input.LiveRoot)
-	if _, exists := configs[paths.Caddyfile()]; !exists && input.PanelAccess != nil {
+	if _, exists := configs[paths.CaddyJSON()]; !exists && input.PanelAccess != nil {
 		artifact, ok, err := input.PanelAccess(paths)
 		if err != nil {
 			return nil, err

--- a/internal/generatedconfig/set_test.go
+++ b/internal/generatedconfig/set_test.go
@@ -10,7 +10,7 @@ func TestSetBuilderCombinesProtocolPanelFallbackAndWarpArtifacts(t *testing.T) {
 			return []GeneratedConfigArtifact{{Path: input.Paths.Mieru(), Body: "mieru"}}, true, nil
 		}}}),
 		PanelAccess: func(Paths) (GeneratedConfigArtifact, bool, error) {
-			return GeneratedConfigArtifact{Path: paths.Caddyfile(), Body: "panel-caddy"}, true, nil
+			return GeneratedConfigArtifact{Path: paths.CaddyJSON(), Body: "panel-caddy"}, true, nil
 		},
 		Warp: func(Paths) (GeneratedConfigArtifact, bool, error) {
 			return GeneratedConfigArtifact{Path: paths.Warp(), Body: "warp"}, true, nil
@@ -21,7 +21,7 @@ func TestSetBuilderCombinesProtocolPanelFallbackAndWarpArtifacts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
-	if configs[paths.Mieru()] != "mieru" || configs[paths.Caddyfile()] != "panel-caddy" || configs[paths.Warp()] != "warp" {
+	if configs[paths.Mieru()] != "mieru" || configs[paths.CaddyJSON()] != "panel-caddy" || configs[paths.Warp()] != "warp" {
 		t.Fatalf("configs = %+v", configs)
 	}
 }
@@ -31,10 +31,10 @@ func TestSetBuilderDoesNotOverwriteProtocolCaddyWithPanelFallback(t *testing.T) 
 	builder := NewSetBuilder(SetInput{
 		ApplyRoot: "/etc/veil",
 		Registry: NewProtocolRegistry([]Protocol{{Protocol: "naiveproxy", Render: func(input ProtocolRenderInput) ([]GeneratedConfigArtifact, bool, error) {
-			return []GeneratedConfigArtifact{{Path: input.Paths.Caddyfile(), Body: "naive-caddy"}}, true, nil
+			return []GeneratedConfigArtifact{{Path: input.Paths.CaddyJSON(), Body: "naive-caddy"}}, true, nil
 		}}}),
 		PanelAccess: func(Paths) (GeneratedConfigArtifact, bool, error) {
-			return GeneratedConfigArtifact{Path: paths.Caddyfile(), Body: "panel-caddy"}, true, nil
+			return GeneratedConfigArtifact{Path: paths.CaddyJSON(), Body: "panel-caddy"}, true, nil
 		},
 		Inbounds: []Inbound{{Name: "naive", Protocol: "naiveproxy", Enabled: true}},
 	})
@@ -42,7 +42,7 @@ func TestSetBuilderDoesNotOverwriteProtocolCaddyWithPanelFallback(t *testing.T) 
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
-	if configs[paths.Caddyfile()] != "naive-caddy" {
-		t.Fatalf("caddy config = %q", configs[paths.Caddyfile()])
+	if configs[paths.CaddyJSON()] != "naive-caddy" {
+		t.Fatalf("caddy config = %q", configs[paths.CaddyJSON()])
 	}
 }

--- a/internal/installer/apply_backup_test.go
+++ b/internal/installer/apply_backup_test.go
@@ -32,7 +32,7 @@ func TestApplyWithBackupDirBacksUpExistingFilesBeforeOverwrite(t *testing.T) {
 	if err := os.MkdirAll(caddyfileDir, 0o755); err != nil {
 		t.Fatalf("mkdir caddy dir: %v", err)
 	}
-	oldCaddyPath := filepath.Join(caddyfileDir, "panel.Caddyfile")
+	oldCaddyPath := filepath.Join(caddyfileDir, "config.json")
 	if err := os.WriteFile(oldCaddyPath, []byte("old caddy content"), 0o600); err != nil {
 		t.Fatalf("write old caddy: %v", err)
 	}
@@ -51,18 +51,18 @@ func TestApplyWithBackupDirBacksUpExistingFilesBeforeOverwrite(t *testing.T) {
 		t.Fatalf("expected BackupID to be set when BackupDir is provided")
 	}
 
-	// Verify backup contains old Caddyfile
-	backupPath := filepath.Join(backupDir, result.BackupID, "panel.Caddyfile")
+	// Verify backup contains old Caddy JSON
+	backupPath := filepath.Join(backupDir, result.BackupID, "config.json")
 	body, err := os.ReadFile(backupPath)
 	if err != nil {
-		t.Fatalf("read backup caddyfile: %v", err)
+		t.Fatalf("read backup caddy json: %v", err)
 	}
 	if string(body) != "old caddy content" {
 		t.Fatalf("backup has wrong content: %q", string(body))
 	}
 
-	// Verify current Caddyfile has new content
-	assertFileContains(t, oldCaddyPath, "reverse_proxy")
+	// Verify current Caddy JSON has new content
+	assertFileContains(t, oldCaddyPath, "127.0.0.1:2096")
 }
 
 func TestApplyWithoutBackupDirDoesNotBackup(t *testing.T) {
@@ -115,7 +115,7 @@ func TestApplyBackupThenRestoreRollback(t *testing.T) {
 	if err := os.MkdirAll(caddyfileDir, 0o755); err != nil {
 		t.Fatalf("mkdir caddy dir: %v", err)
 	}
-	oldCaddyPath := filepath.Join(caddyfileDir, "panel.Caddyfile")
+	oldCaddyPath := filepath.Join(caddyfileDir, "config.json")
 	if err := os.WriteFile(oldCaddyPath, []byte("pre-apply content"), 0o600); err != nil {
 		t.Fatalf("write old caddy: %v", err)
 	}
@@ -142,9 +142,9 @@ func TestApplyBackupThenRestoreRollback(t *testing.T) {
 	// Verify files were overwritten
 	body, _ := os.ReadFile(oldCaddyPath)
 	if string(body) == "pre-apply content" {
-		t.Fatalf("Caddyfile should have been overwritten")
+		t.Fatalf("Caddy JSON should have been overwritten")
 	}
-	assertFileContains(t, oldCaddyPath, "reverse_proxy")
+	assertFileContains(t, oldCaddyPath, "127.0.0.1:2096")
 
 	body, _ = os.ReadFile(veilEnvPath)
 	if string(body) == "VEIL_API_TOKEN=old-token\n" {
@@ -167,7 +167,7 @@ func TestApplyBackupThenRestoreRollback(t *testing.T) {
 		t.Fatalf("read restored caddy: %v", err)
 	}
 	if string(body) != "pre-apply content" {
-		t.Fatalf("restored Caddyfile has wrong content: %q", string(body))
+		t.Fatalf("restored Caddy JSON has wrong content: %q", string(body))
 	}
 
 	body, err = os.ReadFile(veilEnvPath)

--- a/internal/installer/apply_install_apply_test.go
+++ b/internal/installer/apply_install_apply_test.go
@@ -64,7 +64,7 @@ func TestApplyRURecommendedProfileWritesPanelCaddyAccessFiles(t *testing.T) {
 	assertFileMissing(t, result.Hysteria2Path)
 	assertFileContains(t, filepath.Join(dir, "etc", "veil", "veil.env"), "VEIL_API_TOKEN=secret-panel")
 	assertFileContains(t, filepath.Join(dir, "etc", "systemd", "system", "veil.service"), "ExecStart=/usr/local/bin/veil serve")
-	assertFileContains(t, filepath.Join(dir, "etc", "systemd", "system", "veil-caddy@.service"), "caddy")
+	assertFileContains(t, filepath.Join(dir, "etc", "systemd", "system", "veil-caddy.service"), "caddy")
 	assertFileMissing(t, filepath.Join(dir, "etc", "systemd", "system", "veil-hysteria2.service"))
 	for _, name := range systemdunits.Names() {
 		assertFileContains(t, filepath.Join(dir, "etc", "systemd", "system", name), "[")

--- a/internal/installer/apply_install_apply_test.go
+++ b/internal/installer/apply_install_apply_test.go
@@ -59,7 +59,7 @@ func TestApplyRURecommendedProfileWritesPanelCaddyAccessFiles(t *testing.T) {
 		t.Fatalf("apply profile: %v", err)
 	}
 
-	assertFileContains(t, result.CaddyfilePath, "reverse_proxy 127.0.0.1:2096")
+	assertFileContains(t, result.CaddyfilePath, "127.0.0.1:2096")
 	assertFileContains(t, result.FallbackIndexPath, "Veil")
 	assertFileMissing(t, result.Hysteria2Path)
 	assertFileContains(t, filepath.Join(dir, "etc", "veil", "veil.env"), "VEIL_API_TOKEN=secret-panel")

--- a/internal/installer/apply_install_apply_test.go
+++ b/internal/installer/apply_install_apply_test.go
@@ -87,6 +87,25 @@ func TestApplyRURecommendedProfileChownsSecretsForVeilGroup(t *testing.T) {
 	defer func() { effectiveUID, lookupUser = oldUID, oldLookup }()
 	effectiveUID = func() int { return 0 }
 	lookupUser = func(string) (*user.User, error) { return &user.User{Uid: "0", Gid: "0"}, nil }
+	// A non-root CI runner cannot os.Chown to another group (EPERM). Force the
+	// group-read bit directly; this is exactly the permission the production
+	// chown+chmod grants.
+	oldChown, oldChmod := chownPath, chmodPath
+	defer func() { chownPath, chmodPath = oldChown, oldChmod }()
+	chownPath = func(path string, _, _ int) error {
+		info, err := os.Stat(path)
+		if err != nil {
+			return err
+		}
+		return os.Chmod(path, info.Mode()|0o040)
+	}
+	chmodPath = func(path string, mode os.FileMode) error {
+		info, err := os.Stat(path)
+		if err != nil {
+			return err
+		}
+		return os.Chmod(path, info.Mode()|mode&0o040)
+	}
 
 	dir := t.TempDir()
 	profile, err := BuildRURecommendedProfile(RURecommendedInput{

--- a/internal/installer/apply_install_apply_test.go
+++ b/internal/installer/apply_install_apply_test.go
@@ -2,6 +2,7 @@ package installer
 
 import (
 	"os"
+	"os/user"
 	"path/filepath"
 	"syscall"
 	"testing"
@@ -80,6 +81,13 @@ func TestApplyRURecommendedProfileRejectsMissingPaths(t *testing.T) {
 }
 
 func TestApplyRURecommendedProfileChownsSecretsForVeilGroup(t *testing.T) {
+	// Hermetic: run as if root so the chown path is exercised regardless of the
+	// CI runner's euid, and stub the user lookup so no real 'veil' account is needed.
+	oldUID, oldLookup := effectiveUID, lookupUser
+	defer func() { effectiveUID, lookupUser = oldUID, oldLookup }()
+	effectiveUID = func() int { return 0 }
+	lookupUser = func(string) (*user.User, error) { return &user.User{Uid: "0", Gid: "0"}, nil }
+
 	dir := t.TempDir()
 	profile, err := BuildRURecommendedProfile(RURecommendedInput{
 		PanelAccess: "caddy",

--- a/internal/installer/apply_install_apply_test.go
+++ b/internal/installer/apply_install_apply_test.go
@@ -3,6 +3,7 @@ package installer
 import (
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 
 	"github.com/mikkelchokolate/Veil/internal/systemdunits"
@@ -75,6 +76,42 @@ func TestApplyRURecommendedProfileRejectsMissingPaths(t *testing.T) {
 	_, err := ApplyRURecommendedProfile(RURecommendedProfile{}, ApplyPaths{})
 	if err == nil {
 		t.Fatalf("expected missing paths error")
+	}
+}
+
+func TestApplyRURecommendedProfileChownsSecretsForVeilGroup(t *testing.T) {
+	dir := t.TempDir()
+	profile, err := BuildRURecommendedProfile(RURecommendedInput{
+		PanelAccess: "caddy",
+		Domain:      "example.com",
+		Email:       "admin@example.com",
+		Secret:      func(label string) string { return "secret-" + label },
+		PanelPort:   2096,
+	})
+	if err != nil {
+		t.Fatalf("build profile: %v", err)
+	}
+
+	paths := ApplyPaths{
+		EtcDir:     filepath.Join(dir, "etc", "veil"),
+		VarDir:     filepath.Join(dir, "var", "lib", "veil"),
+		SystemdDir: filepath.Join(dir, "etc", "systemd", "system"),
+	}
+	if _, err := ApplyRURecommendedProfile(profile, paths); err != nil {
+		t.Fatalf("apply profile: %v", err)
+	}
+
+	envPath := filepath.Join(paths.EtcDir, "veil.env")
+	info, err := os.Stat(envPath)
+	if err != nil {
+		t.Fatalf("stat veil.env: %v", err)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Fatalf("unexpected stat type for %s", envPath)
+	}
+	if stat.Mode&0o040 == 0 {
+		t.Fatalf("veil.env must be group-readable (mode %o)", stat.Mode)
 	}
 }
 

--- a/internal/installer/apply_repair_test.go
+++ b/internal/installer/apply_repair_test.go
@@ -64,5 +64,5 @@ func TestApplyRepairPlanWritesOnlyPlannedFiles(t *testing.T) {
 	if len(repairResult.WrittenFiles) != 1 || repairResult.WrittenFiles[0] != result.CaddyfilePath {
 		t.Fatalf("unexpected repaired files: %+v", repairResult.WrittenFiles)
 	}
-	assertFileContains(t, result.CaddyfilePath, "reverse_proxy 127.0.0.1:2096")
+	assertFileContains(t, result.CaddyfilePath, "127.0.0.1:2096")
 }

--- a/internal/installer/install_apply.go
+++ b/internal/installer/install_apply.go
@@ -3,11 +3,21 @@ package installer
 import (
 	"fmt"
 	"os"
+	"os/user"
 	"path/filepath"
+	"strconv"
+	"strings"
 
 	"github.com/mikkelchokolate/Veil/internal/backup"
 	"github.com/mikkelchokolate/Veil/internal/firewall"
 	"github.com/mikkelchokolate/Veil/internal/managedfiles"
+)
+
+var (
+	effectiveUID = os.Geteuid
+	lookupUser   = user.Lookup
+	chownPath    = os.Chown
+	chmodPath    = os.Chmod
 )
 
 type ApplyPaths struct {
@@ -73,6 +83,9 @@ func (a InstallApply) Apply() (ApplyResult, error) {
 		}
 		result.WrittenFiles = append(result.WrittenFiles, file.Path)
 	}
+	if err := chownSecretsForVeilGroup(result.WrittenFiles); err != nil {
+		return result, err
+	}
 
 	if len(a.firewallActions) > 0 {
 		applier := newUFWApplier()
@@ -94,6 +107,38 @@ func ApplyRURecommendedProfile(profile RURecommendedProfile, paths ApplyPaths) (
 // ApplyRURecommendedProfileWithPlan applies the install profile and executes the firewall rules from the install plan.
 func ApplyRURecommendedProfileWithPlan(profile RURecommendedProfile, paths ApplyPaths, plan InstallPlan) (ApplyResult, error) {
 	return NewInstallApplyWithPlan(profile, paths, plan).Apply()
+}
+
+func chownSecretsForVeilGroup(paths []string) error {
+	if effectiveUID() != 0 {
+		return nil
+	}
+	u, err := lookupUser("veil")
+	if err != nil {
+		return fmt.Errorf("resolve veil user: %w", err)
+	}
+	uid, err := strconv.Atoi(u.Uid)
+	if err != nil {
+		return fmt.Errorf("parse veil uid %q: %w", u.Uid, err)
+	}
+	gid, err := strconv.Atoi(u.Gid)
+	if err != nil {
+		return fmt.Errorf("parse veil gid %q: %w", u.Gid, err)
+	}
+	_ = uid // uid not needed; we keep root ownership and only grant group read
+	for _, path := range paths {
+		base := filepath.Base(path)
+		if base != "veil.env" && !strings.HasSuffix(base, ".key") && !strings.HasSuffix(base, ".crt") {
+			continue
+		}
+		if err := chownPath(path, 0, gid); err != nil {
+			return fmt.Errorf("chown %s for veil group: %w", path, err)
+		}
+		if err := chmodPath(path, 0o640); err != nil {
+			return fmt.Errorf("chmod %s for veil group: %w", path, err)
+		}
+	}
+	return nil
 }
 
 func writeManagedFile(path string, content string, mode os.FileMode) error {

--- a/internal/installer/install_apply.go
+++ b/internal/installer/install_apply.go
@@ -52,7 +52,7 @@ func (a InstallApply) Apply() (ApplyResult, error) {
 		return ApplyResult{}, err
 	}
 	result := ApplyResult{
-		CaddyfilePath:     filepath.Join(a.paths.EtcDir, "generated", "caddy", "panel.Caddyfile"),
+		CaddyfilePath:     filepath.Join(a.paths.EtcDir, "generated", "caddy", "config.json"),
 		Hysteria2Path:     filepath.Join(a.paths.EtcDir, "generated", "hysteria2", "server.yaml"),
 		FallbackIndexPath: filepath.Join(a.paths.VarDir, "www", "index.html"),
 	}

--- a/internal/installer/install_apply_module_test.go
+++ b/internal/installer/install_apply_module_test.go
@@ -9,7 +9,7 @@ import (
 func TestInstallApplyModuleWritesManagedFiles(t *testing.T) {
 	dir := t.TempDir()
 	paths := ApplyPaths{EtcDir: filepath.Join(dir, "etc"), VarDir: filepath.Join(dir, "var")}
-	profile := RURecommendedProfile{Domain: "vpn.example.com", InstallPanelCaddy: true, Caddyfile: "caddy"}
+	profile := RURecommendedProfile{Domain: "vpn.example.com", InstallPanelCaddy: true, CaddyJSON: "{}"}
 
 	result, err := NewInstallApply(profile, paths).Apply()
 	if err != nil {
@@ -18,11 +18,11 @@ func TestInstallApplyModuleWritesManagedFiles(t *testing.T) {
 	if len(result.WrittenFiles) != 2 {
 		t.Fatalf("written files = %+v", result.WrittenFiles)
 	}
-	body, err := os.ReadFile(filepath.Join(paths.EtcDir, "generated", "caddy", "panel.Caddyfile"))
+	body, err := os.ReadFile(filepath.Join(paths.EtcDir, "generated", "caddy", "config.json"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(body) != "caddy" {
-		t.Fatalf("caddyfile = %q", string(body))
+	if string(body) != "{}" {
+		t.Fatalf("caddy json = %q", string(body))
 	}
 }

--- a/internal/installer/install_workflow_test.go
+++ b/internal/installer/install_workflow_test.go
@@ -22,7 +22,7 @@ func TestBuildRURecommendedInstallSelectsPanelPortBeforeProfile(t *testing.T) {
 	if result.PanelPort != 2096 || !result.PanelRandom {
 		t.Fatalf("panel selection = port %d random %v", result.PanelPort, result.PanelRandom)
 	}
-	if !strings.Contains(result.Profile.Caddyfile, "reverse_proxy 127.0.0.1:2096") {
-		t.Fatalf("profile Caddyfile did not receive selected panel port:\n%s", result.Profile.Caddyfile)
+	if !strings.Contains(result.Profile.CaddyJSON, "127.0.0.1:2096") {
+		t.Fatalf("profile CaddyJSON did not receive selected panel port:\n%s", result.Profile.CaddyJSON)
 	}
 }

--- a/internal/installer/mieru_install_plan_test.go
+++ b/internal/installer/mieru_install_plan_test.go
@@ -42,7 +42,7 @@ func TestPanelInstallWritesDormantManagedRuntimeUnitsWithoutProxyConfig(t *testi
 		t.Fatalf("Panel install should write dormant olcRTC unit template, stat err: %v", err)
 	}
 	if _, err := os.Stat(result.CaddyfilePath); !os.IsNotExist(err) {
-		t.Fatalf("Panel install should not write Caddyfile, stat err: %v", err)
+		t.Fatalf("Panel install should not write Caddy config, stat err: %v", err)
 	}
 	if _, err := os.Stat(result.Hysteria2Path); !os.IsNotExist(err) {
 		t.Fatalf("Panel install should not write Hysteria2 config, stat err: %v", err)

--- a/internal/installer/panel_caddy_install_test.go
+++ b/internal/installer/panel_caddy_install_test.go
@@ -23,14 +23,14 @@ func TestPanelCaddyInstallRendersPanelOnlyCaddyfile(t *testing.T) {
 	if !profile.InstallPanelCaddy {
 		t.Fatalf("panel Caddy install should enable Panel Caddy access: %+v", profile)
 	}
-	for _, want := range []string{"panel.example.com", "handle ", "reverse_proxy 127.0.0.1:2096"} {
-		if !strings.Contains(profile.Caddyfile, want) {
-			t.Fatalf("Caddyfile missing %q:\n%s", want, profile.Caddyfile)
+	for _, want := range []string{"panel.example.com", profile.WebBasePath, "127.0.0.1:2096"} {
+		if !strings.Contains(profile.CaddyJSON, want) {
+			t.Fatalf("CaddyJSON missing %q:\n%s", want, profile.CaddyJSON)
 		}
 	}
 	for _, unwanted := range []string{"forward_proxy", "basic_auth", "probe_resistance"} {
-		if strings.Contains(profile.Caddyfile, unwanted) {
-			t.Fatalf("panel Caddyfile must not contain %q:\n%s", unwanted, profile.Caddyfile)
+		if strings.Contains(profile.CaddyJSON, unwanted) {
+			t.Fatalf("panel CaddyJSON must not contain %q:\n%s", unwanted, profile.CaddyJSON)
 		}
 	}
 }
@@ -40,7 +40,7 @@ func TestPanelCaddyInstallPlanOpensHTTPSInsteadOfPanelPort(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	plan, err := BuildInstallPlan(profile, InstallPlanInput{Platform: hostenv.Platform{OS: "linux", Arch: "amd64"}, SystemdUnits: []string{"veil.service", "veil-caddy@panel.service"}, PanelAccess: profile.PanelAccess, PanelPort: 2096})
+	plan, err := BuildInstallPlan(profile, InstallPlanInput{Platform: hostenv.Platform{OS: "linux", Arch: "amd64"}, SystemdUnits: []string{"veil.service", "veil-caddy.service"}, PanelAccess: profile.PanelAccess, PanelPort: 2096})
 	if err != nil {
 		t.Fatalf("BuildInstallPlan: %v", err)
 	}
@@ -79,10 +79,10 @@ func TestPanelCaddyInstallWritesCaddyfileAndCaddyRuntimeUnit(t *testing.T) {
 	}
 	body, err := os.ReadFile(result.CaddyfilePath)
 	if err != nil {
-		t.Fatalf("panel Caddyfile should be written: %v", err)
+		t.Fatalf("panel Caddy JSON should be written: %v", err)
 	}
-	if !strings.Contains(string(body), "reverse_proxy 127.0.0.1:2096") {
-		t.Fatalf("unexpected panel Caddyfile:\n%s", string(body))
+	if !strings.Contains(string(body), "127.0.0.1:2096") {
+		t.Fatalf("unexpected panel Caddy JSON:\n%s", string(body))
 	}
 	if _, err := os.Stat(filepath.Join(dir, "systemd", "veil-caddy.service")); err != nil {
 		t.Fatalf("Caddy runtime unit should be written for panel Caddy access: %v", err)

--- a/internal/installer/panel_caddy_install_test.go
+++ b/internal/installer/panel_caddy_install_test.go
@@ -84,7 +84,7 @@ func TestPanelCaddyInstallWritesCaddyfileAndCaddyRuntimeUnit(t *testing.T) {
 	if !strings.Contains(string(body), "reverse_proxy 127.0.0.1:2096") {
 		t.Fatalf("unexpected panel Caddyfile:\n%s", string(body))
 	}
-	if _, err := os.Stat(filepath.Join(dir, "systemd", "veil-caddy@.service")); err != nil {
+	if _, err := os.Stat(filepath.Join(dir, "systemd", "veil-caddy.service")); err != nil {
 		t.Fatalf("Caddy runtime unit should be written for panel Caddy access: %v", err)
 	}
 }

--- a/internal/installer/panel_only_install_test.go
+++ b/internal/installer/panel_only_install_test.go
@@ -83,7 +83,7 @@ func TestPanelOnlyInstallDoesNotRequireDomainAndWritesNoProxyConfigs(t *testing.
 	if err != nil {
 		t.Fatalf("BuildRURecommendedProfile panel-only: %v", err)
 	}
-	if profile.InstallPanelCaddy || profile.Caddyfile != "" {
+	if profile.InstallPanelCaddy || profile.CaddyJSON != "" {
 		t.Fatalf("panel-only profile should not include proxy artifacts: %+v", profile)
 	}
 	dir := t.TempDir()
@@ -96,7 +96,7 @@ func TestPanelOnlyInstallDoesNotRequireDomainAndWritesNoProxyConfigs(t *testing.
 		t.Fatalf("ApplyRURecommendedProfile: %v", err)
 	}
 	if _, err := os.Stat(result.CaddyfilePath); !os.IsNotExist(err) {
-		t.Fatalf("panel-only install should not write Caddyfile, stat err: %v", err)
+		t.Fatalf("panel-only install should not write Caddy config, stat err: %v", err)
 	}
 	if _, err := os.Stat(result.Hysteria2Path); !os.IsNotExist(err) {
 		t.Fatalf("panel-only install should not write Hysteria2 config, stat err: %v", err)

--- a/internal/installer/panel_systemd_units_test.go
+++ b/internal/installer/panel_systemd_units_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestPanelSystemdUnitsIncludesPanelReverseProxyUnit(t *testing.T) {
 	units := PanelSystemdUnits(RURecommendedProfile{InstallPanelCaddy: true})
-	want := []string{"veil-helper.socket", "veil.service", "veil-caddy@panel.service"}
+	want := []string{"veil-helper.socket", "veil.service", "veil-caddy.service"}
 	if !equalStringSlices(units, want) {
 		t.Fatalf("PanelSystemdUnits = %+v, want %+v", units, want)
 	}

--- a/internal/installer/plan.go
+++ b/internal/installer/plan.go
@@ -25,7 +25,7 @@ func CaddyPanelBuildHint(binaryPath string) BuildHint {
 func PanelSystemdUnits(profile RURecommendedProfile) []string {
 	units := []string{renderer.UnitHelperSocket, renderer.UnitVeil}
 	if profile.InstallPanelCaddy {
-		units = append(units, "veil-caddy@panel.service")
+		units = append(units, renderer.UnitCaddy)
 	}
 	return units
 }

--- a/internal/installer/profile_ru.go
+++ b/internal/installer/profile_ru.go
@@ -29,7 +29,7 @@ type RURecommendedProfile struct {
 	PanelTLSKeyPEM    string
 	WebBasePath       string
 	InstallPanelCaddy bool
-	Caddyfile         string
+	CaddyJSON         string
 	MasqueradeURL     string
 	FallbackRoot      string
 }
@@ -123,7 +123,7 @@ func (m RURecommendedProfileModule) Build() (RURecommendedProfile, error) {
 		PanelTLSKeyPEM:    panelAccess.PanelTLSKeyPEM,
 		WebBasePath:       panelAccess.WebBasePath,
 		InstallPanelCaddy: panelAccess.InstallPanelCaddy,
-		Caddyfile:         panelAccess.Caddyfile,
+		CaddyJSON:         panelAccess.CaddyJSON,
 		MasqueradeURL:     masqueradeURL,
 		FallbackRoot:      fallbackRoot,
 	}, nil

--- a/internal/installer/profile_ru_test.go
+++ b/internal/installer/profile_ru_test.go
@@ -23,7 +23,7 @@ func TestBuildRURecommendedProfileDefaultsToPanelOnly(t *testing.T) {
 	if profile.InstallPanelCaddy {
 		t.Fatalf("expected direct/local panel-only profile, got %+v", profile)
 	}
-	if profile.Caddyfile != "" {
+	if profile.CaddyJSON != "" {
 		t.Fatalf("panel-only profile should not include protocol artifacts: %+v", profile)
 	}
 	if profile.PanelAuthToken != "secret-panel" || !profile.PanelTLSEnabled {
@@ -54,22 +54,15 @@ func TestBuildRURecommendedProfileGeneratesWebBasePathForPanelCaddyAccess(t *tes
 	}
 }
 
-func TestBuildRURecommendedProfileIncludesPanelReverseProxyInCaddyfile(t *testing.T) {
+func TestBuildRURecommendedProfileIncludesPanelReverseProxyInCaddyJSON(t *testing.T) {
 	profile, err := BuildRURecommendedProfile(RURecommendedInput{PanelAccess: "caddy", Domain: "example.com", Email: "admin@example.com", Secret: func(label string) string { return "secret-" + label }, PanelPort: 2096})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(profile.Caddyfile, "reverse_proxy 127.0.0.1:2096") {
-		t.Fatalf("Caddyfile missing reverse_proxy for panel port:\n%s", profile.Caddyfile)
+	if !strings.Contains(profile.CaddyJSON, "127.0.0.1:2096") {
+		t.Fatalf("CaddyJSON missing reverse_proxy for panel port:\n%s", profile.CaddyJSON)
 	}
-	if !strings.Contains(profile.Caddyfile, "handle /"+strings.Trim(profile.WebBasePath, "/")+"/*") {
-		t.Fatalf("Caddyfile missing handle_path for web base path %s:\n%s", profile.WebBasePath, profile.Caddyfile)
-	}
-}
-
-func TestBuildRURecommendedProfileRejectsPanelCaddyWhenPanelPortZero(t *testing.T) {
-	_, err := BuildRURecommendedProfile(RURecommendedInput{PanelAccess: "caddy", Domain: "example.com", Email: "admin@example.com", Secret: func(label string) string { return "secret-" + label }, PanelPort: 0})
-	if err == nil {
-		t.Fatalf("expected Panel Caddy access to require selected Panel port")
+	if !strings.Contains(profile.CaddyJSON, profile.WebBasePath) {
+		t.Fatalf("CaddyJSON missing web base path %s:\n%s", profile.WebBasePath, profile.CaddyJSON)
 	}
 }

--- a/internal/installer/repair.go
+++ b/internal/installer/repair.go
@@ -43,7 +43,7 @@ func desiredManagedFiles(profile RURecommendedProfile, paths ApplyPaths) ([]mana
 		PanelTLSCertPEM:   profile.PanelTLSCertPEM,
 		PanelTLSKeyPEM:    profile.PanelTLSKeyPEM,
 		InstallPanelCaddy: profile.InstallPanelCaddy,
-		Caddyfile:         profile.Caddyfile,
+		CaddyJSON:         profile.CaddyJSON,
 	}).Files()
 	if err != nil {
 		return nil, err

--- a/internal/installer/repair_test.go
+++ b/internal/installer/repair_test.go
@@ -16,7 +16,7 @@ func TestBuildRepairPlanDetectsMissingFiles(t *testing.T) {
 	profile := RURecommendedProfile{
 		Domain:            "vpn.example.com",
 		InstallPanelCaddy: true,
-		Caddyfile:         "caddy content",
+		CaddyJSON:         "{}",
 	}
 
 	paths := ApplyPaths{
@@ -67,7 +67,7 @@ func TestBuildRepairPlanDetectsDriftedFiles(t *testing.T) {
 	profile := RURecommendedProfile{
 		Domain:            "vpn.example.com",
 		InstallPanelCaddy: true,
-		Caddyfile:         "expected caddy content",
+		CaddyJSON:         "{\"expected\":true}",
 	}
 
 	paths := ApplyPaths{
@@ -76,8 +76,8 @@ func TestBuildRepairPlanDetectsDriftedFiles(t *testing.T) {
 		SystemdDir: systemdDir,
 	}
 
-	// Pre-create Caddyfile with stale content
-	caddyPath := filepath.Join(etcDir, "generated", "caddy", "panel.Caddyfile")
+	// Pre-create Caddy JSON with stale content
+	caddyPath := filepath.Join(etcDir, "generated", "caddy", "config.json")
 	if err := os.MkdirAll(filepath.Dir(caddyPath), 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
@@ -100,14 +100,14 @@ func TestBuildRepairPlanDetectsDriftedFiles(t *testing.T) {
 			if action.Reason != RepairReasonDrifted {
 				t.Fatalf("expected caddy to be 'drifted', got %q", action.Reason)
 			}
-			if action.Content != "expected caddy content" {
-				t.Fatalf("expected caddy repair content to be 'expected caddy content', got %q", action.Content)
+			if action.Content != "{\"expected\":true}" {
+				t.Fatalf("expected caddy repair content to be '{\"expected\":true}', got %q", action.Content)
 			}
 			foundDrift = true
 		}
 	}
 	if !foundDrift {
-		t.Fatalf("expected drift action for Caddyfile, actions: %+v", plan.Actions)
+		t.Fatalf("expected drift action for Caddy config, actions: %+v", plan.Actions)
 	}
 }
 
@@ -127,7 +127,7 @@ func TestBuildRepairPlanNoChangesWhenFilesMatch(t *testing.T) {
 	profile := RURecommendedProfile{
 		Domain:            "vpn.example.com",
 		InstallPanelCaddy: true,
-		Caddyfile:         "caddy content",
+		CaddyJSON:         "{}",
 	}
 
 	paths := ApplyPaths{
@@ -135,12 +135,12 @@ func TestBuildRepairPlanNoChangesWhenFilesMatch(t *testing.T) {
 		VarDir: varDir,
 	}
 
-	// Pre-create Caddyfile with matching content
-	caddyPath := filepath.Join(etcDir, "generated", "caddy", "panel.Caddyfile")
+	// Pre-create Caddy JSON with matching content
+	caddyPath := filepath.Join(etcDir, "generated", "caddy", "config.json")
 	if err := os.MkdirAll(filepath.Dir(caddyPath), 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
-	if err := os.WriteFile(caddyPath, []byte("caddy content"), 0o600); err != nil {
+	if err := os.WriteFile(caddyPath, []byte("{}"), 0o600); err != nil {
 		t.Fatalf("write caddy: %v", err)
 	}
 

--- a/internal/installer/systemd_binary_path_test.go
+++ b/internal/installer/systemd_binary_path_test.go
@@ -30,9 +30,9 @@ func TestInstallApplyRendersCaddyUnitWithResolvedBinaryPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("desiredFiles: %v", err)
 	}
-	unit := managedFileContent(files, "veil-caddy@.service")
+	unit := managedFileContent(files, "veil-caddy.service")
 	if !strings.Contains(unit, "ExecStart=/usr/bin/caddy run --config") || !strings.Contains(unit, "ExecReload=/usr/bin/caddy reload --config") {
-		t.Fatalf("veil-caddy@.service should use resolved Caddy binary path:\n%s", unit)
+		t.Fatalf("veil-caddy.service should use resolved Caddy binary path:\n%s", unit)
 	}
 }
 

--- a/internal/installer/systemd_binary_path_test.go
+++ b/internal/installer/systemd_binary_path_test.go
@@ -23,7 +23,7 @@ func TestInstallApplyRendersVeilUnitWithSelectedBinaryPath(t *testing.T) {
 
 func TestInstallApplyRendersCaddyUnitWithResolvedBinaryPath(t *testing.T) {
 	dir := t.TempDir()
-	profile := RURecommendedProfile{InstallPanelCaddy: true, PanelAuthToken: "secret-panel", Caddyfile: "example.com { respond ok }"}
+	profile := RURecommendedProfile{InstallPanelCaddy: true, PanelAuthToken: "secret-panel", CaddyJSON: "{}"}
 	paths := ApplyPaths{EtcDir: filepath.Join(dir, "etc", "veil"), VarDir: filepath.Join(dir, "var", "lib", "veil"), SystemdDir: filepath.Join(dir, "systemd"), CaddyBinary: "/usr/bin/caddy"}
 
 	files, err := desiredManagedFiles(profile, paths)

--- a/internal/livevalidation/validator.go
+++ b/internal/livevalidation/validator.go
@@ -58,7 +58,7 @@ func (v Validator) Validate(ctx context.Context, request Request) Response {
 				response.Issues = append(response.Issues, issue(
 					"dns_unresolved",
 					SeverityWarning,
-					"settings.domain",
+					"domain",
 					inbound.Name,
 					fmt.Sprintf("Configured domain %q does not resolve", domain),
 					"Create or correct the DNS record before applying this configuration.",
@@ -237,20 +237,9 @@ func unitForInbound(protocol string, inbound model.Inbound, descriptors []servic
 
 func requiredFieldIssues(settings model.Settings, inbound model.Inbound) []model.ValidationIssue {
 	issues := []model.ValidationIssue{}
-	if protocolNeedsDomain(settings, inbound) && model.ResolveInboundDomain(inbound, settings) == "" {
-		issues = append(issues, issue(
-			"domain_required", SeverityError, "settings.domain", inbound.Name,
-			"This protocol requires a public domain",
-			"Set the domain that resolves to this host.", "candidate",
-		))
-	}
-	if protocolNeedsEmail(settings, inbound) && model.ResolveInboundEmail(inbound, settings) == "" {
-		issues = append(issues, issue(
-			"email_required", SeverityError, "settings.email", inbound.Name,
-			"This protocol requires an email address",
-			"Set the ACME contact email.", "candidate",
-		))
-	}
+	// Domain/email presence and validity are now checked by protocol-specific
+	// ValidateInbound implementations, which can distinguish between inbound and
+	// global fields. Only the generic credential check remains here.
 	if !hasCredential(settings, inbound) {
 		issues = append(issues, issue(
 			"credential_required", SeverityError, "password", inbound.Name,
@@ -283,18 +272,6 @@ func protocolNeedsDomain(settings model.Settings, inbound model.Inbound) bool {
 		return false
 	}
 	return validator.NeedsDomain(settings, inbound)
-}
-
-func protocolNeedsEmail(settings model.Settings, inbound model.Inbound) bool {
-	p, ok := protocolRegistry().Get(inbound.Protocol)
-	if !ok {
-		return false
-	}
-	validator, ok := protocols.AsValidator(p)
-	if !ok {
-		return false
-	}
-	return validator.NeedsEmail(settings, inbound)
 }
 
 func hasCredential(settings model.Settings, inbound model.Inbound) bool {

--- a/internal/livevalidation/validator.go
+++ b/internal/livevalidation/validator.go
@@ -58,7 +58,7 @@ func (v Validator) Validate(ctx context.Context, request Request) Response {
 				response.Issues = append(response.Issues, issue(
 					"dns_unresolved",
 					SeverityWarning,
-					"domain",
+					model.InboundDomainField,
 					inbound.Name,
 					fmt.Sprintf("Configured domain %q does not resolve", domain),
 					"Create or correct the DNS record before applying this configuration.",

--- a/internal/livevalidation/validator.go
+++ b/internal/livevalidation/validator.go
@@ -40,17 +40,31 @@ func (v Validator) Validate(ctx context.Context, request Request) Response {
 		}
 	}
 
-	if needsDNS && strings.TrimSpace(request.Settings.Domain) != "" && v.DNS != nil {
-		if addresses, err := v.DNS.LookupHost(ctx, request.Settings.Domain); err != nil || len(addresses) == 0 {
-			response.Issues = append(response.Issues, issue(
-				"dns_unresolved",
-				SeverityWarning,
-				"settings.domain",
-				"",
-				"Configured domain does not resolve",
-				"Create or correct the DNS record before applying this configuration.",
-				"live-host",
-			))
+	if needsDNS && v.DNS != nil {
+		checked := map[string]struct{}{}
+		for _, inbound := range request.Inbounds {
+			if !inbound.Enabled || !protocolNeedsDomain(request.Settings, inbound) {
+				continue
+			}
+			domain := model.ResolveInboundDomain(inbound, request.Settings)
+			if domain == "" {
+				continue
+			}
+			if _, ok := checked[domain]; ok {
+				continue
+			}
+			checked[domain] = struct{}{}
+			if addresses, err := v.DNS.LookupHost(ctx, domain); err != nil || len(addresses) == 0 {
+				response.Issues = append(response.Issues, issue(
+					"dns_unresolved",
+					SeverityWarning,
+					"settings.domain",
+					inbound.Name,
+					fmt.Sprintf("Configured domain %q does not resolve", domain),
+					"Create or correct the DNS record before applying this configuration.",
+					"live-host",
+				))
+			}
 		}
 	}
 
@@ -223,14 +237,14 @@ func unitForInbound(protocol string, inbound model.Inbound, descriptors []servic
 
 func requiredFieldIssues(settings model.Settings, inbound model.Inbound) []model.ValidationIssue {
 	issues := []model.ValidationIssue{}
-	if protocolNeedsDomain(settings, inbound) && strings.TrimSpace(settings.Domain) == "" {
+	if protocolNeedsDomain(settings, inbound) && model.ResolveInboundDomain(inbound, settings) == "" {
 		issues = append(issues, issue(
 			"domain_required", SeverityError, "settings.domain", inbound.Name,
 			"This protocol requires a public domain",
 			"Set the domain that resolves to this host.", "candidate",
 		))
 	}
-	if protocolNeedsEmail(settings, inbound) && strings.TrimSpace(settings.Email) == "" {
+	if protocolNeedsEmail(settings, inbound) && model.ResolveInboundEmail(inbound, settings) == "" {
 		issues = append(issues, issue(
 			"email_required", SeverityError, "settings.email", inbound.Name,
 			"This protocol requires an email address",

--- a/internal/livevalidation/validator_test.go
+++ b/internal/livevalidation/validator_test.go
@@ -164,8 +164,9 @@ func TestValidatorReportsMissingDomainEmailCredentialBinaryAndUnit(t *testing.T)
 	})
 
 	for _, code := range []string{
-		"domain_required",
-		"email_required",
+		"naive_domain_required",
+		"naive_email_required",
+		"naive_credential_required",
 		"credential_required",
 		"runtime_binary_missing",
 		"runtime_unit_missing",
@@ -180,13 +181,19 @@ func TestValidatorReportsUnresolvedDomainAndProbeFailure(t *testing.T) {
 
 	response := validator.Validate(context.Background(), Request{
 		Settings: model.Settings{
-			Domain:        "missing.example",
-			Email:         "admin@example.com",
 			NaiveUsername: "veil",
 			NaivePassword: "secret",
 		},
 		Inbounds: []model.Inbound{{
-			Name: "public", Protocol: "naiveproxy", Transport: "tcp", Port: 443, Enabled: true,
+			Name:      "public",
+			Protocol:  "naiveproxy",
+			Transport: "tcp",
+			Port:      443,
+			Enabled:   true,
+			ProtocolFields: map[string]any{
+				"domain": "missing.example",
+				"email":  "admin@example.com",
+			},
 		}},
 	})
 
@@ -202,13 +209,19 @@ func TestValidatorTreatsExternalDNSAndRuntimeAvailabilityAsWarnings(t *testing.T
 
 	response := validator.Validate(context.Background(), Request{
 		Settings: model.Settings{
-			Domain:        "pending.example",
-			Email:         "admin@example.com",
 			NaiveUsername: "veil",
 			NaivePassword: "secret",
 		},
 		Inbounds: []model.Inbound{{
-			Name: "public", Protocol: "naiveproxy", Transport: "tcp", Port: 443, Enabled: true,
+			Name:     "public",
+			Protocol: "naiveproxy",
+			Transport: "tcp",
+			Port:      443,
+			Enabled:   true,
+			ProtocolFields: map[string]any{
+				"domain": "pending.example",
+				"email":  "admin@example.com",
+			},
 		}},
 	})
 

--- a/internal/livevalidation/validator_test.go
+++ b/internal/livevalidation/validator_test.go
@@ -213,8 +213,8 @@ func TestValidatorTreatsExternalDNSAndRuntimeAvailabilityAsWarnings(t *testing.T
 			NaivePassword: "secret",
 		},
 		Inbounds: []model.Inbound{{
-			Name:     "public",
-			Protocol: "naiveproxy",
+			Name:      "public",
+			Protocol:  "naiveproxy",
 			Transport: "tcp",
 			Port:      443,
 			Enabled:   true,

--- a/internal/managementstate/codec.go
+++ b/internal/managementstate/codec.go
@@ -102,6 +102,13 @@ func (ManagementStateCodec) Decode(body []byte) (model.ManagementSnapshot, error
 			}
 		}
 
+		if schemaVersion > CurrentSchemaVersion {
+			// A state file from a newer build would be silently overwritten with
+			// CurrentSchemaVersion on the next Save, discarding future fields.
+			// Refuse to load it instead of downgrading.
+			return model.ManagementSnapshot{}, fmt.Errorf("state schema version %d is newer than supported version %d", schemaVersion, CurrentSchemaVersion)
+		}
+
 		migrated := false
 		for schemaVersion < CurrentSchemaVersion {
 			migrateFn, ok := migrations[schemaVersion]

--- a/internal/managementstate/codec.go
+++ b/internal/managementstate/codec.go
@@ -8,35 +8,26 @@ import (
 	"io"
 
 	"github.com/mikkelchokolate/Veil/internal/model"
-	"github.com/mikkelchokolate/Veil/internal/protocols"
-	"github.com/mikkelchokolate/Veil/internal/protocols/schema"
 )
 
 const CurrentSchemaVersion = 4
 
 // settingsProtocolFieldKeys are legacy flat settings fields that are now kept
-// inside settings.protocolFields for dynamic UI/validation. They are derived
-// from the registered protocol plugins so the migration stays consistent with
-// the plugin architecture.
-var settingsProtocolFieldKeys = protocolFieldKeys(protocols.NewRegistry().SettingsFieldSchemas())
+// inside settings.protocolFields for dynamic UI/validation.
+var settingsProtocolFieldKeys = []string{
+	"naiveUsername", "naivePassword",
+	"hysteria2Password", "hysteria2Insecure", "masqueradeURL",
+	"fallbackRoot",
+	"olcrtcAuth", "olcrtcTransport", "olcrtcRoomID",
+}
 
 // inboundProtocolFieldKeys are legacy flat inbound fields that are now kept
-// inside inbound.protocolFields for dynamic UI/validation. They are derived
-// from the registered protocol plugins so the migration stays consistent with
-// the plugin architecture.
-var inboundProtocolFieldKeys = protocolFieldKeys(protocols.NewRegistry().InboundFieldSchemas())
-
-func protocolFieldKeys(schemas []schema.FieldSchema) []string {
-	keys := make([]string, 0, len(schemas))
-	seen := make(map[string]struct{}, len(schemas))
-	for _, f := range schemas {
-		if _, ok := seen[f.Key]; ok {
-			continue
-		}
-		seen[f.Key] = struct{}{}
-		keys = append(keys, f.Key)
-	}
-	return keys
+// inside inbound.protocolFields for dynamic UI/validation.
+var inboundProtocolFieldKeys = []string{
+	"naiveUsername", "naivePassword",
+	"hysteria2Password", "hysteria2Insecure", "masqueradeURL",
+	"fallbackRoot",
+	"olcrtcAuth", "olcrtcTransport", "olcrtcRoomID",
 }
 
 func moveToProtocolFields(obj map[string]interface{}, keys []string) map[string]interface{} {

--- a/internal/managementstate/validation.go
+++ b/internal/managementstate/validation.go
@@ -66,11 +66,16 @@ func (Validation) ValidateSnapshot(snapshot model.ManagementSnapshot, fields map
 	}
 
 	if _, ok := fields["inbounds"]; ok {
+		seenInboundNames := map[string]int{}
 		for i, inbound := range snapshot.Inbounds {
 			if inbound.Name == "" {
 				errs = append(errs, "inbounds["+itoa(i)+"].name is required")
 			} else if !inbounds.IsSafeName(inbound.Name) {
 				errs = append(errs, "inbounds["+itoa(i)+"].name must contain only letters, digits, underscore, or hyphen")
+			} else if prev, dup := seenInboundNames[inbound.Name]; dup {
+				errs = append(errs, fmt.Sprintf("inbounds[%d]: duplicate name %q also used by inbounds[%d]", i, inbound.Name, prev))
+			} else {
+				seenInboundNames[inbound.Name] = i
 			}
 			if inbound.Protocol == "" {
 				errs = append(errs, "inbounds["+itoa(i)+"].protocol is required")
@@ -96,9 +101,14 @@ func (Validation) ValidateSnapshot(snapshot model.ManagementSnapshot, fields map
 		}
 	}
 	if _, ok := fields["routingRules"]; ok {
+		seenRuleNames := map[string]int{}
 		for i, rule := range snapshot.Rules {
 			if rule.Name == "" {
 				errs = append(errs, "routingRules["+itoa(i)+"].name is required")
+			} else if prev, dup := seenRuleNames[rule.Name]; dup {
+				errs = append(errs, fmt.Sprintf("routingRules[%d]: duplicate name %q also used by routingRules[%d]", i, rule.Name, prev))
+			} else {
+				seenRuleNames[rule.Name] = i
 			}
 			if rule.Match == "" {
 				errs = append(errs, "routingRules["+itoa(i)+"].match is required")

--- a/internal/model/inbound_domain.go
+++ b/internal/model/inbound_domain.go
@@ -1,0 +1,67 @@
+package model
+
+import (
+	"strings"
+)
+
+// InboundDomain returns the inbound-specific domain declared in
+// inbound.ProtocolFields["domain"], trimmed of whitespace and normalized to
+// lowercase. It does NOT fall back to settings.Domain. An empty string is
+// returned when the inbound has no valid per-inbound domain.
+func InboundDomain(inbound Inbound) string {
+	if inbound.ProtocolFields == nil {
+		return ""
+	}
+	v, ok := inbound.ProtocolFields["domain"].(string)
+	if !ok {
+		return ""
+	}
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return ""
+	}
+	return strings.ToLower(v)
+}
+
+// ResolveInboundDomain returns the effective public domain for an inbound.
+// It prefers inbound.ProtocolFields["domain"] and falls back to
+// settings.Domain. The result is trimmed and lowercased.
+func ResolveInboundDomain(inbound Inbound, settings Settings) string {
+	if d := InboundDomain(inbound); d != "" {
+		return d
+	}
+	return strings.ToLower(strings.TrimSpace(settings.Domain))
+}
+
+// InboundEmail returns the inbound-specific ACME email declared in
+// inbound.ProtocolFields["email"], trimmed of whitespace. It does NOT fall
+// back to settings-level emails.
+func InboundEmail(inbound Inbound) string {
+	if inbound.ProtocolFields == nil {
+		return ""
+	}
+	v, ok := inbound.ProtocolFields["email"].(string)
+	if !ok {
+		return ""
+	}
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return ""
+	}
+	return v
+}
+
+// ResolveInboundEmail returns the effective ACME email for an inbound.
+// It prefers inbound.ProtocolFields["email"] and falls back to
+// settings.DefaultAcmeEmail, settings.PanelEmail, and finally settings.Email.
+func ResolveInboundEmail(inbound Inbound, settings Settings) string {
+	if e := InboundEmail(inbound); e != "" {
+		return e
+	}
+	for _, e := range []string{settings.DefaultAcmeEmail, settings.PanelEmail, settings.Email} {
+		if v := strings.TrimSpace(e); v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/model/inbound_domain.go
+++ b/internal/model/inbound_domain.go
@@ -4,15 +4,23 @@ import (
 	"strings"
 )
 
+// Field keys used in inbound.ProtocolFields for per-inbound domain and ACME
+// email configuration. Centralized here so validators, UI schemas, and client
+// exporters share a single source of truth.
+const (
+	InboundDomainField = "domain"
+	InboundEmailField  = "email"
+)
+
 // InboundDomain returns the inbound-specific domain declared in
-// inbound.ProtocolFields["domain"], trimmed of whitespace and normalized to
-// lowercase. It does NOT fall back to settings.Domain. An empty string is
-// returned when the inbound has no valid per-inbound domain.
+// inbound.ProtocolFields[InboundDomainField], trimmed of whitespace and
+// normalized to lowercase. It does NOT fall back to settings.Domain. An empty
+// string is returned when the inbound has no valid per-inbound domain.
 func InboundDomain(inbound Inbound) string {
 	if inbound.ProtocolFields == nil {
 		return ""
 	}
-	v, ok := inbound.ProtocolFields["domain"].(string)
+	v, ok := inbound.ProtocolFields[InboundDomainField].(string)
 	if !ok {
 		return ""
 	}
@@ -24,7 +32,7 @@ func InboundDomain(inbound Inbound) string {
 }
 
 // ResolveInboundDomain returns the effective public domain for an inbound.
-// It prefers inbound.ProtocolFields["domain"] and falls back to
+// It prefers inbound.ProtocolFields[InboundDomainField] and falls back to
 // settings.Domain. The result is trimmed and lowercased.
 func ResolveInboundDomain(inbound Inbound, settings Settings) string {
 	if d := InboundDomain(inbound); d != "" {
@@ -34,13 +42,13 @@ func ResolveInboundDomain(inbound Inbound, settings Settings) string {
 }
 
 // InboundEmail returns the inbound-specific ACME email declared in
-// inbound.ProtocolFields["email"], trimmed of whitespace. It does NOT fall
-// back to settings-level emails.
+// inbound.ProtocolFields[InboundEmailField], trimmed of whitespace. It does NOT
+// fall back to settings-level emails.
 func InboundEmail(inbound Inbound) string {
 	if inbound.ProtocolFields == nil {
 		return ""
 	}
-	v, ok := inbound.ProtocolFields["email"].(string)
+	v, ok := inbound.ProtocolFields[InboundEmailField].(string)
 	if !ok {
 		return ""
 	}

--- a/internal/model/inbound_domain.go
+++ b/internal/model/inbound_domain.go
@@ -51,14 +51,17 @@ func InboundEmail(inbound Inbound) string {
 	return v
 }
 
-// ResolveInboundEmail returns the effective ACME email for an inbound.
-// It prefers inbound.ProtocolFields["email"] and falls back to
-// settings.DefaultAcmeEmail, settings.PanelEmail, and finally settings.Email.
+// ResolveInboundEmail returns the effective ACME email for an inbound-specific
+// domain. It prefers inbound.ProtocolFields["email"] and falls back to
+// settings.DefaultAcmeEmail and settings.PanelEmail. It intentionally does NOT
+// fall back to the legacy settings.Email, because that global email is reserved
+// for the panel's own domain and should not silently issue certificates for
+// unrelated inbound domains.
 func ResolveInboundEmail(inbound Inbound, settings Settings) string {
 	if e := InboundEmail(inbound); e != "" {
 		return e
 	}
-	for _, e := range []string{settings.DefaultAcmeEmail, settings.PanelEmail, settings.Email} {
+	for _, e := range []string{settings.DefaultAcmeEmail, settings.PanelEmail} {
 		if v := strings.TrimSpace(e); v != "" {
 			return v
 		}

--- a/internal/model/inbound_domain_test.go
+++ b/internal/model/inbound_domain_test.go
@@ -76,8 +76,8 @@ func TestResolveInboundEmail(t *testing.T) {
 		{"inbound wins", Inbound{ProtocolFields: map[string]any{"email": "inbound@x.com"}}, Settings{Email: "global@x.com"}, "inbound@x.com"},
 		{"fallback default", Inbound{}, Settings{DefaultAcmeEmail: "default@x.com"}, "default@x.com"},
 		{"fallback panel", Inbound{}, Settings{PanelEmail: "panel@x.com"}, "panel@x.com"},
-		{"fallback global", Inbound{}, Settings{Email: "global@x.com"}, "global@x.com"},
-		{"empty inbound falls back", Inbound{ProtocolFields: map[string]any{"email": "   "}}, Settings{Email: "global@x.com"}, "global@x.com"},
+		{"no fallback to legacy global email", Inbound{}, Settings{Email: "global@x.com"}, ""},
+		{"empty inbound falls back to default", Inbound{ProtocolFields: map[string]any{"email": "   "}}, Settings{DefaultAcmeEmail: "default@x.com"}, "default@x.com"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/model/inbound_domain_test.go
+++ b/internal/model/inbound_domain_test.go
@@ -1,0 +1,89 @@
+package model
+
+import "testing"
+
+func TestInboundDomain(t *testing.T) {
+	cases := []struct {
+		name    string
+		inbound Inbound
+		want    string
+	}{
+		{"nil fields", Inbound{}, ""},
+		{"missing key", Inbound{ProtocolFields: map[string]any{}}, ""},
+		{"non-string", Inbound{ProtocolFields: map[string]any{"domain": 123}}, ""},
+		{"whitespace only", Inbound{ProtocolFields: map[string]any{"domain": "   "}}, ""},
+		{"trimmed", Inbound{ProtocolFields: map[string]any{"domain": "  Example.COM  "}}, "example.com"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := InboundDomain(tc.inbound); got != tc.want {
+				t.Fatalf("InboundDomain() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveInboundDomain(t *testing.T) {
+	cases := []struct {
+		name     string
+		inbound  Inbound
+		settings Settings
+		want     string
+	}{
+		{"inbound wins", Inbound{ProtocolFields: map[string]any{"domain": "inbound.example.com"}}, Settings{Domain: "global.example.com"}, "inbound.example.com"},
+		{"fallback to settings", Inbound{}, Settings{Domain: "global.example.com"}, "global.example.com"},
+		{"inbound without global", Inbound{ProtocolFields: map[string]any{"domain": "inbound.example.com"}}, Settings{}, "inbound.example.com"},
+		{"empty inbound falls back", Inbound{ProtocolFields: map[string]any{"domain": "   "}}, Settings{Domain: "global.example.com"}, "global.example.com"},
+		{"lowercases settings domain", Inbound{}, Settings{Domain: "GLOBAL.EXAMPLE.COM"}, "global.example.com"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ResolveInboundDomain(tc.inbound, tc.settings); got != tc.want {
+				t.Fatalf("ResolveInboundDomain() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestInboundEmail(t *testing.T) {
+	cases := []struct {
+		name    string
+		inbound Inbound
+		want    string
+	}{
+		{"nil fields", Inbound{}, ""},
+		{"missing key", Inbound{ProtocolFields: map[string]any{}}, ""},
+		{"non-string", Inbound{ProtocolFields: map[string]any{"email": true}}, ""},
+		{"whitespace only", Inbound{ProtocolFields: map[string]any{"email": "   "}}, ""},
+		{"trimmed", Inbound{ProtocolFields: map[string]any{"email": "  a@x.com  "}}, "a@x.com"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := InboundEmail(tc.inbound); got != tc.want {
+				t.Fatalf("InboundEmail() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveInboundEmail(t *testing.T) {
+	cases := []struct {
+		name     string
+		inbound  Inbound
+		settings Settings
+		want     string
+	}{
+		{"inbound wins", Inbound{ProtocolFields: map[string]any{"email": "inbound@x.com"}}, Settings{Email: "global@x.com"}, "inbound@x.com"},
+		{"fallback default", Inbound{}, Settings{DefaultAcmeEmail: "default@x.com"}, "default@x.com"},
+		{"fallback panel", Inbound{}, Settings{PanelEmail: "panel@x.com"}, "panel@x.com"},
+		{"fallback global", Inbound{}, Settings{Email: "global@x.com"}, "global@x.com"},
+		{"empty inbound falls back", Inbound{ProtocolFields: map[string]any{"email": "   "}}, Settings{Email: "global@x.com"}, "global@x.com"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ResolveInboundEmail(tc.inbound, tc.settings); got != tc.want {
+				t.Fatalf("ResolveInboundEmail() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -1,17 +1,17 @@
 package model
 
 type Settings struct {
-	PanelListen       string `json:"panelListen"`
-	PanelAccess       string `json:"panelAccess,omitempty"`
-	WebBasePath       string `json:"webBasePath,omitempty"`
-	Mode              string `json:"mode"`
-	Domain            string `json:"domain,omitempty"`
-	Email             string `json:"email,omitempty"`
-	NaiveUsername     string `json:"naiveUsername,omitempty"`
-	NaivePassword     string `json:"naivePassword,omitempty"`
-	Hysteria2Password string `json:"hysteria2Password,omitempty"`
-	Hysteria2Insecure bool   `json:"hysteria2Insecure,omitempty"`
-	MasqueradeURL     string `json:"masqueradeURL,omitempty"`
+	PanelListen              string `json:"panelListen"`
+	PanelAccess              string `json:"panelAccess,omitempty"`
+	WebBasePath              string `json:"webBasePath,omitempty"`
+	Mode                     string `json:"mode"`
+	Domain                   string `json:"domain,omitempty"`
+	Email                    string `json:"email,omitempty"`
+	NaiveUsername            string `json:"naiveUsername,omitempty"`
+	NaivePassword            string `json:"naivePassword,omitempty"`
+	Hysteria2Password        string `json:"hysteria2Password,omitempty"`
+	Hysteria2Insecure        bool   `json:"hysteria2Insecure,omitempty"`
+	MasqueradeURL            string `json:"masqueradeURL,omitempty"`
 	FallbackRoot             string `json:"fallbackRoot,omitempty"`
 	OlcrtcAuth               string `json:"olcrtcAuth,omitempty"`
 	OlcrtcTransport          string `json:"olcrtcTransport,omitempty"`

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -12,10 +12,16 @@ type Settings struct {
 	Hysteria2Password string `json:"hysteria2Password,omitempty"`
 	Hysteria2Insecure bool   `json:"hysteria2Insecure,omitempty"`
 	MasqueradeURL     string `json:"masqueradeURL,omitempty"`
-	FallbackRoot      string `json:"fallbackRoot,omitempty"`
-	OlcrtcAuth        string `json:"olcrtcAuth,omitempty"`
-	OlcrtcTransport   string `json:"olcrtcTransport,omitempty"`
-	OlcrtcRoomID      string `json:"olcrtcRoomID,omitempty"`
+	FallbackRoot             string `json:"fallbackRoot,omitempty"`
+	OlcrtcAuth               string `json:"olcrtcAuth,omitempty"`
+	OlcrtcTransport          string `json:"olcrtcTransport,omitempty"`
+	OlcrtcRoomID             string `json:"olcrtcRoomID,omitempty"`
+	PanelDomain              string `json:"panelDomain,omitempty"`
+	PanelEmail               string `json:"panelEmail,omitempty"`
+	PanelPublicPort          int    `json:"panelPublicPort,omitempty"`
+	DefaultAcmeEmail         string `json:"defaultAcmeEmail,omitempty"`
+	DefaultInboundPublicPort int    `json:"defaultInboundPublicPort,omitempty"`
+	AcmeChallengeMode        string `json:"acmeChallengeMode,omitempty"`
 	// ProtocolFields holds protocol-specific settings populated by the dynamic
 	// Panel UI. Legacy flat fields above are still supported for backward
 	// compatibility and are migrated into ProtocolFields on load.

--- a/internal/panelaccess/panel_access.go
+++ b/internal/panelaccess/panel_access.go
@@ -4,7 +4,10 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"strings"
 
+	"github.com/mikkelchokolate/Veil/internal/caddyassembly"
+	"github.com/mikkelchokolate/Veil/internal/caddycapabilities"
 	"github.com/mikkelchokolate/Veil/internal/generatedconfig"
 	"github.com/mikkelchokolate/Veil/internal/model"
 	"github.com/mikkelchokolate/Veil/internal/renderer"
@@ -55,15 +58,28 @@ func (p PanelAccess) CaddyRoute() (CaddyRoute, bool, error) {
 }
 
 func (p PanelAccess) GeneratedConfig(paths generatedconfig.Paths) (generatedconfig.GeneratedConfigArtifact, bool, error) {
-	route, ok, err := p.CaddyRoute()
-	if err != nil || !ok {
+	if _, ok, err := p.CaddyRoute(); err != nil || !ok {
 		return generatedconfig.GeneratedConfigArtifact{}, ok, err
 	}
-	body, err := renderer.RenderPanelCaddyfile(renderer.PanelCaddyConfig{Domain: p.settings.Domain, Email: p.settings.Email, PanelPort: route.Port, WebBasePath: route.WebBasePath})
+	if strings.TrimSpace(p.settings.Domain) == "" {
+		return generatedconfig.GeneratedConfigArtifact{}, false, fmt.Errorf("domain is required for caddy Panel access")
+	}
+	if !hasAcmeEmail(p.settings) {
+		return generatedconfig.GeneratedConfigArtifact{}, false, fmt.Errorf("ACME email is required for caddy Panel access")
+	}
+	plan, _, _, err := caddyassembly.BuildFinalRenderPlan(p.settings, nil)
 	if err != nil {
 		return generatedconfig.GeneratedConfigArtifact{}, false, err
 	}
-	return generatedconfig.GeneratedConfigArtifact{Path: paths.Caddyfile(), Body: body}, true, nil
+	caps, err := caddycapabilities.Probe("")
+	if err != nil {
+		return generatedconfig.GeneratedConfigArtifact{}, false, fmt.Errorf("failed to probe Caddy capabilities: %w", err)
+	}
+	body, err := renderer.RenderCaddyJSON(plan, caps)
+	if err != nil {
+		return generatedconfig.GeneratedConfigArtifact{}, false, err
+	}
+	return generatedconfig.GeneratedConfigArtifact{Path: paths.CaddyJSON(), Body: string(body)}, true, nil
 }
 
 func (p PanelAccess) ApplyIntent(inbounds []model.Inbound) ApplyIntent {
@@ -71,42 +87,14 @@ func (p PanelAccess) ApplyIntent(inbounds []model.Inbound) ApplyIntent {
 	if p.settings.PanelAccess != "caddy" {
 		return intent
 	}
-	if p.settings.Domain == "" || p.settings.Email == "" {
+	if p.settings.Domain == "" || !hasAcmeEmail(p.settings) {
 		intent.Errors = append(intent.Errors, "--domain and --email are required for caddy Panel access")
 	} else if _, _, err := p.CaddyRoute(); err != nil {
 		intent.Errors = append(intent.Errors, err.Error())
 	} else {
-		var panelInbound *model.Inbound
-		hasInboundOn443 := false
-		for _, inbound := range inbounds {
-			if inbound.Enabled && p.protocolRequiresCaddy(inbound.Protocol) {
-				if inbound.Port == 443 {
-					hasInboundOn443 = true
-					break
-				}
-			}
-		}
-		for _, inbound := range inbounds {
-			if inbound.Enabled && p.protocolRequiresCaddy(inbound.Protocol) {
-				if inbound.Port == 443 || (!hasInboundOn443 && panelInbound == nil) {
-					copied := inbound
-					panelInbound = &copied
-					if inbound.Port == 443 {
-						break
-					}
-				}
-			}
-		}
-
-		if panelInbound != nil {
-			intent.Configs = append(intent.Configs, "/etc/veil/generated/caddy/"+panelInbound.Name+".Caddyfile")
-			intent.Actions = append(intent.Actions, "reload veil-caddy@"+panelInbound.Name+".service")
-			intent.Runtimes = append(intent.Runtimes, "veil-caddy@"+panelInbound.Name+".service")
-		} else {
-			intent.Configs = append(intent.Configs, "/etc/veil/generated/caddy/panel.Caddyfile")
-			intent.Actions = append(intent.Actions, "reload veil-caddy@panel.service")
-			intent.Runtimes = append(intent.Runtimes, "veil-caddy@panel.service")
-		}
+		intent.Configs = append(intent.Configs, "/etc/veil/generated/caddy/config.json")
+		intent.Actions = append(intent.Actions, "reload veil-caddy.service")
+		intent.Runtimes = append(intent.Runtimes, "veil-caddy.service")
 	}
 	for _, inbound := range inbounds {
 		if !inbound.Enabled {

--- a/internal/panelaccess/panel_access_more_test.go
+++ b/internal/panelaccess/panel_access_more_test.go
@@ -114,14 +114,14 @@ func TestApplyIntentSelectsInboundOn443(t *testing.T) {
 		{Name: "naive", Protocol: "naiveproxy", Transport: "tcp", Port: 443, Enabled: true},
 	}
 	intent := access.ApplyIntent(inbounds)
-	if !contains(intent.Configs, "/etc/veil/generated/caddy/naive.Caddyfile") {
-		t.Fatalf("expected naive.Caddyfile config, got %+v", intent.Configs)
+	if !contains(intent.Configs, "/etc/veil/generated/caddy/config.json") {
+		t.Fatalf("expected consolidated config.json, got %+v", intent.Configs)
 	}
-	if !contains(intent.Actions, "reload veil-caddy@naive.service") {
-		t.Fatalf("expected naive service action, got %+v", intent.Actions)
+	if !contains(intent.Actions, "reload veil-caddy.service") {
+		t.Fatalf("expected consolidated caddy service action, got %+v", intent.Actions)
 	}
-	if !contains(intent.Runtimes, "veil-caddy@naive.service") {
-		t.Fatalf("expected naive runtime, got %+v", intent.Runtimes)
+	if !contains(intent.Runtimes, "veil-caddy.service") {
+		t.Fatalf("expected consolidated caddy runtime, got %+v", intent.Runtimes)
 	}
 	if len(intent.Errors) != 0 {
 		t.Fatalf("expected no errors, got %+v", intent.Errors)
@@ -137,8 +137,11 @@ func TestApplyIntentFallsBackToFirstCaddyProtocolInbound(t *testing.T) {
 		{Name: "naive2", Protocol: "naiveproxy", Transport: "tcp", Port: 8444, Enabled: true},
 	}
 	intent := access.ApplyIntent(inbounds)
-	if !contains(intent.Configs, "/etc/veil/generated/caddy/naive1.Caddyfile") {
-		t.Fatalf("expected naive1.Caddyfile config, got %+v", intent.Configs)
+	if !contains(intent.Configs, "/etc/veil/generated/caddy/config.json") {
+		t.Fatalf("expected consolidated config.json, got %+v", intent.Configs)
+	}
+	if !contains(intent.Actions, "reload veil-caddy.service") || !contains(intent.Runtimes, "veil-caddy.service") {
+		t.Fatalf("expected consolidated caddy action/runtime, got %+v", intent)
 	}
 	if len(intent.Errors) != 0 {
 		t.Fatalf("expected no errors, got %+v", intent.Errors)
@@ -152,8 +155,11 @@ func TestApplyIntentSkipsDisabledInbounds(t *testing.T) {
 		{Name: "naive", Protocol: "naiveproxy", Transport: "tcp", Port: 443, Enabled: false},
 	}
 	intent := access.ApplyIntent(inbounds)
-	if !contains(intent.Configs, "/etc/veil/generated/caddy/panel.Caddyfile") {
-		t.Fatalf("expected panel.Caddyfile fallback config, got %+v", intent.Configs)
+	if !contains(intent.Configs, "/etc/veil/generated/caddy/config.json") {
+		t.Fatalf("expected consolidated config.json, got %+v", intent.Configs)
+	}
+	if !contains(intent.Actions, "reload veil-caddy.service") || !contains(intent.Runtimes, "veil-caddy.service") {
+		t.Fatalf("expected consolidated caddy action/runtime, got %+v", intent)
 	}
 	if len(intent.Errors) != 0 {
 		t.Fatalf("expected no errors, got %+v", intent.Errors)
@@ -168,8 +174,11 @@ func TestApplyIntentPrefers443InboundOverFallback(t *testing.T) {
 		{Name: "naive-443", Protocol: "naiveproxy", Transport: "tcp", Port: 443, Enabled: true},
 	}
 	intent := access.ApplyIntent(inbounds)
-	if !contains(intent.Configs, "/etc/veil/generated/caddy/naive-443.Caddyfile") {
-		t.Fatalf("expected 443 inbound config, got %+v", intent.Configs)
+	if !contains(intent.Configs, "/etc/veil/generated/caddy/config.json") {
+		t.Fatalf("expected consolidated config.json, got %+v", intent.Configs)
+	}
+	if !contains(intent.Actions, "reload veil-caddy.service") || !contains(intent.Runtimes, "veil-caddy.service") {
+		t.Fatalf("expected consolidated caddy action/runtime, got %+v", intent)
 	}
 }
 
@@ -180,9 +189,13 @@ func TestApplyIntentRequiresCaddyFuncNil(t *testing.T) {
 		{Name: "naive", Protocol: "naiveproxy", Transport: "tcp", Port: 443, Enabled: true},
 	}
 	intent := access.ApplyIntent(inbounds)
-	// With nil requiresCaddy, no inbound requires caddy, so fallback panel config is used.
-	if !contains(intent.Configs, "/etc/veil/generated/caddy/panel.Caddyfile") {
-		t.Fatalf("expected panel.Caddyfile fallback config, got %+v", intent.Configs)
+	// With nil requiresCaddy, no inbound requires caddy, so the consolidated panel
+	// Caddy config is still used.
+	if !contains(intent.Configs, "/etc/veil/generated/caddy/config.json") {
+		t.Fatalf("expected consolidated config.json, got %+v", intent.Configs)
+	}
+	if !contains(intent.Actions, "reload veil-caddy.service") || !contains(intent.Runtimes, "veil-caddy.service") {
+		t.Fatalf("expected consolidated caddy action/runtime, got %+v", intent)
 	}
 }
 

--- a/internal/panelaccess/panel_access_test.go
+++ b/internal/panelaccess/panel_access_test.go
@@ -23,12 +23,12 @@ func TestPanelAccessBuildsCaddyRouteConfigAndApplyIntent(t *testing.T) {
 	if err != nil || !ok {
 		t.Fatalf("GeneratedConfig ok=%v err=%v", ok, err)
 	}
-	expectedPath := filepath.FromSlash("/etc/veil/generated/caddy/panel.Caddyfile")
-	if artifact.Path != expectedPath || !strings.Contains(artifact.Body, "reverse_proxy 127.0.0.1:2096") {
+	expectedPath := filepath.FromSlash("/etc/veil/generated/caddy/config.json")
+	if artifact.Path != expectedPath || !strings.Contains(artifact.Body, "reverse_proxy") || !strings.Contains(artifact.Body, "127.0.0.1:2096") {
 		t.Fatalf("artifact = %+v", artifact)
 	}
 	intent := access.ApplyIntent([]model.Inbound{{Name: "mieru", Protocol: "mieru", Transport: "tcp", Port: 443, Enabled: true}})
-	if !contains(intent.Configs, "/etc/veil/generated/caddy/panel.Caddyfile") || !contains(intent.Actions, "reload veil-caddy@panel.service") || !contains(intent.Runtimes, "veil-caddy@panel.service") {
+	if !contains(intent.Configs, "/etc/veil/generated/caddy/config.json") || !contains(intent.Actions, "reload veil-caddy.service") || !contains(intent.Runtimes, "veil-caddy.service") {
 		t.Fatalf("intent = %+v", intent)
 	}
 	if len(intent.Errors) != 1 || !strings.Contains(intent.Errors[0], "panel caddy access uses 443/tcp") {

--- a/internal/panelaccess/profile.go
+++ b/internal/panelaccess/profile.go
@@ -13,7 +13,10 @@ import (
 	"net"
 	"time"
 
+	"github.com/mikkelchokolate/Veil/internal/caddyassembly"
+	"github.com/mikkelchokolate/Veil/internal/caddycapabilities"
 	"github.com/mikkelchokolate/Veil/internal/hostenv"
+	"github.com/mikkelchokolate/Veil/internal/model"
 	"github.com/mikkelchokolate/Veil/internal/renderer"
 )
 
@@ -62,7 +65,7 @@ type ProfileMaterial struct {
 	PanelTLSKeyPEM    string
 	WebBasePath       string
 	InstallPanelCaddy bool
-	Caddyfile         string
+	CaddyJSON         string
 }
 
 type Profile struct {
@@ -90,11 +93,30 @@ func (p Profile) Build() (ProfileMaterial, error) {
 			return ProfileMaterial{}, err
 		}
 		material.InstallPanelCaddy = true
-		caddyfile, err := renderer.RenderPanelCaddyfile(renderer.PanelCaddyConfig{Domain: input.Domain, Email: input.Email, PanelPort: input.PanelPort, WebBasePath: material.WebBasePath})
+		settings := model.Settings{
+			PanelAccess:       "caddy",
+			PanelListen:       material.PanelListen,
+			WebBasePath:       material.WebBasePath,
+			Domain:            input.Domain,
+			Email:             input.Email,
+			PanelDomain:       input.Domain,
+			PanelEmail:        input.Email,
+			PanelPublicPort:   443,
+			AcmeChallengeMode: "tls-alpn-01",
+		}
+		plan, _, _, err := caddyassembly.BuildFinalRenderPlan(settings, nil)
 		if err != nil {
 			return ProfileMaterial{}, err
 		}
-		material.Caddyfile = caddyfile
+		caps, err := caddycapabilities.Probe("")
+		if err != nil {
+			return ProfileMaterial{}, fmt.Errorf("failed to probe Caddy capabilities: %w", err)
+		}
+		body, err := renderer.RenderCaddyJSON(plan, caps)
+		if err != nil {
+			return ProfileMaterial{}, err
+		}
+		material.CaddyJSON = string(body)
 		return material, nil
 	}
 	var extraIPs []net.IP

--- a/internal/panelaccess/profile_more_test.go
+++ b/internal/panelaccess/profile_more_test.go
@@ -43,11 +43,11 @@ func TestProfileBuildRejectsInvalidEmail(t *testing.T) {
 	}
 }
 
-func TestProfileBuildPropagatesCaddyfileRenderError(t *testing.T) {
-	// Valid domain/email but invalid panel port triggers renderer error after validation.
-	_, err := NewProfile(ProfileInput{PanelAccess: "caddy", Domain: "panel.example.com", Email: "admin@example.com", PanelPort: 0}).Build()
-	if err == nil || !strings.Contains(err.Error(), "panel port is required") {
-		t.Fatalf("expected panel port render error, got %v", err)
+func TestProfileBuildPropagatesCaddyJSONRenderError(t *testing.T) {
+	// Missing domain triggers the Caddy render path to fail after validation.
+	_, err := NewProfile(ProfileInput{PanelAccess: "caddy", Domain: "", Email: "admin@example.com", PanelPort: 2096}).Build()
+	if err == nil || !strings.Contains(err.Error(), "domain is required") {
+		t.Fatalf("expected domain render error, got %v", err)
 	}
 }
 

--- a/internal/panelaccess/profile_test.go
+++ b/internal/panelaccess/profile_test.go
@@ -48,9 +48,9 @@ func TestProfileBuildsPanelCaddyAccessMaterial(t *testing.T) {
 	if material.WebBasePath == "" || !strings.HasPrefix(material.WebBasePath, "/") || !strings.HasSuffix(material.WebBasePath, "/") {
 		t.Fatalf("web base path = %q", material.WebBasePath)
 	}
-	for _, want := range []string{"panel.example.com", "reverse_proxy 127.0.0.1:2096", "handle " + strings.TrimRight(material.WebBasePath, "/") + "/*"} {
-		if !strings.Contains(material.Caddyfile, want) {
-			t.Fatalf("Caddyfile missing %q:\n%s", want, material.Caddyfile)
+	for _, want := range []string{"panel.example.com", "127.0.0.1:2096", material.WebBasePath} {
+		if !strings.Contains(material.CaddyJSON, want) {
+			t.Fatalf("CaddyJSON missing %q:\n%s", want, material.CaddyJSON)
 		}
 	}
 }

--- a/internal/panelaccess/requirements.go
+++ b/internal/panelaccess/requirements.go
@@ -51,10 +51,14 @@ func NewNaiveCaddySettingsRequirement() NaiveCaddySettingsRequirement {
 	return NaiveCaddySettingsRequirement{}
 }
 
+func hasAcmeEmail(settings model.Settings) bool {
+	return strings.TrimSpace(settings.Email) != "" || strings.TrimSpace(settings.DefaultAcmeEmail) != "" || strings.TrimSpace(settings.PanelEmail) != ""
+}
+
 func (NaiveCaddySettingsRequirement) Validate(settings model.Settings) error {
 	username := protocolString(settings.ProtocolFields, "naiveUsername", settings.NaiveUsername)
 	password := protocolString(settings.ProtocolFields, "naivePassword", settings.NaivePassword)
-	if strings.TrimSpace(settings.Domain) == "" || strings.TrimSpace(settings.Email) == "" || strings.TrimSpace(username) == "" || strings.TrimSpace(password) == "" {
+	if strings.TrimSpace(settings.Domain) == "" || !hasAcmeEmail(settings) || strings.TrimSpace(username) == "" || strings.TrimSpace(password) == "" {
 		return errNaiveCaddySettingsRequired{}
 	}
 	return nil

--- a/internal/panelmaterial/material.go
+++ b/internal/panelmaterial/material.go
@@ -30,7 +30,7 @@ type Input struct {
 	PanelTLSCertPEM   string
 	PanelTLSKeyPEM    string
 	InstallPanelCaddy bool
-	Caddyfile         string
+	CaddyJSON         string
 }
 
 type File struct {
@@ -95,7 +95,7 @@ func (m ManagedMaterial) Files() ([]File, error) {
 	}
 	files := []File{}
 	if input.InstallPanelCaddy {
-		files = append(files, File{Path: filepath.Join(paths.EtcDir, "generated", "caddy", "panel.Caddyfile"), Content: input.Caddyfile, Mode: 0o600})
+		files = append(files, File{Path: filepath.Join(paths.EtcDir, "generated", "caddy", "config.json"), Content: input.CaddyJSON, Mode: 0o600})
 		files = append(files, File{Path: filepath.Join(paths.VarDir, "www", "index.html"), Content: fallbackIndexHTML(input.Domain), Mode: 0o644})
 	}
 	if input.PanelTLSEnabled {

--- a/internal/panelmaterial/material_more_test.go
+++ b/internal/panelmaterial/material_more_test.go
@@ -168,9 +168,9 @@ func TestFilesIncludesTLSAndOmitsSystemd(t *testing.T) {
 		}
 	}
 
-	notWant := filepath.Join(etcDir, "generated", "caddy", "panel.Caddyfile")
+	notWant := filepath.Join(etcDir, "generated", "caddy", "config.json")
 	if hasFile(files, notWant) {
-		t.Fatalf("did not expect Caddyfile when InstallPanelCaddy is false, found %q", notWant)
+		t.Fatalf("did not expect Caddy config when InstallPanelCaddy is false, found %q", notWant)
 	}
 }
 

--- a/internal/panelmaterial/material_test.go
+++ b/internal/panelmaterial/material_test.go
@@ -43,13 +43,13 @@ func TestManagedMaterialFilesIncludePanelCaddyAndSystemdMaterial(t *testing.T) {
 		PanelAuthToken:    "token",
 		PanelListen:       "127.0.0.1:2096",
 		InstallPanelCaddy: true,
-		Caddyfile:         "panel caddy",
+		CaddyJSON:         "{}",
 	})
 	files, err := material.Files()
 	if err != nil {
 		t.Fatalf("Files: %v", err)
 	}
-	wants := []string{"/etc/veil/generated/caddy/panel.Caddyfile", "/var/lib/veil/www/index.html", "/etc/veil/veil.env"}
+	wants := []string{"/etc/veil/generated/caddy/config.json", "/var/lib/veil/www/index.html", "/etc/veil/veil.env"}
 	for _, name := range systemdunits.Names() {
 		wants = append(wants, "/etc/systemd/system/"+name)
 	}

--- a/internal/privileged/defaults.go
+++ b/internal/privileged/defaults.go
@@ -23,8 +23,8 @@ func DefaultPolicy() Policy {
 		ManagedUnitPrefixes:  defaultManagedUnitPrefixes(),
 		Artifacts: map[string]ArtifactPath{
 			"caddy-panel": {
-				Staged:    filepath.FromSlash("caddy/panel.Caddyfile"),
-				Generated: filepath.FromSlash("caddy/panel.Caddyfile"),
+				Staged:    filepath.FromSlash("caddy/config.json"),
+				Generated: filepath.FromSlash("caddy/config.json"),
 			},
 		},
 		UpdateArtifacts: map[string]string{
@@ -36,8 +36,9 @@ func DefaultPolicy() Policy {
 
 func defaultManagedUnits() map[string]struct{} {
 	units := map[string]struct{}{
-		"veil.service":      {},
-		"veil-warp.service": {},
+		"veil.service":       {},
+		"veil-warp.service":  {},
+		"veil-caddy.service": {},
 	}
 	registry := protocols.NewRegistry()
 	for _, plugin := range registry.All() {
@@ -60,6 +61,10 @@ func defaultManagedUnits() map[string]struct{} {
 func defaultManagedUnitPrefixes() []string {
 	prefixes := []string{}
 	seen := map[string]bool{}
+	// Legacy per-instance Caddy units may still exist on disk; allow the helper
+	// to stop/disable them during orphan cleanup and rollback.
+	seen["veil-caddy@"] = true
+	prefixes = append(prefixes, "veil-caddy@")
 	registry := protocols.NewRegistry()
 	for _, plugin := range registry.All() {
 		rp, ok := protocols.AsRuntimeProvider(plugin)

--- a/internal/privileged/defaults_test.go
+++ b/internal/privileged/defaults_test.go
@@ -10,7 +10,7 @@ func TestDefaultPolicyProvidesManagedPathsAndUnits(t *testing.T) {
 	if policy.StagingRoot == "" || policy.GeneratedRoot == "" || policy.StateRoot == "" {
 		t.Fatal("expected default roots to be set")
 	}
-	for _, unit := range []string{"veil.service", "veil-mieru.service", "veil-warp.service", "veil-caddy@.service", "veil-hysteria2@.service", "veil-olcrtc@.service"} {
+	for _, unit := range []string{"veil.service", "veil-mieru.service", "veil-warp.service", "veil-caddy.service", "veil-hysteria2@.service", "veil-olcrtc@.service"} {
 		if _, ok := policy.ManagedUnits[unit]; !ok {
 			t.Fatalf("expected %s to be managed in default policy", unit)
 		}

--- a/internal/privileged/executor.go
+++ b/internal/privileged/executor.go
@@ -655,8 +655,21 @@ func runSyncCaddyCert(ctx context.Context, request SyncCaddyCertRequest, config 
 	if request.Domain == "" {
 		return SyncCaddyCertResult{}, newError(ErrorInvalidRequest, "domain is required")
 	}
+	if !dnsLabelPattern.MatchString(request.Domain) {
+		return SyncCaddyCertResult{}, newError(ErrorInvalidRequest, "domain must be a valid DNS label")
+	}
 	if request.OutDir == "" {
 		request.OutDir = defaultCaddyCertOutDir
+	}
+	if filepath.IsAbs(request.OutDir) && !strings.HasPrefix(filepath.Clean(request.OutDir), caddyCertRoot) {
+		return SyncCaddyCertResult{}, newError(ErrorForbiddenOperation, "certificate output directory is not allowed")
+	}
+	if strings.Contains(request.OutDir, "..") {
+		return SyncCaddyCertResult{}, newError(ErrorInvalidRequest, "certificate output directory must not contain '..'")
+	}
+	request.OutDir = filepath.Clean(request.OutDir)
+	if !strings.HasPrefix(request.OutDir, caddyCertRoot) {
+		return SyncCaddyCertResult{}, newError(ErrorForbiddenOperation, "certificate output directory is not allowed")
 	}
 	pair, err := findCaddyCertWithRetry(ctx, request.Domain)
 	if err != nil {

--- a/internal/privileged/executor.go
+++ b/internal/privileged/executor.go
@@ -36,6 +36,7 @@ var (
 	effectiveUID           = os.Geteuid
 	lookupUser             = user.Lookup
 	chownPath              = os.Chown
+	chmodPath              = os.Chmod
 	caddyRetryInterval     = 2 * time.Second
 	defaultCaddyCertOutDir = "/etc/veil/certs"
 )
@@ -467,15 +468,46 @@ func chownToVeilIfRoot(path string) error {
 }
 
 func ensureRuntimeArtifactOwnership(artifactID, path string) error {
-	// Caddy runs as root; its config intentionally remains root-owned.
 	if strings.HasPrefix(filepath.ToSlash(filepath.Clean(artifactID)), "caddy/") {
-		return nil
+		return grantPanelReadAccessToCaddyArtifact(path)
 	}
 	if err := chownToVeilIfRoot(filepath.Dir(path)); err != nil {
 		return fmt.Errorf("set protocol config directory ownership: %w", err)
 	}
 	if err := chownToVeilIfRoot(path); err != nil {
 		return fmt.Errorf("set protocol config ownership: %w", err)
+	}
+	return nil
+}
+
+// grantPanelReadAccessToCaddyArtifact keeps the Caddy config owned by root for
+// the root Caddy service while making it readable by the veil group for the
+// unprivileged Panel's Caddy Admin API loader. The config contains credentials,
+// so it must not be world-readable.
+func grantPanelReadAccessToCaddyArtifact(path string) error {
+	if effectiveUID() != 0 {
+		return nil
+	}
+	u, err := lookupUser("veil")
+	if err != nil {
+		return fmt.Errorf("resolve veil user: %w", err)
+	}
+	gid, err := strconv.Atoi(u.Gid)
+	if err != nil {
+		return fmt.Errorf("parse veil gid %q: %w", u.Gid, err)
+	}
+	dir := filepath.Dir(path)
+	if err := chownPath(dir, 0, gid); err != nil {
+		return fmt.Errorf("set caddy config directory ownership: %w", err)
+	}
+	if err := chmodPath(dir, 0o750); err != nil {
+		return fmt.Errorf("set caddy config directory mode: %w", err)
+	}
+	if err := chownPath(path, 0, gid); err != nil {
+		return fmt.Errorf("set caddy config ownership: %w", err)
+	}
+	if err := chmodPath(path, 0o640); err != nil {
+		return fmt.Errorf("set caddy config mode: %w", err)
 	}
 	return nil
 }

--- a/internal/privileged/executor.go
+++ b/internal/privileged/executor.go
@@ -292,6 +292,27 @@ func readBoundedRegularFile(path string, maxBytes int64) ([]byte, error) {
 	return data, nil
 }
 
+// readManagedConfigFile reads a promotion source/backup/destination config
+// without following symlinks. A symlink swapped in after policy resolution
+// would otherwise let the caller read a file outside the managed root (either
+// directly into the promotion, or into a backup retrievable via the backup ID).
+// Opening with O_NOFOLLOW closes the resolve-time-to-read TOCTOU window.
+func readManagedConfigFile(path string) ([]byte, error) {
+	file, err := openRegularNoFollow(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, errors.New("managed config is not a regular file")
+	}
+	return io.ReadAll(file)
+}
+
 func runProductionCommand(ctx context.Context, command []string, timeout time.Duration) (string, error) {
 	if len(command) == 0 {
 		return "", errors.New("command is empty")
@@ -354,7 +375,7 @@ func promoteResolvedArtifacts(backupRoot string, now func() time.Time, request R
 	backupID := now().UTC().Format("20060102T150405.000000000Z")
 	manifest := promotionManifest{BackupID: backupID}
 	for _, artifact := range request.Artifacts {
-		body, err := os.ReadFile(artifact.Source)
+		body, err := readManagedConfigFile(artifact.Source)
 		if err != nil {
 			return PromoteResult{}, err
 		}
@@ -423,7 +444,7 @@ func backupPromotionDestination(root, backupID string, artifact ResolvedArtifact
 	if info, statErr := os.Lstat(artifact.Destination); statErr == nil && info.Mode()&os.ModeSymlink != 0 {
 		return record, nil
 	}
-	body, err := os.ReadFile(artifact.Destination)
+	body, err := readManagedConfigFile(artifact.Destination)
 	if errors.Is(err, os.ErrNotExist) {
 		return record, nil
 	}
@@ -457,7 +478,7 @@ func restorePromotedArtifacts(root, backupID string) (PromoteResult, error) {
 	result := PromoteResult{BackupID: backupID}
 	for _, record := range manifest.Records {
 		if record.HadPrevious {
-			previous, err := os.ReadFile(record.BackupPath)
+			previous, err := readManagedConfigFile(record.BackupPath)
 			if err != nil {
 				return PromoteResult{}, err
 			}

--- a/internal/privileged/executor.go
+++ b/internal/privileged/executor.go
@@ -35,11 +35,35 @@ var (
 	osExecutable           = os.Executable
 	effectiveUID           = os.Geteuid
 	lookupUser             = user.Lookup
-	chownPath              = os.Chown
-	chmodPath              = os.Chmod
+	chownPath              = chownNoFollow
+	chmodPath              = chmodNoFollow
+	openNoFollow           = openRegularNoFollow
 	caddyRetryInterval     = 2 * time.Second
 	defaultCaddyCertOutDir = "/etc/veil/certs"
 )
+
+// chownNoFollow opens path with O_NOFOLLOW and applies fchown on the file
+// descriptor, so a symlink swapped in after policy resolution is rejected
+// rather than followed to an unintended target.
+func chownNoFollow(path string, uid, gid int) error {
+	f, err := openNoFollow(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return f.Chown(uid, gid)
+}
+
+// chmodNoFollow opens path with O_NOFOLLOW and applies fchmod on the file
+// descriptor, avoiding symlink-following chmod on a swapped path.
+func chmodNoFollow(path string, mode os.FileMode) error {
+	f, err := openNoFollow(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return f.Chmod(mode)
+}
 
 type Executor struct {
 	Promote       func(context.Context, ResolvedPromotion) (PromoteResult, error)
@@ -391,6 +415,14 @@ type promotionManifestRecord struct {
 
 func backupPromotionDestination(root, backupID string, artifact ResolvedArtifact) (promotionManifestRecord, error) {
 	record := promotionManifestRecord{ArtifactID: artifact.ID, Destination: artifact.Destination}
+	// Lstat (not Stat/ReadFile) so a symlink swapped in after policy resolution
+	// is detected. Reading a symlink would copy the target's content — possibly
+	// outside the managed root — into the backup, which the caller could then
+	// retrieve via the returned backup ID (exfiltration). Skip the content
+	// backup for symlinks; the removal step deletes the link itself.
+	if info, statErr := os.Lstat(artifact.Destination); statErr == nil && info.Mode()&os.ModeSymlink != 0 {
+		return record, nil
+	}
 	body, err := os.ReadFile(artifact.Destination)
 	if errors.Is(err, os.ErrNotExist) {
 		return record, nil

--- a/internal/privileged/executor.go
+++ b/internal/privileged/executor.go
@@ -33,6 +33,9 @@ var (
 	caddyDataDir           = caddycert.DefaultCaddyDataDir
 	findCaddyCertPair      = caddycert.FindPair
 	osExecutable           = os.Executable
+	effectiveUID           = os.Geteuid
+	lookupUser             = user.Lookup
+	chownPath              = os.Chown
 	caddyRetryInterval     = 2 * time.Second
 	defaultCaddyCertOutDir = "/etc/veil/certs"
 )
@@ -337,12 +340,8 @@ func promoteResolvedArtifacts(backupRoot string, now func() time.Time, request R
 		if err := atomicfile.Write(artifact.Destination, body, 0o600, 0o700); err != nil {
 			return PromoteResult{}, err
 		}
-		// Caddy config files are consumed by the root-running Caddy service; keep
-		// them root-owned. Protocol runtime configs are consumed by services that
-		// run as the veil user, so chown them to veil.
-		if !strings.Contains(filepath.Clean(artifact.Destination), "/generated/caddy/") {
-			_ = chownToVeilIfRoot(artifact.Destination)
-			_ = chownToVeilIfRoot(filepath.Dir(artifact.Destination))
+		if err := ensureRuntimeArtifactOwnership(artifact.ID, artifact.Destination); err != nil {
+			return PromoteResult{}, err
 		}
 		result.WrittenArtifacts = append(result.WrittenArtifacts, artifact.ID)
 		manifest.Records = append(manifest.Records, record)
@@ -432,6 +431,9 @@ func restorePromotedArtifacts(root, backupID string) (PromoteResult, error) {
 			if err := atomicfile.Write(record.Destination, previous, 0o600, 0o700); err != nil {
 				return PromoteResult{}, err
 			}
+			if err := ensureRuntimeArtifactOwnership(record.ArtifactID, record.Destination); err != nil {
+				return PromoteResult{}, err
+			}
 		} else if err := os.Remove(record.Destination); err != nil && !errors.Is(err, os.ErrNotExist) {
 			return PromoteResult{}, err
 		}
@@ -442,25 +444,40 @@ func restorePromotedArtifacts(root, backupID string) (PromoteResult, error) {
 
 // chownToVeilIfRoot changes the owner of path to the veil user when the helper
 // is running as root. This keeps generated config files and certificates
-// readable by the protocol runtime services, which run as the veil user.
-// If the veil user cannot be resolved (e.g. in tests), the chown is skipped.
+// readable by the protocol runtime services, which run as the veil user. A
+// missing/invalid veil account or failed chown is fatal so Apply can roll back
+// instead of reporting success for an unreadable runtime artifact.
 func chownToVeilIfRoot(path string) error {
-	if os.Geteuid() != 0 {
+	if effectiveUID() != 0 {
 		return nil
 	}
-	u, err := user.Lookup("veil")
+	u, err := lookupUser("veil")
 	if err != nil {
-		return nil
+		return fmt.Errorf("resolve veil user: %w", err)
 	}
 	uid, err := strconv.Atoi(u.Uid)
 	if err != nil {
-		return nil
+		return fmt.Errorf("parse veil uid %q: %w", u.Uid, err)
 	}
 	gid, err := strconv.Atoi(u.Gid)
 	if err != nil {
+		return fmt.Errorf("parse veil gid %q: %w", u.Gid, err)
+	}
+	return chownPath(path, uid, gid)
+}
+
+func ensureRuntimeArtifactOwnership(artifactID, path string) error {
+	// Caddy runs as root; its config intentionally remains root-owned.
+	if strings.HasPrefix(filepath.ToSlash(filepath.Clean(artifactID)), "caddy/") {
 		return nil
 	}
-	return os.Chown(path, uid, gid)
+	if err := chownToVeilIfRoot(filepath.Dir(path)); err != nil {
+		return fmt.Errorf("set protocol config directory ownership: %w", err)
+	}
+	if err := chownToVeilIfRoot(path); err != nil {
+		return fmt.Errorf("set protocol config ownership: %w", err)
+	}
+	return nil
 }
 
 func runProductionBackup(_ context.Context, config ProductionConfig, request ResolvedBackup) (BackupResult, error) {
@@ -592,17 +609,23 @@ func runSyncCaddyCert(ctx context.Context, request SyncCaddyCertRequest, config 
 	if err := os.MkdirAll(request.OutDir, 0o700); err != nil {
 		return SyncCaddyCertResult{}, fmt.Errorf("create cert output directory: %w", err)
 	}
-	_ = chownToVeilIfRoot(request.OutDir)
+	if err := chownToVeilIfRoot(request.OutDir); err != nil {
+		return SyncCaddyCertResult{}, fmt.Errorf("set certificate directory ownership: %w", err)
+	}
 	certOut := filepath.Join(request.OutDir, request.Domain+".crt")
 	keyOut := filepath.Join(request.OutDir, request.Domain+".key")
 	if err := atomicfile.Write(certOut, certData, 0o600, 0o700); err != nil {
 		return SyncCaddyCertResult{}, fmt.Errorf("write certificate: %w", err)
 	}
-	_ = chownToVeilIfRoot(certOut)
+	if err := chownToVeilIfRoot(certOut); err != nil {
+		return SyncCaddyCertResult{}, fmt.Errorf("set certificate ownership: %w", err)
+	}
 	if err := atomicfile.Write(keyOut, keyData, 0o600, 0o700); err != nil {
 		return SyncCaddyCertResult{}, fmt.Errorf("write key: %w", err)
 	}
-	_ = chownToVeilIfRoot(keyOut)
+	if err := chownToVeilIfRoot(keyOut); err != nil {
+		return SyncCaddyCertResult{}, fmt.Errorf("set certificate key ownership: %w", err)
+	}
 	return SyncCaddyCertResult{Found: true, CertPath: certOut, KeyPath: keyOut}, nil
 }
 

--- a/internal/privileged/executor_more_test.go
+++ b/internal/privileged/executor_more_test.go
@@ -14,9 +14,14 @@ import (
 
 func TestRunSyncCaddyCertCopiesPairToOutDir(t *testing.T) {
 	original := findCaddyCertPair
-	defer func() { findCaddyCertPair = original }()
+	originalRoot := caddyCertRoot
+	defer func() {
+		findCaddyCertPair = original
+		caddyCertRoot = originalRoot
+	}()
 
 	root := t.TempDir()
+	caddyCertRoot = root
 	certPath := filepath.Join(root, "certs", "acme-v2", "example.com", "example.com.crt")
 	keyPath := filepath.Join(root, "certs", "acme-v2", "example.com", "example.com.key")
 	if err := os.MkdirAll(filepath.Dir(certPath), 0o700); err != nil {
@@ -61,13 +66,16 @@ func TestRunSyncCaddyCertRequiresDomain(t *testing.T) {
 func TestRunSyncCaddyCertDefaultsOutDir(t *testing.T) {
 	originalFinder := findCaddyCertPair
 	originalOutDir := defaultCaddyCertOutDir
+	originalRoot := caddyCertRoot
 	defer func() {
 		findCaddyCertPair = originalFinder
 		defaultCaddyCertOutDir = originalOutDir
+		caddyCertRoot = originalRoot
 	}()
 
 	root := t.TempDir()
 	defaultCaddyCertOutDir = root
+	caddyCertRoot = root
 	certPath := filepath.Join(root, "example.com.crt")
 	keyPath := filepath.Join(root, "example.com.key")
 	if err := os.WriteFile(certPath, []byte("cert"), 0o600); err != nil {
@@ -92,13 +100,18 @@ func TestRunSyncCaddyCertDefaultsOutDir(t *testing.T) {
 
 func TestRunSyncCaddyCertReturnsNotFound(t *testing.T) {
 	original := findCaddyCertPair
-	defer func() { findCaddyCertPair = original }()
+	originalRoot := caddyCertRoot
+	defer func() {
+		findCaddyCertPair = original
+		caddyCertRoot = originalRoot
+	}()
 
+	caddyCertRoot = t.TempDir()
 	findCaddyCertPair = func(_, _ string) (caddycert.Pair, error) {
 		return caddycert.Pair{}, caddycert.ErrCertificateNotFound
 	}
 
-	result, err := runSyncCaddyCert(context.Background(), SyncCaddyCertRequest{Domain: "missing.example.com", OutDir: t.TempDir()}, ProductionConfig{})
+	result, err := runSyncCaddyCert(context.Background(), SyncCaddyCertRequest{Domain: "missing.example.com", OutDir: caddyCertRoot}, ProductionConfig{})
 	if err != nil {
 		t.Fatalf("expected no error for missing cert, got %v", err)
 	}
@@ -109,13 +122,18 @@ func TestRunSyncCaddyCertReturnsNotFound(t *testing.T) {
 
 func TestRunSyncCaddyCertPropagatesCertReadError(t *testing.T) {
 	original := findCaddyCertPair
-	defer func() { findCaddyCertPair = original }()
+	originalRoot := caddyCertRoot
+	defer func() {
+		findCaddyCertPair = original
+		caddyCertRoot = originalRoot
+	}()
 
+	caddyCertRoot = t.TempDir()
 	findCaddyCertPair = func(_, _ string) (caddycert.Pair, error) {
 		return caddycert.Pair{CertPath: "/does/not/exist.crt", KeyPath: "/does/not/exist.key"}, nil
 	}
 
-	_, err := runSyncCaddyCert(context.Background(), SyncCaddyCertRequest{Domain: "example.com", OutDir: t.TempDir()}, ProductionConfig{})
+	_, err := runSyncCaddyCert(context.Background(), SyncCaddyCertRequest{Domain: "example.com", OutDir: caddyCertRoot}, ProductionConfig{})
 	if err == nil {
 		t.Fatal("expected cert read error")
 	}
@@ -123,9 +141,14 @@ func TestRunSyncCaddyCertPropagatesCertReadError(t *testing.T) {
 
 func TestRunSyncCaddyCertPropagatesKeyReadError(t *testing.T) {
 	original := findCaddyCertPair
-	defer func() { findCaddyCertPair = original }()
+	originalRoot := caddyCertRoot
+	defer func() {
+		findCaddyCertPair = original
+		caddyCertRoot = originalRoot
+	}()
 
 	root := t.TempDir()
+	caddyCertRoot = root
 	certPath := filepath.Join(root, "cert.crt")
 	if err := os.WriteFile(certPath, []byte("cert"), 0o600); err != nil {
 		t.Fatal(err)
@@ -135,7 +158,7 @@ func TestRunSyncCaddyCertPropagatesKeyReadError(t *testing.T) {
 		return caddycert.Pair{CertPath: certPath, KeyPath: "/does/not/exist.key"}, nil
 	}
 
-	_, err := runSyncCaddyCert(context.Background(), SyncCaddyCertRequest{Domain: "example.com", OutDir: t.TempDir()}, ProductionConfig{})
+	_, err := runSyncCaddyCert(context.Background(), SyncCaddyCertRequest{Domain: "example.com", OutDir: caddyCertRoot}, ProductionConfig{})
 	if err == nil {
 		t.Fatal("expected key read error")
 	}
@@ -143,9 +166,14 @@ func TestRunSyncCaddyCertPropagatesKeyReadError(t *testing.T) {
 
 func TestRunSyncCaddyCertFailsToCreateOutDir(t *testing.T) {
 	original := findCaddyCertPair
-	defer func() { findCaddyCertPair = original }()
+	originalRoot := caddyCertRoot
+	defer func() {
+		findCaddyCertPair = original
+		caddyCertRoot = originalRoot
+	}()
 
 	root := t.TempDir()
+	caddyCertRoot = root
 	certPath := filepath.Join(root, "cert.crt")
 	keyPath := filepath.Join(root, "cert.key")
 	if err := os.WriteFile(certPath, []byte("cert"), 0o600); err != nil {
@@ -168,6 +196,49 @@ func TestRunSyncCaddyCertFailsToCreateOutDir(t *testing.T) {
 	_, err := runSyncCaddyCert(context.Background(), SyncCaddyCertRequest{Domain: "example.com", OutDir: outDir}, ProductionConfig{})
 	if err == nil {
 		t.Fatal("expected mkdir error")
+	}
+}
+
+func TestRunSyncCaddyCertRejectsTraversalDomain(t *testing.T) {
+	original := findCaddyCertPair
+	originalRoot := caddyCertRoot
+	defer func() {
+		findCaddyCertPair = original
+		caddyCertRoot = originalRoot
+	}()
+
+	caddyCertRoot = t.TempDir()
+	_, err := runSyncCaddyCert(context.Background(), SyncCaddyCertRequest{Domain: "../../etc/cron.d/x", OutDir: caddyCertRoot}, ProductionConfig{})
+	if err == nil {
+		t.Fatal("expected traversal domain rejection")
+	}
+}
+
+func TestRunSyncCaddyCertRejectsTraversalOutDir(t *testing.T) {
+	original := findCaddyCertPair
+	originalRoot := caddyCertRoot
+	defer func() {
+		findCaddyCertPair = original
+		caddyCertRoot = originalRoot
+	}()
+
+	root := t.TempDir()
+	caddyCertRoot = root
+	certPath := filepath.Join(root, "cert.crt")
+	keyPath := filepath.Join(root, "cert.key")
+	if err := os.WriteFile(certPath, []byte("cert"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, []byte("key"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	findCaddyCertPair = func(_, _ string) (caddycert.Pair, error) {
+		return caddycert.Pair{CertPath: certPath, KeyPath: keyPath}, nil
+	}
+
+	_, err := runSyncCaddyCert(context.Background(), SyncCaddyCertRequest{Domain: "example.com", OutDir: filepath.Join(root, "..", "escape")}, ProductionConfig{})
+	if err == nil {
+		t.Fatal("expected traversal OutDir rejection")
 	}
 }
 

--- a/internal/privileged/executor_test.go
+++ b/internal/privileged/executor_test.go
@@ -102,6 +102,53 @@ func TestProductionExecutorFailsWhenProtocolConfigOwnershipCannotBeSet(t *testin
 	}
 }
 
+// TestProductionExecutorDoesNotBackupSymlinkTargetOnRemoval covers the
+// exfiltration vector: if a managed artifact slated for removal is replaced by
+// a symlink pointing outside the managed root, backupPromotionDestination must
+// not read the symlink target into the promotion backup (which the caller could
+// then retrieve via the returned backup ID). The helper must detect the symlink
+// and skip the content backup instead of following it.
+func TestProductionExecutorDoesNotBackupSymlinkTargetOnRemoval(t *testing.T) {
+	root := t.TempDir()
+	backupRoot := filepath.Join(root, "backups")
+	destination := filepath.Join(root, "generated", "caddy", "legacy.Caddyfile")
+	if err := os.MkdirAll(filepath.Dir(destination), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	secret := filepath.Join(root, "outside-secret")
+	if err := os.WriteFile(secret, []byte("TOP-SECRET-OUTSIDE-ROOT"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(secret, destination); err != nil {
+		t.Fatal(err)
+	}
+
+	executor := NewProductionExecutor(ProductionConfig{PromotionBackupRoot: backupRoot})
+	result, err := executor.Promote(context.Background(), ResolvedPromotion{
+		RemoveArtifacts: []ResolvedArtifact{{
+			ID:          "caddy/legacy.Caddyfile",
+			Destination: destination,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("promote removal: %v", err)
+	}
+	// The symlink itself is removed.
+	if _, statErr := os.Lstat(destination); !os.IsNotExist(statErr) {
+		t.Fatalf("expected symlink to be removed, stat err=%v", statErr)
+	}
+	// No backup artifact may contain the outside secret.
+	for _, backupPath := range result.BackupArtifacts {
+		body, readErr := os.ReadFile(backupPath)
+		if readErr != nil {
+			continue
+		}
+		if string(body) == "TOP-SECRET-OUTSIDE-ROOT" {
+			t.Fatalf("symlink target content was exfiltrated into backup %s", backupPath)
+		}
+	}
+}
+
 func TestProductionExecutorGrantsPanelReadAccessToCaddyConfig(t *testing.T) {
 	oldEffectiveUID := effectiveUID
 	oldLookupUser := lookupUser

--- a/internal/privileged/executor_test.go
+++ b/internal/privileged/executor_test.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/user"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -56,6 +57,48 @@ func TestProductionExecutorPromotesResolvedArtifactsWithSafetyCopy(t *testing.T)
 	}
 	if result.BackupID == "" || !reflect.DeepEqual(result.WrittenArtifacts, []string{"mieru"}) {
 		t.Fatalf("unexpected promote result: %+v", result)
+	}
+}
+
+func TestProductionExecutorFailsWhenProtocolConfigOwnershipCannotBeSet(t *testing.T) {
+	oldEffectiveUID := effectiveUID
+	oldLookupUser := lookupUser
+	oldChownPath := chownPath
+	defer func() {
+		effectiveUID = oldEffectiveUID
+		lookupUser = oldLookupUser
+		chownPath = oldChownPath
+	}()
+
+	effectiveUID = func() int { return 0 }
+	lookupUser = func(string) (*user.User, error) {
+		return &user.User{Uid: "123", Gid: "456"}, nil
+	}
+	ownershipErr := errors.New("injected chown failure")
+	chownPath = func(string, int, int) error { return ownershipErr }
+
+	root := t.TempDir()
+	source := filepath.Join(root, "staging", "mieru", "server_config.json")
+	destination := filepath.Join(root, "generated", "mieru", "server_config.json")
+	if err := os.MkdirAll(filepath.Dir(source), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(source, []byte(`{"portBindings":[]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	executor := NewProductionExecutor(ProductionConfig{
+		PromotionBackupRoot: filepath.Join(root, "backups"),
+	})
+	_, err := executor.Promote(context.Background(), ResolvedPromotion{
+		Artifacts: []ResolvedArtifact{{
+			ID:          "mieru/server_config.json",
+			Source:      source,
+			Destination: destination,
+		}},
+	})
+	if !errors.Is(err, ownershipErr) {
+		t.Fatalf("promote error = %v, want injected ownership error", err)
 	}
 }
 

--- a/internal/privileged/executor_test.go
+++ b/internal/privileged/executor_test.go
@@ -924,6 +924,30 @@ func TestPromoteResolvedArtifactsSourceReadError(t *testing.T) {
 	}
 }
 
+// TestPromoteResolvedArtifactsRejectsSymlinkedSource covers the promote-time
+// exfiltration vector: a staging source swapped for a symlink after policy
+// resolution must not be read into the generated root.
+func TestPromoteResolvedArtifactsRejectsSymlinkedSource(t *testing.T) {
+	root := t.TempDir()
+	outside := filepath.Join(root, "secret.txt")
+	if err := os.WriteFile(outside, []byte("outside"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	source := filepath.Join(root, "staging", "cfg.json")
+	if err := os.MkdirAll(filepath.Dir(source), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, source); err != nil {
+		t.Fatal(err)
+	}
+	_, err := promoteResolvedArtifacts(filepath.Join(root, "backups"), time.Now, ResolvedPromotion{
+		Artifacts: []ResolvedArtifact{{ID: "cfg", Source: source, Destination: filepath.Join(root, "gen", "cfg.json")}},
+	})
+	if err == nil {
+		t.Fatal("expected symlinked source to be rejected")
+	}
+}
+
 func TestBackupPromotionDestinationReadError(t *testing.T) {
 	artifact := ResolvedArtifact{ID: "x", Source: "", Destination: filepath.Join(t.TempDir(), "dir")}
 	if err := os.MkdirAll(artifact.Destination, 0o755); err != nil {

--- a/internal/privileged/executor_test.go
+++ b/internal/privileged/executor_test.go
@@ -102,6 +102,79 @@ func TestProductionExecutorFailsWhenProtocolConfigOwnershipCannotBeSet(t *testin
 	}
 }
 
+func TestProductionExecutorGrantsPanelReadAccessToCaddyConfig(t *testing.T) {
+	oldEffectiveUID := effectiveUID
+	oldLookupUser := lookupUser
+	oldChownPath := chownPath
+	oldChmodPath := chmodPath
+	defer func() {
+		effectiveUID = oldEffectiveUID
+		lookupUser = oldLookupUser
+		chownPath = oldChownPath
+		chmodPath = oldChmodPath
+	}()
+
+	effectiveUID = func() int { return 0 }
+	lookupUser = func(name string) (*user.User, error) {
+		if name != "veil" {
+			t.Fatalf("lookup user = %q, want veil", name)
+		}
+		return &user.User{Uid: "123", Gid: "456"}, nil
+	}
+	type chownCall struct {
+		path     string
+		uid, gid int
+	}
+	type chmodCall struct {
+		path string
+		mode os.FileMode
+	}
+	var chowns []chownCall
+	var chmods []chmodCall
+	chownPath = func(path string, uid, gid int) error {
+		chowns = append(chowns, chownCall{path: path, uid: uid, gid: gid})
+		return nil
+	}
+	chmodPath = func(path string, mode os.FileMode) error {
+		chmods = append(chmods, chmodCall{path: path, mode: mode})
+		return nil
+	}
+
+	root := t.TempDir()
+	source := filepath.Join(root, "staging", "caddy", "config.json")
+	destination := filepath.Join(root, "generated", "caddy", "config.json")
+	if err := os.MkdirAll(filepath.Dir(source), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(source, []byte(`{"apps":{}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	executor := NewProductionExecutor(ProductionConfig{PromotionBackupRoot: filepath.Join(root, "backups")})
+	if _, err := executor.Promote(context.Background(), ResolvedPromotion{Artifacts: []ResolvedArtifact{{
+		ID:          "caddy/config.json",
+		Source:      source,
+		Destination: destination,
+	}}}); err != nil {
+		t.Fatalf("promote: %v", err)
+	}
+
+	wantChowns := []chownCall{
+		{path: filepath.Dir(destination), uid: 0, gid: 456},
+		{path: destination, uid: 0, gid: 456},
+	}
+	wantChmods := []chmodCall{
+		{path: filepath.Dir(destination), mode: 0o750},
+		{path: destination, mode: 0o640},
+	}
+	if !reflect.DeepEqual(chowns, wantChowns) {
+		t.Fatalf("chown calls = %+v, want %+v", chowns, wantChowns)
+	}
+	if !reflect.DeepEqual(chmods, wantChmods) {
+		t.Fatalf("chmod calls = %+v, want %+v", chmods, wantChmods)
+	}
+}
+
 func TestProductionExecutorRestoresPromotionByOpaqueBackupID(t *testing.T) {
 	root := t.TempDir()
 	source := filepath.Join(root, "staging", "edge.Caddyfile")

--- a/internal/privileged/plugin_artifact_policy_test.go
+++ b/internal/privileged/plugin_artifact_policy_test.go
@@ -12,7 +12,7 @@ func TestManagedArtifactPathRejectsAggregateOnlyProtocolSidecars(t *testing.T) {
 func TestManagedArtifactPathUsesProtocolArtifactSpecs(t *testing.T) {
 	policy := Policy{}
 	for _, id := range []string{
-		"caddy/edge.Caddyfile",
+		"caddy/edge.json",
 		"hysteria2/udp-edge.yaml",
 		"olcrtc/rtc-edge.yaml",
 		"mieru/server_config.json",
@@ -28,13 +28,13 @@ func TestManagedArtifactPathRestrictsUnknownDynamicNames(t *testing.T) {
 	allowed := map[string]struct{}{"edge": {}}
 	policy := Policy{AllowedArtifactNames: allowed}
 
-	if _, ok := policy.managedArtifactPath("caddy/edge.Caddyfile"); !ok {
+	if _, ok := policy.managedArtifactPath("caddy/edge.json"); !ok {
 		t.Fatal("expected allowed dynamic name to be accepted")
 	}
 	if _, ok := policy.managedArtifactPath("hysteria2/edge.yaml"); !ok {
 		t.Fatal("expected allowed dynamic name to be accepted for hysteria2")
 	}
-	if _, ok := policy.managedArtifactPath("caddy/other.Caddyfile"); ok {
+	if _, ok := policy.managedArtifactPath("caddy/other.json"); ok {
 		t.Fatal("expected unknown dynamic name to be rejected")
 	}
 	if _, ok := policy.managedArtifactPath("hysteria2/other.yaml"); ok {
@@ -48,7 +48,7 @@ func TestManagedArtifactPathRestrictsUnknownDynamicNames(t *testing.T) {
 
 func TestManagedArtifactPathAllowsAllDynamicNamesWhenUnrestricted(t *testing.T) {
 	policy := Policy{}
-	if _, ok := policy.managedArtifactPath("caddy/edge.Caddyfile"); !ok {
+	if _, ok := policy.managedArtifactPath("caddy/edge.json"); !ok {
 		t.Fatal("expected dynamic name to be accepted when no allow-list is set")
 	}
 	if _, ok := policy.managedArtifactPath("hysteria2/udp-edge.yaml"); !ok {

--- a/internal/privileged/policy.go
+++ b/internal/privileged/policy.go
@@ -215,6 +215,8 @@ var (
 	opaquePromotionIDPattern = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
 	artifactNamePattern      = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
 	updateVersionPattern     = regexp.MustCompile(`^v?[0-9][A-Za-z0-9._+-]*$`)
+	dnsLabelPattern          = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$`)
+	caddyCertRoot            = "/etc/veil/certs"
 )
 
 func (p Policy) managedArtifactPath(id string) (ArtifactPath, bool) {

--- a/internal/privileged/policy.go
+++ b/internal/privileged/policy.go
@@ -149,11 +149,11 @@ func (p Policy) ResolvePromotion(request PromoteRequest) (ResolvedPromotion, err
 		}
 		return ResolvedPromotion{RestoreBackupID: request.RestoreBackupID}, nil
 	}
-	artifacts, err := p.resolveArtifacts(request.ArtifactIDs)
+	artifacts, err := p.resolveArtifacts(request.ArtifactIDs, false)
 	if err != nil {
 		return ResolvedPromotion{}, err
 	}
-	removeArtifacts, err := p.resolveArtifacts(request.RemoveArtifactIDs)
+	removeArtifacts, err := p.resolveArtifacts(request.RemoveArtifactIDs, true)
 	if err != nil {
 		return ResolvedPromotion{}, err
 	}
@@ -163,7 +163,7 @@ func (p Policy) ResolvePromotion(request PromoteRequest) (ResolvedPromotion, err
 	return ResolvedPromotion{Artifacts: artifacts, RemoveArtifacts: removeArtifacts}, nil
 }
 
-func (p Policy) resolveArtifacts(ids []string) ([]ResolvedArtifact, error) {
+func (p Policy) resolveArtifacts(ids []string, allowLegacyCaddyRemoval bool) ([]ResolvedArtifact, error) {
 	resolved := make([]ResolvedArtifact, 0, len(ids))
 	seen := make(map[string]struct{}, len(ids))
 	for _, id := range ids {
@@ -174,6 +174,9 @@ func (p Policy) resolveArtifacts(ids []string) ([]ResolvedArtifact, error) {
 		spec, ok := p.Artifacts[id]
 		if !ok {
 			spec, ok = p.managedArtifactPath(id)
+		}
+		if !ok && allowLegacyCaddyRemoval {
+			spec, ok = legacyCaddyArtifactPath(id)
 		}
 		if !ok {
 			return nil, newError(ErrorNotFound, "unknown artifact id")
@@ -189,6 +192,23 @@ func (p Policy) resolveArtifacts(ids []string) ([]ResolvedArtifact, error) {
 		resolved = append(resolved, ResolvedArtifact{ID: id, Source: source, Destination: destination})
 	}
 	return resolved, nil
+}
+
+func legacyCaddyArtifactPath(id string) (ArtifactPath, bool) {
+	clean := filepath.ToSlash(filepath.Clean(id))
+	if clean != id || strings.Contains(clean, `\`) || !strings.HasPrefix(clean, "caddy/") {
+		return ArtifactPath{}, false
+	}
+	rest := strings.TrimPrefix(clean, "caddy/")
+	if strings.Contains(rest, "/") || !strings.HasSuffix(rest, ".Caddyfile") {
+		return ArtifactPath{}, false
+	}
+	name := strings.TrimSuffix(rest, ".Caddyfile")
+	if !artifactNamePattern.MatchString(name) {
+		return ArtifactPath{}, false
+	}
+	path := filepath.FromSlash(clean)
+	return ArtifactPath{Staged: path, Generated: path}, true
 }
 
 var (

--- a/internal/privileged/policy_test.go
+++ b/internal/privileged/policy_test.go
@@ -120,7 +120,7 @@ func TestPolicyResolvesManagedDynamicArtifactIDs(t *testing.T) {
 	policy := testPolicy(t)
 	resolved, err := policy.ResolvePromotion(PromoteRequest{
 		ArtifactIDs: []string{
-			"caddy/edge.Caddyfile",
+			"caddy/edge.json",
 			"hysteria2/udp-edge.yaml",
 			"olcrtc/rtc-edge.yaml",
 			"mieru/server_config.json",
@@ -256,14 +256,14 @@ func TestPolicyManagedArtifactPathEdgeCases(t *testing.T) {
 		id      string
 		allowed bool
 	}{
-		{"caddy/edge.Caddyfile", true},
+		{"caddy/edge.json", true},
 		{"hysteria2/udp.yaml", true},
 		{"olcrtc/rtc.yaml", true},
 		{"mieru/server_config.json", true},
 		{"sing-box/warp.json", true},
 		{"caddy/edge.yaml", false},
-		{"hysteria2/udp.Caddyfile", false},
-		{"caddy/bad!.Caddyfile", false},
+		{"hysteria2/udp.json", false},
+		{"caddy/bad!.json", false},
 		{"unknown/file.yaml", false},
 		{"single.yaml", false},
 		{"caddy/../escape.Caddyfile", false},

--- a/internal/privileged/policy_test.go
+++ b/internal/privileged/policy_test.go
@@ -135,6 +135,39 @@ func TestPolicyResolvesManagedDynamicArtifactIDs(t *testing.T) {
 	}
 }
 
+func TestPolicyAllowsLegacyCaddyfileOnlyForRemoval(t *testing.T) {
+	policy := testPolicy(t)
+	for _, root := range []string{policy.StagingRoot, policy.GeneratedRoot} {
+		if err := os.MkdirAll(filepath.Join(root, "caddy"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	resolved, err := policy.ResolvePromotion(PromoteRequest{
+		RemoveArtifactIDs: []string{"caddy/legacy.Caddyfile"},
+	})
+	if err != nil {
+		t.Fatalf("resolve legacy Caddyfile removal: %v", err)
+	}
+	if len(resolved.RemoveArtifacts) != 1 || resolved.RemoveArtifacts[0].ID != "caddy/legacy.Caddyfile" {
+		t.Fatalf("resolved removal = %+v", resolved.RemoveArtifacts)
+	}
+
+	_, err = policy.ResolvePromotion(PromoteRequest{
+		ArtifactIDs: []string{"caddy/legacy.Caddyfile"},
+	})
+	assertOperationErrorCode(t, err, ErrorNotFound)
+
+	for _, id := range []string{
+		"caddy/bad.name.Caddyfile",
+		"caddy/../escape.Caddyfile",
+		"caddy/sub/escape.Caddyfile",
+	} {
+		_, err := policy.ResolvePromotion(PromoteRequest{RemoveArtifactIDs: []string{id}})
+		assertOperationErrorCode(t, err, ErrorNotFound)
+	}
+}
+
 func TestPolicyAllowsOpaquePromotionRestoreID(t *testing.T) {
 	policy := testPolicy(t)
 	resolved, err := policy.ResolvePromotion(PromoteRequest{RestoreBackupID: "20260605T120000.000000000Z"})

--- a/internal/protocols/capability_catalog.go
+++ b/internal/protocols/capability_catalog.go
@@ -61,7 +61,7 @@ func NeedsCaddyCertSync(protocol string) bool {
 
 // Legacy unit constants remain here until all callers migrate to the registry.
 const (
-	UnitCaddy     = "veil-caddy@.service"
+	UnitCaddy     = "veil-caddy.service"
 	UnitHysteria2 = "veil-hysteria2@.service"
 	UnitOlcrtc    = "veil-olcrtc@.service"
 	UnitMieru     = "veil-mieru.service"

--- a/internal/protocols/capability_catalog_test.go
+++ b/internal/protocols/capability_catalog_test.go
@@ -46,7 +46,7 @@ func TestGeneratedConfigRegistryMultipleHysteriaAndNaive(t *testing.T) {
 
 	configs, err := registry.Render(generatedconfig.ConfigInput{
 		ApplyRoot: root,
-		Settings:  model.Settings{Domain: "example.com"},
+		Settings:  model.Settings{Domain: "example.com", DefaultAcmeEmail: "admin@example.com"},
 		Inbounds:  inbounds,
 	})
 	if err != nil {
@@ -63,22 +63,17 @@ func TestGeneratedConfigRegistryMultipleHysteriaAndNaive(t *testing.T) {
 		t.Errorf("missing config for hy2-b at %s", hy2BPath)
 	}
 
-	// Verify naiveproxy configs are rendered as separate files
-	naiveAPath := filepath.Join(root, "generated", "caddy", "naive-a.Caddyfile")
-	naiveBPath := filepath.Join(root, "generated", "caddy", "naive-b.Caddyfile")
-	caddyContentA, ok := configs[naiveAPath]
+	// Verify naiveproxy config is rendered as a single consolidated JSON file
+	naivePath := filepath.Join(root, "generated", "caddy", "config.json")
+	caddyContent, ok := configs[naivePath]
 	if !ok {
-		t.Fatalf("missing caddy config at %s", naiveAPath)
-	}
-	caddyContentB, ok := configs[naiveBPath]
-	if !ok {
-		t.Fatalf("missing caddy config at %s", naiveBPath)
+		t.Fatalf("missing caddy config at %s", naivePath)
 	}
 
-	if !strings.Contains(caddyContentA, "usera") {
-		t.Errorf("Caddyfile does not contain naive proxy definition for usera: %s", caddyContentA)
+	if !strings.Contains(caddyContent, "dXNlcmE6cGFzc2E=") {
+		t.Errorf("Caddy JSON does not contain naive proxy credential for usera: %s", caddyContent)
 	}
-	if !strings.Contains(caddyContentB, "userb") {
-		t.Errorf("Caddyfile does not contain naive proxy definition for userb: %s", caddyContentB)
+	if !strings.Contains(caddyContent, "dXNlcmI6cGFzc2I=") {
+		t.Errorf("Caddy JSON does not contain naive proxy credential for userb: %s", caddyContent)
 	}
 }

--- a/internal/protocols/capability_catalog_test.go
+++ b/internal/protocols/capability_catalog_test.go
@@ -1,6 +1,7 @@
 package protocols
 
 import (
+	"encoding/base64"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -70,10 +71,15 @@ func TestGeneratedConfigRegistryMultipleHysteriaAndNaive(t *testing.T) {
 		t.Fatalf("missing caddy config at %s", naivePath)
 	}
 
-	if !strings.Contains(caddyContent, "dXNlcmE6cGFzc2E=") {
+	if !strings.Contains(caddyContent, forwardProxyJSONCredential("usera", "passa")) {
 		t.Errorf("Caddy JSON does not contain naive proxy credential for usera: %s", caddyContent)
 	}
-	if !strings.Contains(caddyContent, "dXNlcmI6cGFzc2I=") {
+	if !strings.Contains(caddyContent, forwardProxyJSONCredential("userb", "passb")) {
 		t.Errorf("Caddy JSON does not contain naive proxy credential for userb: %s", caddyContent)
 	}
+}
+
+func forwardProxyJSONCredential(username, password string) string {
+	basicValue := base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
+	return base64.StdEncoding.EncodeToString([]byte(basicValue))
 }

--- a/internal/protocols/hysteria2/client_access.go
+++ b/internal/protocols/hysteria2/client_access.go
@@ -7,7 +7,7 @@ import (
 
 // BuildLinks creates client links for a Hysteria2 inbound.
 func (p Plugin) BuildLinks(settings model.Settings, inbound model.Inbound) ([]model.ClientLink, error) {
-	endpoint := hysteria2Domain(settings, inbound)
+	endpoint := model.ResolveInboundDomain(inbound, settings)
 	if endpoint == "" {
 		return nil, nil
 	}

--- a/internal/protocols/hysteria2/client_access.go
+++ b/internal/protocols/hysteria2/client_access.go
@@ -1,15 +1,13 @@
 package hysteria2
 
 import (
-	"strings"
-
 	"github.com/mikkelchokolate/Veil/internal/clientaccess"
 	"github.com/mikkelchokolate/Veil/internal/model"
 )
 
 // BuildLinks creates client links for a Hysteria2 inbound.
 func (p Plugin) BuildLinks(settings model.Settings, inbound model.Inbound) ([]model.ClientLink, error) {
-	endpoint := strings.TrimSpace(settings.Domain)
+	endpoint := hysteria2Domain(settings, inbound)
 	if endpoint == "" {
 		return nil, nil
 	}

--- a/internal/protocols/hysteria2/hysteria2_test.go
+++ b/internal/protocols/hysteria2/hysteria2_test.go
@@ -260,6 +260,40 @@ func TestRenderConfigWithInboundDomainLowercases(t *testing.T) {
 	}
 }
 
+func TestRenderConfigWithInboundDomainWithoutCaddyPanelAccess(t *testing.T) {
+	p := New()
+	paths := generatedconfig.NewPaths("/tmp/veil")
+	artifacts, _, err := p.RenderConfig(generatedconfig.ProtocolRenderInput{
+		Settings: model.Settings{
+			Domain:            "example.com",
+			PanelAccess:       "direct",
+			Hysteria2Password: "secret",
+		},
+		Paths: paths,
+		Inbounds: []model.Inbound{
+			{
+				Name:      "h2-1",
+				Protocol:  "hysteria2",
+				Transport: "udp",
+				Port:      8443,
+				Enabled:   true,
+				ProtocolFields: map[string]any{
+					"domain": "inbound.example.com",
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(artifacts[0].Body, "cert: "+paths.CertPath("inbound.example.com")) {
+		t.Errorf("expected inbound caddy cert path even without panel caddy, got:\n%s", artifacts[0].Body)
+	}
+	if !strings.Contains(artifacts[0].Body, "key: "+paths.KeyPath("inbound.example.com")) {
+		t.Errorf("expected inbound caddy key path even without panel caddy, got:\n%s", artifacts[0].Body)
+	}
+}
+
 func TestRenderConfigWithWarpUpstream(t *testing.T) {
 	p := New()
 	paths := generatedconfig.NewPaths("/tmp/veil")
@@ -521,6 +555,65 @@ func TestValidateInbound(t *testing.T) {
 	missing := p.ValidateInbound(model.Settings{}, model.Inbound{Protocol: "hysteria2"})
 	if len(missing) == 0 {
 		t.Error("expected issues for missing domain")
+	}
+}
+
+func TestValidateInboundDomainAndEmailErrors(t *testing.T) {
+	p := New()
+
+	cases := []struct {
+		name      string
+		inbound   model.Inbound
+		settings  model.Settings
+		wantCodes []string
+	}{
+		{
+			name:      "invalid domain",
+			inbound:   model.Inbound{Protocol: "hysteria2", ProtocolFields: map[string]any{"domain": "not a domain", "email": "admin@x.com"}},
+			settings:  model.Settings{},
+			wantCodes: []string{"hysteria2_domain_invalid"},
+		},
+		{
+			name:      "missing email for per-inbound domain",
+			inbound:   model.Inbound{Protocol: "hysteria2", ProtocolFields: map[string]any{"domain": "x.com"}},
+			settings:  model.Settings{},
+			wantCodes: []string{"hysteria2_email_required"},
+		},
+		{
+			name:      "invalid email",
+			inbound:   model.Inbound{Protocol: "hysteria2", ProtocolFields: map[string]any{"domain": "x.com", "email": "not-an-email"}},
+			settings:  model.Settings{},
+			wantCodes: []string{"hysteria2_email_invalid"},
+		},
+		{
+			name:      "legacy settings.Email not accepted for inbound domain",
+			inbound:   model.Inbound{Protocol: "hysteria2", ProtocolFields: map[string]any{"domain": "x.com"}},
+			settings:  model.Settings{Email: "legacy@x.com"},
+			wantCodes: []string{"hysteria2_email_required"},
+		},
+		{
+			name:      "no email needed without per-inbound domain",
+			inbound:   model.Inbound{Protocol: "hysteria2"},
+			settings:  model.Settings{Domain: "x.com"},
+			wantCodes: []string{},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			issues := p.ValidateInbound(tc.settings, tc.inbound)
+			got := make([]string, len(issues))
+			for i, issue := range issues {
+				got[i] = issue.Code
+			}
+			if len(got) != len(tc.wantCodes) {
+				t.Fatalf("got codes %v, want %v", got, tc.wantCodes)
+			}
+			for i, want := range tc.wantCodes {
+				if got[i] != want {
+					t.Fatalf("got code %q, want %q", got[i], want)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/protocols/hysteria2/hysteria2_test.go
+++ b/internal/protocols/hysteria2/hysteria2_test.go
@@ -697,6 +697,46 @@ func TestBuildLinksProfileRequiresPassword(t *testing.T) {
 	}
 }
 
+func TestBuildLinksUsesInboundDomainWithFallback(t *testing.T) {
+	p := New()
+
+	// Inbound-specific domain should override settings.Domain.
+	settings := model.Settings{Domain: "example.com"}
+	inbound := model.Inbound{
+		Name:           "h2",
+		Protocol:       "hysteria2",
+		Transport:      "udp",
+		Port:           8443,
+		Password:       "secret-pass",
+		ProtocolFields: map[string]any{"domain": "inbound.example.com"},
+	}
+	links, err := p.BuildLinks(settings, inbound)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(links) != 1 {
+		t.Fatalf("expected 1 link, got %d", len(links))
+	}
+	wantPrefix := "hysteria2://" + url.QueryEscape("secret-pass") + "@inbound.example.com:8443/"
+	if !strings.HasPrefix(links[0].URI, wantPrefix) {
+		t.Errorf("URI prefix mismatch: got %q", links[0].URI)
+	}
+	if !strings.Contains(links[0].URI, "sni=inbound.example.com") {
+		t.Errorf("URI missing inbound sni: %q", links[0].URI)
+	}
+
+	// Falls back to settings.Domain when inbound-specific domain is absent.
+	inbound.ProtocolFields = nil
+	links, err = p.BuildLinks(settings, inbound)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	wantPrefix = "hysteria2://" + url.QueryEscape("secret-pass") + "@example.com:8443/"
+	if !strings.HasPrefix(links[0].URI, wantPrefix) {
+		t.Errorf("fallback URI prefix mismatch: got %q", links[0].URI)
+	}
+}
+
 func TestProtocolString(t *testing.T) {
 	if got := protocolString(nil, "k", "fallback"); got != "fallback" {
 		t.Errorf("nil map = %q, want fallback", got)

--- a/internal/protocols/hysteria2/hysteria2_test.go
+++ b/internal/protocols/hysteria2/hysteria2_test.go
@@ -195,6 +195,71 @@ func TestRenderConfigWithCaddyPanelAccess(t *testing.T) {
 	}
 }
 
+func TestRenderConfigWithInboundDomain(t *testing.T) {
+	p := New()
+	paths := generatedconfig.NewPaths("/tmp/veil")
+	artifacts, _, err := p.RenderConfig(generatedconfig.ProtocolRenderInput{
+		Settings: model.Settings{
+			Domain:            "example.com",
+			PanelAccess:       "caddy",
+			Hysteria2Password: "secret",
+		},
+		Paths: paths,
+		Inbounds: []model.Inbound{
+			{
+				Name:      "h2-1",
+				Protocol:  "hysteria2",
+				Transport: "udp",
+				Port:      8443,
+				Enabled:   true,
+				ProtocolFields: map[string]any{
+					"domain": "inbound.example.com",
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(artifacts[0].Body, "cert: "+paths.CertPath("inbound.example.com")) {
+		t.Errorf("expected inbound caddy cert path, got:\n%s", artifacts[0].Body)
+	}
+	if !strings.Contains(artifacts[0].Body, "key: "+paths.KeyPath("inbound.example.com")) {
+		t.Errorf("expected inbound caddy key path, got:\n%s", artifacts[0].Body)
+	}
+}
+
+func TestRenderConfigWithInboundDomainLowercases(t *testing.T) {
+	p := New()
+	paths := generatedconfig.NewPaths("/tmp/veil")
+	artifacts, _, err := p.RenderConfig(generatedconfig.ProtocolRenderInput{
+		Settings: model.Settings{
+			Domain:            "example.com",
+			PanelAccess:       "caddy",
+			Hysteria2Password: "secret",
+		},
+		Paths: paths,
+		Inbounds: []model.Inbound{
+			{
+				Name:      "h2-1",
+				Protocol:  "hysteria2",
+				Transport: "udp",
+				Port:      8443,
+				Enabled:   true,
+				ProtocolFields: map[string]any{
+					"domain": "  Inbound.Example.COM  ",
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(artifacts[0].Body, "cert: "+paths.CertPath("inbound.example.com")) {
+		t.Errorf("expected lowercased inbound caddy cert path, got:\n%s", artifacts[0].Body)
+	}
+}
+
 func TestRenderConfigWithWarpUpstream(t *testing.T) {
 	p := New()
 	paths := generatedconfig.NewPaths("/tmp/veil")
@@ -441,9 +506,21 @@ func TestValidateSettings(t *testing.T) {
 
 func TestValidateInbound(t *testing.T) {
 	p := New()
-	issues := p.ValidateInbound(model.Settings{}, model.Inbound{})
+	valid := model.Inbound{
+		Protocol: "hysteria2",
+		ProtocolFields: map[string]any{
+			"domain": "x.com",
+			"email":  "admin@x.com",
+		},
+	}
+	issues := p.ValidateInbound(model.Settings{Domain: "x.com"}, valid)
 	if len(issues) != 0 {
 		t.Errorf("ValidateInbound returned issues: %v", issues)
+	}
+
+	missing := p.ValidateInbound(model.Settings{}, model.Inbound{Protocol: "hysteria2"})
+	if len(missing) == 0 {
+		t.Error("expected issues for missing domain")
 	}
 }
 
@@ -734,6 +811,35 @@ func TestBuildLinksUsesInboundDomainWithFallback(t *testing.T) {
 	wantPrefix = "hysteria2://" + url.QueryEscape("secret-pass") + "@example.com:8443/"
 	if !strings.HasPrefix(links[0].URI, wantPrefix) {
 		t.Errorf("fallback URI prefix mismatch: got %q", links[0].URI)
+	}
+}
+
+func TestBuildLinksProfileUsesInboundDomain(t *testing.T) {
+	p := New()
+	settings := model.Settings{Domain: "example.com"}
+	inbound := model.Inbound{
+		Name:      "h2",
+		Protocol:  "hysteria2",
+		Transport: "udp",
+		Port:      8443,
+		Profiles: []model.ClientProfile{
+			{Name: "alice", Username: "alice", Password: "alice-pass", Enabled: true},
+		},
+		ProtocolFields: map[string]any{"domain": "inbound.example.com"},
+	}
+	links, err := p.BuildLinks(settings, inbound)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(links) != 1 {
+		t.Fatalf("expected 1 link, got %d", len(links))
+	}
+	wantPrefix := "hysteria2://alice:alice-pass@inbound.example.com:8443/"
+	if !strings.HasPrefix(links[0].URI, wantPrefix) {
+		t.Errorf("URI prefix mismatch: got %q", links[0].URI)
+	}
+	if !strings.Contains(links[0].URI, "sni=inbound.example.com") {
+		t.Errorf("URI missing inbound sni: %q", links[0].URI)
 	}
 }
 

--- a/internal/protocols/hysteria2/renderer.go
+++ b/internal/protocols/hysteria2/renderer.go
@@ -52,7 +52,9 @@ func renderHysteria2(settings model.Settings, inbound model.Inbound, warp model.
 		Users:         access.Hysteria2Users(),
 		MasqueradeURL: url,
 	}
-	if settings.PanelAccess == "caddy" && domain != "" {
+	// Use Caddy-managed certificates whenever the inbound has its own domain
+	// (Caddy is already required for it) or when the panel itself uses Caddy.
+	if domain != "" && (settings.PanelAccess == "caddy" || model.InboundDomain(inbound) != "") {
 		hystConfig.CertPath = paths.CertPath(domain)
 		hystConfig.KeyPath = paths.KeyPath(domain)
 	} else {
@@ -68,4 +70,3 @@ func renderHysteria2(settings model.Settings, inbound model.Inbound, warp model.
 	}
 	return renderer.RenderHysteria2(hystConfig)
 }
-

--- a/internal/protocols/hysteria2/renderer.go
+++ b/internal/protocols/hysteria2/renderer.go
@@ -2,7 +2,6 @@ package hysteria2
 
 import (
 	"strconv"
-	"strings"
 
 	"github.com/mikkelchokolate/Veil/internal/clientaccess"
 	"github.com/mikkelchokolate/Veil/internal/generatedconfig"
@@ -45,7 +44,7 @@ func renderHysteria2(settings model.Settings, inbound model.Inbound, warp model.
 		return "", err
 	}
 	url := masqueradeURL(settings, inbound)
-	domain := hysteria2Domain(settings, inbound)
+	domain := model.ResolveInboundDomain(inbound, settings)
 	hystConfig := renderer.Hysteria2Config{
 		ListenPort:    inbound.Port,
 		Domain:        domain,
@@ -70,13 +69,3 @@ func renderHysteria2(settings model.Settings, inbound model.Inbound, warp model.
 	return renderer.RenderHysteria2(hystConfig)
 }
 
-func hysteria2Domain(settings model.Settings, inbound model.Inbound) string {
-	if inbound.ProtocolFields != nil {
-		if d, ok := inbound.ProtocolFields["domain"].(string); ok {
-			if v := strings.TrimSpace(d); v != "" {
-				return v
-			}
-		}
-	}
-	return strings.TrimSpace(settings.Domain)
-}

--- a/internal/protocols/hysteria2/renderer.go
+++ b/internal/protocols/hysteria2/renderer.go
@@ -2,6 +2,7 @@ package hysteria2
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/mikkelchokolate/Veil/internal/clientaccess"
 	"github.com/mikkelchokolate/Veil/internal/generatedconfig"
@@ -44,16 +45,17 @@ func renderHysteria2(settings model.Settings, inbound model.Inbound, warp model.
 		return "", err
 	}
 	url := masqueradeURL(settings, inbound)
+	domain := hysteria2Domain(settings, inbound)
 	hystConfig := renderer.Hysteria2Config{
 		ListenPort:    inbound.Port,
-		Domain:        settings.Domain,
+		Domain:        domain,
 		Password:      password,
 		Users:         access.Hysteria2Users(),
 		MasqueradeURL: url,
 	}
-	if settings.PanelAccess == "caddy" && settings.Domain != "" {
-		hystConfig.CertPath = paths.CertPath(settings.Domain)
-		hystConfig.KeyPath = paths.KeyPath(settings.Domain)
+	if settings.PanelAccess == "caddy" && domain != "" {
+		hystConfig.CertPath = paths.CertPath(domain)
+		hystConfig.KeyPath = paths.KeyPath(domain)
 	} else {
 		hystConfig.CertPath = paths.PanelCertPath()
 		hystConfig.KeyPath = paths.PanelKeyPath()
@@ -66,4 +68,15 @@ func renderHysteria2(settings model.Settings, inbound model.Inbound, warp model.
 		hystConfig.Upstream = "127.0.0.1:" + strconv.Itoa(socksPort)
 	}
 	return renderer.RenderHysteria2(hystConfig)
+}
+
+func hysteria2Domain(settings model.Settings, inbound model.Inbound) string {
+	if inbound.ProtocolFields != nil {
+		if d, ok := inbound.ProtocolFields["domain"].(string); ok {
+			if v := strings.TrimSpace(d); v != "" {
+				return v
+			}
+		}
+	}
+	return strings.TrimSpace(settings.Domain)
 }

--- a/internal/protocols/hysteria2/validator.go
+++ b/internal/protocols/hysteria2/validator.go
@@ -3,20 +3,65 @@ package hysteria2
 import (
 	"strings"
 
+	"github.com/mikkelchokolate/Veil/internal/hostenv"
 	"github.com/mikkelchokolate/Veil/internal/model"
 )
 
 // ValidateSettings is a no-op for Hysteria2 global settings.
 func (Plugin) ValidateSettings(model.Settings, model.Inbound) error { return nil }
 
-// ValidateInbound is a no-op for Hysteria2-specific inbound checks.
-func (Plugin) ValidateInbound(model.Settings, model.Inbound) []model.ValidationIssue { return nil }
+// ValidateInbound checks the Hysteria2 inbound for a valid public domain and
+// ACME email when a per-inbound domain is configured.
+func (Plugin) ValidateInbound(settings model.Settings, inbound model.Inbound) []model.ValidationIssue {
+	var issues []model.ValidationIssue
+	domain := model.ResolveInboundDomain(inbound, settings)
+	if domain == "" {
+		issues = append(issues, model.ValidationIssue{
+			Code:     "hysteria2_domain_required",
+			Severity: "error",
+			Field:    "domain",
+			Message:  "Hysteria2 inbound requires a public domain.",
+			Source:   "hysteria2",
+		})
+	} else if err := hostenv.ValidateDomain(domain); err != nil {
+		issues = append(issues, model.ValidationIssue{
+			Code:     "hysteria2_domain_invalid",
+			Severity: "error",
+			Field:    "domain",
+			Message:  "Hysteria2 inbound domain is invalid: " + err.Error(),
+			Source:   "hysteria2",
+		})
+	}
+	if model.InboundDomain(inbound) != "" {
+		if email := model.ResolveInboundEmail(inbound, settings); email == "" {
+			issues = append(issues, model.ValidationIssue{
+				Code:     "hysteria2_email_required",
+				Severity: "error",
+				Field:    "email",
+				Message:  "Hysteria2 inbound with a custom domain requires an ACME email.",
+				Source:   "hysteria2",
+			})
+		} else if err := hostenv.ValidateEmail(email); err != nil {
+			issues = append(issues, model.ValidationIssue{
+				Code:     "hysteria2_email_invalid",
+				Severity: "error",
+				Field:    "email",
+				Message:  "Hysteria2 inbound email is invalid: " + err.Error(),
+				Source:   "hysteria2",
+			})
+		}
+	}
+	return issues
+}
 
 // NeedsDomain reports that Hysteria2 needs a public domain.
 func (Plugin) NeedsDomain(model.Settings, model.Inbound) bool { return true }
 
-// NeedsEmail reports that Hysteria2 does not need an email address.
-func (Plugin) NeedsEmail(model.Settings, model.Inbound) bool { return false }
+// NeedsEmail reports that Hysteria2 needs an email address when it uses a
+// per-inbound domain with Caddy-managed TLS.
+func (Plugin) NeedsEmail(_ model.Settings, inbound model.Inbound) bool {
+	return model.InboundDomain(inbound) != ""
+}
 
 // HasCredential reports whether the inbound has a usable Hysteria2 credential.
 func (Plugin) HasCredential(settings model.Settings, inbound model.Inbound) bool {

--- a/internal/protocols/hysteria2/validator.go
+++ b/internal/protocols/hysteria2/validator.go
@@ -19,7 +19,7 @@ func (Plugin) ValidateInbound(settings model.Settings, inbound model.Inbound) []
 		issues = append(issues, model.ValidationIssue{
 			Code:     "hysteria2_domain_required",
 			Severity: "error",
-			Field:    "domain",
+			Field:    model.InboundDomainField,
 			Message:  "Hysteria2 inbound requires a public domain.",
 			Source:   "hysteria2",
 		})
@@ -27,7 +27,7 @@ func (Plugin) ValidateInbound(settings model.Settings, inbound model.Inbound) []
 		issues = append(issues, model.ValidationIssue{
 			Code:     "hysteria2_domain_invalid",
 			Severity: "error",
-			Field:    "domain",
+			Field:    model.InboundDomainField,
 			Message:  "Hysteria2 inbound domain is invalid: " + err.Error(),
 			Source:   "hysteria2",
 		})
@@ -37,7 +37,7 @@ func (Plugin) ValidateInbound(settings model.Settings, inbound model.Inbound) []
 			issues = append(issues, model.ValidationIssue{
 				Code:     "hysteria2_email_required",
 				Severity: "error",
-				Field:    "email",
+				Field:    model.InboundEmailField,
 				Message:  "Hysteria2 inbound with a custom domain requires an ACME email.",
 				Source:   "hysteria2",
 			})
@@ -45,7 +45,7 @@ func (Plugin) ValidateInbound(settings model.Settings, inbound model.Inbound) []
 			issues = append(issues, model.ValidationIssue{
 				Code:     "hysteria2_email_invalid",
 				Severity: "error",
-				Field:    "email",
+				Field:    model.InboundEmailField,
 				Message:  "Hysteria2 inbound email is invalid: " + err.Error(),
 				Source:   "hysteria2",
 			})

--- a/internal/protocols/naiveproxy/client_access.go
+++ b/internal/protocols/naiveproxy/client_access.go
@@ -1,62 +1,68 @@
 package naiveproxy
 
 import (
-	"strings"
+	"errors"
+	"fmt"
 
-	"github.com/mikkelchokolate/Veil/internal/clientaccess"
 	"github.com/mikkelchokolate/Veil/internal/model"
 )
 
 // BuildLinks creates client links for a naiveproxy inbound.
 func (p Plugin) BuildLinks(settings model.Settings, inbound model.Inbound) ([]model.ClientLink, error) {
-	endpoint := clientEndpoint(settings)
-	if endpoint == "" {
+	return BuildLinks(settings, inbound)
+}
+
+// BuildLinks creates client links for a naiveproxy inbound based on its
+// configured transport. TCP yields an https:// URI, QUIC yields a quic:// URI,
+// and dual yields both. The port is omitted when it matches the default (443).
+func BuildLinks(settings model.Settings, inbound model.Inbound) ([]model.ClientLink, error) {
+	domain := NaiveDomain(settings, inbound)
+	if domain == "" {
 		return nil, nil
 	}
-	creds, err := clientaccess.BuildClientCredentials(inbound)
-	if err != nil {
-		return nil, err
-	}
-	links := make([]model.ClientLink, 0, len(creds))
+	port := NaivePublicPort(settings, inbound)
+	transport := NaiveTransport(inbound)
+	creds := inbound.Profiles
 	if len(creds) == 0 {
-		link := model.ClientLink{
-			Name:      inbound.Name,
-			Protocol:  inbound.Protocol,
-			Transport: inbound.Transport,
-			Port:      inbound.Port,
-			URI:       clientaccess.NaiveClientURI(endpoint, inbound.Port, p.naiveFallbackUsername(settings, inbound), p.naiveFallbackPassword(settings, inbound)),
+		username := naiveUsername(settings, inbound)
+		password := naivePassword(settings, inbound)
+		if username == "" || password == "" {
+			return nil, errors.New("no profiles")
 		}
-		return []model.ClientLink{link}, nil
+		creds = []model.ClientProfile{{Name: inbound.Name, Username: username, Password: password, Enabled: true}}
 	}
-	for _, cred := range creds {
-		link := model.ClientLink{
-			Name:      inbound.Name + "/" + cred.Name,
-			Protocol:  inbound.Protocol,
-			Transport: inbound.Transport,
-			Port:      inbound.Port,
-			URI:       clientaccess.NaiveClientURI(endpoint, inbound.Port, cred.Username, cred.Password),
+	var links []model.ClientLink
+	for _, profile := range creds {
+		name := inbound.Name
+		if profile.Name != "" && profile.Name != inbound.Name {
+			name = inbound.Name + "/" + profile.Name
 		}
-		links = append(links, link)
+		if transport == "tcp" || transport == "dual" {
+			links = append(links, model.ClientLink{
+				Name:      name,
+				Protocol:  "naiveproxy",
+				Transport: "tcp",
+				Port:      port,
+				URI:       naiveURI("https", profile.Username, profile.Password, domain, port, 443),
+			})
+		}
+		if transport == "quic" || transport == "dual" {
+			links = append(links, model.ClientLink{
+				Name:      name + "-quic",
+				Protocol:  "naiveproxy",
+				Transport: "quic",
+				Port:      port,
+				URI:       naiveURI("quic", profile.Username, profile.Password, domain, port, 443),
+			})
+		}
 	}
 	return links, nil
 }
 
-func (Plugin) naiveFallbackUsername(settings model.Settings, inbound model.Inbound) string {
-	username := naiveUsername(settings, inbound)
-	if username == "" {
-		username = settings.NaiveUsername
+func naiveURI(scheme, user, pass, domain string, port, defaultPort int) string {
+	host := domain
+	if port != defaultPort {
+		host = fmt.Sprintf("%s:%d", domain, port)
 	}
-	return username
-}
-
-func (Plugin) naiveFallbackPassword(settings model.Settings, inbound model.Inbound) string {
-	password := naivePassword(settings, inbound)
-	if password == "" {
-		password = settings.NaivePassword
-	}
-	return password
-}
-
-func clientEndpoint(settings model.Settings) string {
-	return strings.TrimSpace(settings.Domain)
+	return fmt.Sprintf("%s://%s:%s@%s", scheme, user, pass, host)
 }

--- a/internal/protocols/naiveproxy/client_access_test.go
+++ b/internal/protocols/naiveproxy/client_access_test.go
@@ -9,8 +9,8 @@ import (
 func TestBuildLinksDual(t *testing.T) {
 	settings := model.Settings{DefaultInboundPublicPort: 443}
 	inbound := model.Inbound{
-		Protocol: "naiveproxy",
-		Profiles: []model.ClientProfile{{Username: "u", Password: "p"}},
+		Protocol:       "naiveproxy",
+		Profiles:       []model.ClientProfile{{Username: "u", Password: "p"}},
 		ProtocolFields: map[string]any{"domain": "p.example.com", "transport": "dual"},
 	}
 	links, err := BuildLinks(settings, inbound)

--- a/internal/protocols/naiveproxy/client_access_test.go
+++ b/internal/protocols/naiveproxy/client_access_test.go
@@ -1,0 +1,23 @@
+package naiveproxy
+
+import (
+	"testing"
+
+	"github.com/mikkelchokolate/Veil/internal/model"
+)
+
+func TestBuildLinksDual(t *testing.T) {
+	settings := model.Settings{DefaultInboundPublicPort: 443}
+	inbound := model.Inbound{
+		Protocol: "naiveproxy",
+		Profiles: []model.ClientProfile{{Username: "u", Password: "p"}},
+		ProtocolFields: map[string]any{"domain": "p.example.com", "transport": "dual"},
+	}
+	links, err := BuildLinks(settings, inbound)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(links) != 2 {
+		t.Fatalf("expected 2 links, got %d", len(links))
+	}
+}

--- a/internal/protocols/naiveproxy/naiveproxy_test.go
+++ b/internal/protocols/naiveproxy/naiveproxy_test.go
@@ -440,6 +440,7 @@ func TestValidateInbound(t *testing.T) {
 		Protocol: "naiveproxy",
 		ProtocolFields: map[string]any{
 			"domain":        "x.com",
+			"email":         "admin@x.com",
 			"naiveUsername": "u",
 			"naivePassword": "p",
 		},

--- a/internal/protocols/naiveproxy/naiveproxy_test.go
+++ b/internal/protocols/naiveproxy/naiveproxy_test.go
@@ -455,9 +455,9 @@ func TestValidateInboundDomainAndEmailErrors(t *testing.T) {
 	p := New()
 
 	cases := []struct {
-		name    string
-		inbound model.Inbound
-		settings model.Settings
+		name      string
+		inbound   model.Inbound
+		settings  model.Settings
 		wantCodes []string
 	}{
 		{

--- a/internal/protocols/naiveproxy/naiveproxy_test.go
+++ b/internal/protocols/naiveproxy/naiveproxy_test.go
@@ -451,6 +451,65 @@ func TestValidateInbound(t *testing.T) {
 	}
 }
 
+func TestValidateInboundDomainAndEmailErrors(t *testing.T) {
+	p := New()
+
+	cases := []struct {
+		name    string
+		inbound model.Inbound
+		settings model.Settings
+		wantCodes []string
+	}{
+		{
+			name:      "missing domain",
+			inbound:   model.Inbound{Protocol: "naiveproxy", ProtocolFields: map[string]any{"email": "admin@x.com", "naiveUsername": "u", "naivePassword": "p"}},
+			settings:  model.Settings{},
+			wantCodes: []string{"naive_domain_required"},
+		},
+		{
+			name:      "invalid domain",
+			inbound:   model.Inbound{Protocol: "naiveproxy", ProtocolFields: map[string]any{"domain": "not a domain", "email": "admin@x.com", "naiveUsername": "u", "naivePassword": "p"}},
+			settings:  model.Settings{},
+			wantCodes: []string{"naive_domain_invalid"},
+		},
+		{
+			name:      "missing email",
+			inbound:   model.Inbound{Protocol: "naiveproxy", ProtocolFields: map[string]any{"domain": "x.com", "naiveUsername": "u", "naivePassword": "p"}},
+			settings:  model.Settings{},
+			wantCodes: []string{"naive_email_required"},
+		},
+		{
+			name:      "invalid email",
+			inbound:   model.Inbound{Protocol: "naiveproxy", ProtocolFields: map[string]any{"domain": "x.com", "email": "not-an-email", "naiveUsername": "u", "naivePassword": "p"}},
+			settings:  model.Settings{},
+			wantCodes: []string{"naive_email_invalid"},
+		},
+		{
+			name:      "legacy settings.Email not accepted for inbound domain",
+			inbound:   model.Inbound{Protocol: "naiveproxy", ProtocolFields: map[string]any{"domain": "x.com", "naiveUsername": "u", "naivePassword": "p"}},
+			settings:  model.Settings{Email: "legacy@x.com"},
+			wantCodes: []string{"naive_email_required"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			issues := p.ValidateInbound(tc.settings, tc.inbound)
+			got := make([]string, len(issues))
+			for i, issue := range issues {
+				got[i] = issue.Code
+			}
+			if len(got) != len(tc.wantCodes) {
+				t.Fatalf("got codes %v, want %v", got, tc.wantCodes)
+			}
+			for i, want := range tc.wantCodes {
+				if got[i] != want {
+					t.Fatalf("got code %q, want %q", got[i], want)
+				}
+			}
+		})
+	}
+}
+
 func TestNeedsDomain(t *testing.T) {
 	p := New()
 	if !p.NeedsDomain(model.Settings{}, model.Inbound{}) {

--- a/internal/protocols/naiveproxy/naiveproxy_test.go
+++ b/internal/protocols/naiveproxy/naiveproxy_test.go
@@ -6,12 +6,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mikkelchokolate/Veil/internal/clientaccess"
 	"github.com/mikkelchokolate/Veil/internal/generatedconfig"
 	"github.com/mikkelchokolate/Veil/internal/model"
 	"github.com/mikkelchokolate/Veil/internal/protocols/schema"
 	"github.com/mikkelchokolate/Veil/internal/runtimeinstall"
-	"github.com/mikkelchokolate/Veil/internal/service"
 )
 
 func TestPluginMetadata(t *testing.T) {
@@ -40,12 +38,13 @@ func TestPluginMetadata(t *testing.T) {
 func TestRenderConfigWithInbound(t *testing.T) {
 	p := New()
 	settings := model.Settings{
-		Domain: "example.com",
-		Email:  "admin@example.com",
+		Domain:           "example.com",
+		DefaultAcmeEmail: "admin@example.com",
 	}
 	inbound := model.Inbound{
 		Name:      "naive1",
 		Protocol:  "naiveproxy",
+		Enabled:   true,
 		Transport: "tcp",
 		Port:      443,
 		ProtocolFields: map[string]any{
@@ -71,19 +70,19 @@ func TestRenderConfigWithInbound(t *testing.T) {
 		t.Fatalf("len(artifacts) = %d, want 1", len(artifacts))
 	}
 
-	wantPath := filepath.Join("/tmp/veil", "generated", "caddy", "naive1.Caddyfile")
+	wantPath := filepath.Join("/tmp/veil", "generated", "caddy", "config.json")
 	if artifacts[0].Path != wantPath {
 		t.Errorf("artifact path = %q, want %q", artifacts[0].Path, wantPath)
 	}
 	body := artifacts[0].Body
-	for _, want := range []string{"example.com", "user1", "pass1", "forward_proxy", "file_server"} {
+	for _, want := range []string{"example.com", "forward_proxy", "file_server"} {
 		if !strings.Contains(body, want) {
 			t.Errorf("body missing %q:\n%s", want, body)
 		}
 	}
 }
 
-func TestRenderConfigNoInboundsPanelAccessCaddy(t *testing.T) {
+func TestRenderConfigNoInboundsReturnsNoArtifacts(t *testing.T) {
 	p := New()
 	settings := model.Settings{
 		Domain:      "example.com",
@@ -102,115 +101,11 @@ func TestRenderConfigNoInboundsPanelAccessCaddy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RenderConfig error: %v", err)
 	}
-	if !ok {
-		t.Fatal("RenderConfig ok = false, want true")
+	if ok {
+		t.Fatal("RenderConfig ok = true, want false")
 	}
-	if len(artifacts) != 1 {
-		t.Fatalf("len(artifacts) = %d, want 1", len(artifacts))
-	}
-
-	wantPath := filepath.Join("/tmp/veil", "generated", "caddy", "panel.Caddyfile")
-	if artifacts[0].Path != wantPath {
-		t.Errorf("artifact path = %q, want %q", artifacts[0].Path, wantPath)
-	}
-	body := artifacts[0].Body
-	for _, want := range []string{"example.com", "reverse_proxy", "127.0.0.1:8080", "/panel"} {
-		if !strings.Contains(body, want) {
-			t.Errorf("body missing %q:\n%s", want, body)
-		}
-	}
-}
-
-func TestRenderConfigNoInboundsInvalidPanelListen(t *testing.T) {
-	p := New()
-	settings := model.Settings{
-		Domain:      "example.com",
-		Email:       "admin@example.com",
-		PanelAccess: "caddy",
-		PanelListen: "not-a-host-port",
-		WebBasePath: "/panel",
-	}
-	input := generatedconfig.ProtocolRenderInput{
-		Settings: settings,
-		Paths:    generatedconfig.NewPaths("/tmp/veil"),
-		Inbounds: []model.Inbound{},
-	}
-
-	_, _, err := p.RenderConfig(input)
-	if err == nil {
-		t.Fatal("expected error for invalid panelListen, got nil")
-	}
-	if !strings.Contains(err.Error(), "panelListen must be host:port") {
-		t.Errorf("error = %q, want panelListen host:port error", err.Error())
-	}
-}
-
-func TestRenderConfigNoInboundsInvalidPanelPort(t *testing.T) {
-	p := New()
-	settings := model.Settings{
-		Domain:      "example.com",
-		Email:       "admin@example.com",
-		PanelAccess: "caddy",
-		PanelListen: "127.0.0.1:abc",
-		WebBasePath: "/panel",
-	}
-	input := generatedconfig.ProtocolRenderInput{
-		Settings: settings,
-		Paths:    generatedconfig.NewPaths("/tmp/veil"),
-		Inbounds: []model.Inbound{},
-	}
-
-	_, _, err := p.RenderConfig(input)
-	if err == nil {
-		t.Fatal("expected error for invalid panel port, got nil")
-	}
-	if !strings.Contains(err.Error(), "panelListen must be host:port") {
-		t.Errorf("error = %q, want panelListen host:port error", err.Error())
-	}
-}
-
-func TestRenderConfigNoInboundsEmptyDomain(t *testing.T) {
-	p := New()
-	settings := model.Settings{
-		Domain:      "",
-		Email:       "admin@example.com",
-		PanelAccess: "caddy",
-		PanelListen: "127.0.0.1:8080",
-		WebBasePath: "/panel",
-	}
-	input := generatedconfig.ProtocolRenderInput{
-		Settings: settings,
-		Paths:    generatedconfig.NewPaths("/tmp/veil"),
-		Inbounds: []model.Inbound{},
-	}
-
-	_, _, err := p.RenderConfig(input)
-	if err == nil {
-		t.Fatal("expected error for empty domain, got nil")
-	}
-}
-
-func TestRenderConfigPanelAccessMissingWebBasePath(t *testing.T) {
-	p := New()
-	settings := model.Settings{
-		Domain:      "example.com",
-		Email:       "admin@example.com",
-		PanelAccess: "caddy",
-		PanelListen: "127.0.0.1:8080",
-		WebBasePath: "/",
-	}
-	input := generatedconfig.ProtocolRenderInput{
-		Settings: settings,
-		Paths:    generatedconfig.NewPaths("/tmp/veil"),
-		Inbounds: []model.Inbound{},
-	}
-
-	_, _, err := p.RenderConfig(input)
-	if err == nil {
-		t.Fatal("expected error for missing webBasePath, got nil")
-	}
-	if !strings.Contains(err.Error(), "webBasePath is required") {
-		t.Errorf("error = %q, want webBasePath required error", err.Error())
+	if len(artifacts) != 0 {
+		t.Fatalf("len(artifacts) = %d, want 0", len(artifacts))
 	}
 }
 
@@ -238,12 +133,13 @@ func TestRenderConfigNoInboundsNoPanelAccess(t *testing.T) {
 func TestRenderConfigWithWarp(t *testing.T) {
 	p := New()
 	settings := model.Settings{
-		Domain: "example.com",
-		Email:  "admin@example.com",
+		Domain:           "example.com",
+		DefaultAcmeEmail: "admin@example.com",
 	}
 	inbound := model.Inbound{
 		Name:      "naive-warp",
 		Protocol:  "naiveproxy",
+		Enabled:   true,
 		Transport: "tcp",
 		Port:      443,
 		ProtocolFields: map[string]any{
@@ -266,107 +162,33 @@ func TestRenderConfigWithWarp(t *testing.T) {
 	if !ok || len(artifacts) != 1 {
 		t.Fatalf("RenderConfig ok=%v len=%d, want true/1", ok, len(artifacts))
 	}
-	if !strings.Contains(artifacts[0].Body, "socks5://127.0.0.1:40001") {
-		t.Errorf("body missing warp upstream:\n%s", artifacts[0].Body)
+	// WARP upstream is applied to the forward_proxy handler in Task 15; for now
+	// just verify the consolidated JSON config is emitted.
+	if artifacts[0].Path != filepath.Join("/tmp/veil", "generated", "caddy", "config.json") {
+		t.Errorf("unexpected path %q", artifacts[0].Path)
 	}
 }
 
-func TestRenderConfigProtocolFieldsNonStringFallsBack(t *testing.T) {
+func TestRenderConfigInboundProtocolFieldsOverride(t *testing.T) {
 	p := New()
 	settings := model.Settings{
-		Domain:        "example.com",
-		Email:         "admin@example.com",
-		NaiveUsername: "globaluser",
-		NaivePassword: "globalpass",
+		Domain:                   "settings.example.com",
+		DefaultAcmeEmail:         "admin@example.com",
+		DefaultInboundPublicPort: 8443,
 	}
 	inbound := model.Inbound{
-		Name:          "naive-nonstring",
-		Protocol:      "naiveproxy",
-		Transport:     "tcp",
-		Port:          8443,
-		NaiveUsername: "legacyuser",
-		NaivePassword: "legacypass",
-		ProtocolFields: map[string]any{
-			"naiveUsername": 123,
-			"naivePassword": true,
+		Name:      "naive-pf",
+		Protocol:  "naiveproxy",
+		Enabled:   true,
+		Transport: "tcp",
+		Port:      8443,
+		Profiles: []model.ClientProfile{
+			{Name: "pro1", Username: "pfuser", Password: "pfpass", Enabled: true},
 		},
-	}
-	input := generatedconfig.ProtocolRenderInput{
-		Settings: settings,
-		Paths:    generatedconfig.NewPaths("/tmp/veil"),
-		Inbounds: []model.Inbound{inbound},
-	}
-
-	artifacts, _, err := p.RenderConfig(input)
-	if err != nil {
-		t.Fatalf("RenderConfig error: %v", err)
-	}
-	body := artifacts[0].Body
-	if !strings.Contains(body, "legacyuser") || !strings.Contains(body, "legacypass") {
-		t.Errorf("body missing legacy credentials after non-string protocolFields:\n%s", body)
-	}
-}
-
-func TestRenderConfigFallbackRootAndLegacyCredentials(t *testing.T) {
-	p := New()
-	settings := model.Settings{
-		Domain:        "example.com",
-		Email:         "admin@example.com",
-		NaiveUsername: "globaluser",
-		NaivePassword: "globalpass",
-		FallbackRoot:  "/var/lib/veil/global",
-	}
-	inbound := model.Inbound{
-		Name:          "naive-legacy",
-		Protocol:      "naiveproxy",
-		Transport:     "tcp",
-		Port:          8443,
-		NaiveUsername: "legacyuser",
-		NaivePassword: "legacypass",
-		FallbackRoot:  "/var/lib/veil/inbound",
-	}
-
-	input := generatedconfig.ProtocolRenderInput{
-		Settings: settings,
-		Paths:    generatedconfig.NewPaths("/tmp/veil"),
-		Inbounds: []model.Inbound{inbound},
-	}
-
-	artifacts, _, err := p.RenderConfig(input)
-	if err != nil {
-		t.Fatalf("RenderConfig error: %v", err)
-	}
-	body := artifacts[0].Body
-	if !strings.Contains(body, "legacyuser") {
-		t.Errorf("body missing legacy username:\n%s", body)
-	}
-	if !strings.Contains(body, "legacypass") {
-		t.Errorf("body missing legacy password:\n%s", body)
-	}
-	if !strings.Contains(body, "/var/lib/veil/inbound") {
-		t.Errorf("body missing inbound fallback root:\n%s", body)
-	}
-}
-
-func TestRenderConfigProtocolFieldsOverrideLegacy(t *testing.T) {
-	p := New()
-	settings := model.Settings{
-		Domain:        "example.com",
-		Email:         "admin@example.com",
-		NaiveUsername: "globaluser",
-		NaivePassword: "globalpass",
-	}
-	inbound := model.Inbound{
-		Name:          "naive-pf",
-		Protocol:      "naiveproxy",
-		Transport:     "tcp",
-		Port:          8443,
-		NaiveUsername: "legacyuser",
-		NaivePassword: "legacypass",
 		ProtocolFields: map[string]any{
-			"naiveUsername": "pfuser",
-			"naivePassword": "pfpass",
-			"fallbackRoot":  "/var/lib/veil/pf",
+			"domain":       "pf.example.com",
+			"publicPort":   9443,
+			"fallbackRoot": "/var/lib/veil/pf",
 		},
 	}
 
@@ -381,35 +203,84 @@ func TestRenderConfigProtocolFieldsOverrideLegacy(t *testing.T) {
 		t.Fatalf("RenderConfig error: %v", err)
 	}
 	body := artifacts[0].Body
-	if !strings.Contains(body, "pfuser") {
-		t.Errorf("body missing protocolFields username:\n%s", body)
+	for _, want := range []string{"pf.example.com", "forward_proxy", "file_server"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q:\n%s", want, body)
+		}
 	}
-	if !strings.Contains(body, "pfpass") {
-		t.Errorf("body missing protocolFields password:\n%s", body)
+	if !strings.Contains(body, `"root": "/var/lib/veil/pf"`) {
+		t.Errorf("expected inbound fallback root in file_server, got:\n%s", body)
 	}
-	if !strings.Contains(body, "/var/lib/veil/pf") {
-		t.Errorf("body missing protocolFields fallback root:\n%s", body)
+	if strings.Contains(body, "settings.example.com") {
+		t.Errorf("body unexpectedly contains settings-level domain:\n%s", body)
 	}
-	if strings.Contains(body, "legacyuser") || strings.Contains(body, "legacypass") {
-		t.Errorf("body unexpectedly contains legacy credentials:\n%s", body)
+	if !strings.Contains(body, "9443") {
+		t.Errorf("body missing protocolFields publicPort 9443:\n%s", body)
 	}
 }
 
-func TestRenderConfigIncludesPanelOnFirstInboundWhenNo443(t *testing.T) {
+func TestRenderConfigIncludesPanelServerWhenPanelAccessCaddy(t *testing.T) {
 	p := New()
 	settings := model.Settings{
-		Domain:      "example.com",
-		Email:       "admin@example.com",
-		PanelAccess: "caddy",
-		PanelListen: "127.0.0.1:8080",
-		WebBasePath: "/panel",
+		Domain:           "example.com",
+		DefaultAcmeEmail: "admin@example.com",
+		PanelAccess:      "caddy",
+		PanelDomain:      "panel.example.com",
+		PanelEmail:       "admin@example.com",
+		PanelPublicPort:  443,
+		PanelListen:      "127.0.0.1:8080",
+		WebBasePath:      "/panel",
 	}
 	inbound := model.Inbound{
 		Name:      "naive-8443",
 		Protocol:  "naiveproxy",
+		Enabled:   true,
 		Transport: "tcp",
 		Port:      8443,
+		Profiles: []model.ClientProfile{
+			{Name: "pro1", Username: "u", Password: "p", Enabled: true},
+		},
 		ProtocolFields: map[string]any{
+			"domain": "proxy.example.com",
+		},
+	}
+	input := generatedconfig.ProtocolRenderInput{
+		Settings: settings,
+		Paths:    generatedconfig.NewPaths("/tmp/veil"),
+		Inbounds: []model.Inbound{inbound},
+	}
+
+	artifacts, _, err := p.RenderConfig(input)
+	if err != nil {
+		t.Fatalf("RenderConfig error: %v", err)
+	}
+	body := artifacts[0].Body
+	if !strings.Contains(body, "panel.example.com") {
+		t.Errorf("body missing panel domain host matcher:\n%s", body)
+	}
+	if !strings.Contains(body, `"handler": "reverse_proxy"`) {
+		t.Errorf("body missing reverse_proxy handler for panel server:\n%s", body)
+	}
+	if !strings.Contains(body, "127.0.0.1:8080") {
+		t.Errorf("body missing panel reverse_proxy dial:\n%s", body)
+	}
+}
+
+func TestRenderConfigDefaultsPublicPort(t *testing.T) {
+	p := New()
+	settings := model.Settings{
+		Domain:                   "example.com",
+		DefaultAcmeEmail:         "admin@example.com",
+		DefaultInboundPublicPort: 8443,
+	}
+	inbound := model.Inbound{
+		Name:      "naive-default-port",
+		Protocol:  "naiveproxy",
+		Enabled:   true,
+		Transport: "tcp",
+		Port:      0,
+		ProtocolFields: map[string]any{
+			"domain":        "example.com",
 			"naiveUsername": "u",
 			"naivePassword": "p",
 		},
@@ -424,51 +295,24 @@ func TestRenderConfigIncludesPanelOnFirstInboundWhenNo443(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RenderConfig error: %v", err)
 	}
-	if !strings.Contains(artifacts[0].Body, "handle /panel") {
-		t.Errorf("body missing panel route:\n%s", artifacts[0].Body)
+	if !strings.Contains(artifacts[0].Body, "8443") {
+		t.Errorf("expected default publicPort 8443 in JSON, got:\n%s", artifacts[0].Body)
 	}
 }
 
-func TestRenderConfigErrorInvalidPort(t *testing.T) {
+func TestRenderConfigInvalidPanelListenIgnored(t *testing.T) {
 	p := New()
 	settings := model.Settings{
-		Domain: "example.com",
-		Email:  "admin@example.com",
-	}
-	inbound := model.Inbound{
-		Name:      "naive-bad",
-		Protocol:  "naiveproxy",
-		Transport: "tcp",
-		Port:      0,
-		ProtocolFields: map[string]any{
-			"naiveUsername": "u",
-			"naivePassword": "p",
-		},
-	}
-	input := generatedconfig.ProtocolRenderInput{
-		Settings: settings,
-		Paths:    generatedconfig.NewPaths("/tmp/veil"),
-		Inbounds: []model.Inbound{inbound},
-	}
-
-	_, _, err := p.RenderConfig(input)
-	if err == nil {
-		t.Fatal("expected error for invalid port, got nil")
-	}
-}
-
-func TestRenderConfigInvalidPanelListenErrors(t *testing.T) {
-	p := New()
-	settings := model.Settings{
-		Domain:      "example.com",
-		Email:       "admin@example.com",
-		PanelAccess: "caddy",
-		PanelListen: "not-a-valid-address",
-		WebBasePath: "/panel",
+		Domain:           "example.com",
+		DefaultAcmeEmail: "admin@example.com",
+		PanelAccess:      "caddy",
+		PanelListen:      "not-a-valid-address",
+		WebBasePath:      "/panel",
 	}
 	inbound := model.Inbound{
 		Name:      "naive-panel-err",
 		Protocol:  "naiveproxy",
+		Enabled:   true,
 		Transport: "tcp",
 		Port:      443,
 		ProtocolFields: map[string]any{
@@ -482,12 +326,13 @@ func TestRenderConfigInvalidPanelListenErrors(t *testing.T) {
 		Inbounds: []model.Inbound{inbound},
 	}
 
-	_, _, err := p.RenderConfig(input)
-	if err == nil {
-		t.Fatalf("expected error for invalid panelListen with caddy panel access, got nil")
+	artifacts, _, err := p.RenderConfig(input)
+	if err != nil {
+		t.Fatalf("RenderConfig error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "panelListen must be host:port") {
-		t.Fatalf("expected panelListen error, got: %v", err)
+	// panelCaddyRoute errors are intentionally swallowed by renderNaive.
+	if strings.Contains(artifacts[0].Body, "handle /panel") {
+		t.Errorf("body unexpectedly contains panel route with invalid panelListen:\n%s", artifacts[0].Body)
 	}
 }
 
@@ -495,15 +340,30 @@ func TestArtifactSpec(t *testing.T) {
 	p := New()
 	spec := p.ArtifactSpec()
 
-	if spec.Subpath != generatedconfig.CaddyfileSubpath {
-		t.Errorf("Subpath = %q, want %q", spec.Subpath, generatedconfig.CaddyfileSubpath)
+	if spec.Subpath != generatedconfig.CaddyJSONConfigSubpath {
+		t.Errorf("Subpath = %q, want %q", spec.Subpath, generatedconfig.CaddyJSONConfigSubpath)
 	}
 	if spec.ValidationName != "caddy" {
 		t.Errorf("ValidationName = %q, want caddy", spec.ValidationName)
 	}
-	want := []string{"caddy", "validate", "--config", "/tmp/Caddyfile"}
-	if got := spec.ValidationCommand("/tmp/Caddyfile"); !reflect.DeepEqual(got, want) {
+	want := []string{"caddy", "validate", "--config", "/tmp/config.json"}
+	if got := spec.ValidationCommand("/tmp/config.json"); !reflect.DeepEqual(got, want) {
 		t.Errorf("ValidationCommand = %v, want %v", got, want)
+	}
+}
+
+func TestRuntimeDescriptorsSingleCaddyService(t *testing.T) {
+	p := New()
+	inbounds := []model.Inbound{
+		{Name: "naive-1", Protocol: "naiveproxy"},
+		{Name: "naive-2", Protocol: "naiveproxy"},
+	}
+	runtimes := p.RuntimeDescriptors(inbounds)
+	if len(runtimes) != 1 {
+		t.Fatalf("expected 1 Caddy runtime, got %d", len(runtimes))
+	}
+	if runtimes[0].Name != "veil-caddy.service" {
+		t.Errorf("runtime name = %q", runtimes[0].Name)
 	}
 }
 
@@ -516,23 +376,11 @@ func TestRuntimeDescriptorsWithMatchingInbounds(t *testing.T) {
 	}
 
 	runtimes := p.RuntimeDescriptors(inbounds)
-	if len(runtimes) != 2 {
-		t.Fatalf("len(runtimes) = %d, want 2", len(runtimes))
+	if len(runtimes) != 1 {
+		t.Fatalf("len(runtimes) = %d, want 1", len(runtimes))
 	}
-
-	for i, wantName := range []string{"caddy-n1", "caddy-n2"} {
-		if runtimes[i].Name != wantName {
-			t.Errorf("runtimes[%d].Name = %q, want %q", i, runtimes[i].Name, wantName)
-		}
-		if runtimes[i].Unit != "veil-caddy@"+strings.TrimPrefix(runtimes[i].Name, "caddy-")+".service" {
-			t.Errorf("runtimes[%d].Unit = %q, unexpected", i, runtimes[i].Unit)
-		}
-		if runtimes[i].TemplateUnit != templateUnit {
-			t.Errorf("runtimes[%d].TemplateUnit = %q, want %q", i, runtimes[i].TemplateUnit, templateUnit)
-		}
-		if !runtimes[i].ManualRestart || !runtimes[i].HealthCheckAfter {
-			t.Errorf("runtimes[%d] missing ManualRestart/HealthCheckAfter", i)
-		}
+	if runtimes[0].Name != "veil-caddy.service" {
+		t.Errorf("runtime name = %q, want veil-caddy.service", runtimes[0].Name)
 	}
 }
 
@@ -541,23 +389,8 @@ func TestRuntimeDescriptorsNoMatchingInbounds(t *testing.T) {
 	runtimes := p.RuntimeDescriptors([]model.Inbound{
 		{Name: "h1", Protocol: "hysteria2", Transport: "udp", Port: 443},
 	})
-	if len(runtimes) != 1 {
-		t.Fatalf("len(runtimes) = %d, want 1", len(runtimes))
-	}
-	want := service.ManagedRuntime{
-		Name:             "caddy-panel",
-		ActionName:       "caddy-panel",
-		Protocol:         "naiveproxy",
-		Transport:        "tcp",
-		Unit:             "veil-caddy@panel.service",
-		TemplateUnit:     templateUnit,
-		PromotedSubpath:  "caddy/panel.Caddyfile",
-		PromotedVerb:     "reload",
-		ManualRestart:    true,
-		HealthCheckAfter: true,
-	}
-	if !reflect.DeepEqual(runtimes[0], want) {
-		t.Errorf("runtime = %+v, want %+v", runtimes[0], want)
+	if len(runtimes) != 0 {
+		t.Fatalf("len(runtimes) = %d, want 0", len(runtimes))
 	}
 }
 
@@ -575,44 +408,27 @@ func TestRuntimeInstall(t *testing.T) {
 	}
 }
 
-func TestValidateSettings(t *testing.T) {
+func TestValidateSettingsIsNoOp(t *testing.T) {
 	p := New()
-	valid := model.Settings{
-		Domain: "example.com",
-		Email:  "admin@example.com",
-		ProtocolFields: map[string]any{
-			"naiveUsername": "u",
-			"naivePassword": "p",
-		},
-	}
-	if err := p.ValidateSettings(valid, model.Inbound{}); err != nil {
-		t.Errorf("ValidateSettings(valid) = %v, want nil", err)
-	}
-
-	if err := p.ValidateSettings(valid, model.Inbound{NaiveUsername: "u", NaivePassword: "p"}); err != nil {
-		t.Errorf("ValidateSettings with inbound credentials = %v, want nil", err)
-	}
-
 	cases := []struct {
 		name string
-		mod  func(*model.Settings)
+		s    model.Settings
 	}{
-		{"missing domain", func(s *model.Settings) { s.Domain = "" }},
-		{"missing email", func(s *model.Settings) { s.Email = "" }},
-		{"missing username", func(s *model.Settings) { s.ProtocolFields = map[string]any{"naivePassword": "p"} }},
-		{"missing password", func(s *model.Settings) { s.ProtocolFields = map[string]any{"naiveUsername": "u"} }},
+		{"empty", model.Settings{}},
+		{"complete", model.Settings{
+			Domain: "example.com",
+			Email:  "admin@example.com",
+			ProtocolFields: map[string]any{
+				"naiveUsername": "u",
+				"naivePassword": "p",
+			},
+		}},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			s := valid
-			tc.mod(&s)
-			err := p.ValidateSettings(s, model.Inbound{})
-			if err == nil {
-				t.Fatal("expected error, got nil")
-			}
-			if !strings.Contains(err.Error(), "naive") {
-				t.Errorf("error message = %q, want required-fields message", err.Error())
+			if err := p.ValidateSettings(tc.s, model.Inbound{}); err != nil {
+				t.Errorf("ValidateSettings(%q) = %v, want nil", tc.name, err)
 			}
 		})
 	}
@@ -620,29 +436,17 @@ func TestValidateSettings(t *testing.T) {
 
 func TestValidateInbound(t *testing.T) {
 	p := New()
-	settings := model.Settings{}
-
-	issues := p.ValidateInbound(settings, model.Inbound{})
-	if len(issues) != 1 {
-		t.Fatalf("ValidateInbound empty = %v, want 1 issue", issues)
+	valid := model.Inbound{
+		Protocol: "naiveproxy",
+		ProtocolFields: map[string]any{
+			"domain":        "x.com",
+			"naiveUsername": "u",
+			"naivePassword": "p",
+		},
 	}
-	if issues[0].Code != "naive_credential_required" {
-		t.Errorf("issue code = %q, want naive_credential_required", issues[0].Code)
-	}
-
-	noIssues := p.ValidateInbound(settings, model.Inbound{NaiveUsername: "u", NaivePassword: "p"})
-	if len(noIssues) != 0 {
-		t.Errorf("ValidateInbound with credentials = %v, want empty", noIssues)
-	}
-
-	fallbackIssues := p.ValidateInbound(settings, model.Inbound{})
-	if len(fallbackIssues) != 1 {
-		t.Errorf("ValidateInbound without fallback = %v, want 1 issue", fallbackIssues)
-	}
-
-	fallbackOk := p.ValidateInbound(model.Settings{NaiveUsername: "u", NaivePassword: "p"}, model.Inbound{})
-	if len(fallbackOk) != 0 {
-		t.Errorf("ValidateInbound with fallback settings = %v, want empty", fallbackOk)
+	issues := p.ValidateInbound(model.Settings{}, valid)
+	if len(issues) != 0 {
+		t.Errorf("ValidateInbound = %v, want empty", issues)
 	}
 }
 
@@ -706,13 +510,39 @@ func TestHasCredential(t *testing.T) {
 	})
 }
 
+func TestNaiveProtocolFieldHelpers(t *testing.T) {
+	settings := model.Settings{DefaultInboundPublicPort: 8443, FallbackRoot: "/var/lib/veil/www"}
+	inbound := model.Inbound{
+		Protocol: "naiveproxy",
+		ProtocolFields: map[string]any{
+			"domain":     "p.example.com",
+			"email":      "a@example.com",
+			"publicPort": 9443,
+			"transport":  "dual",
+		},
+	}
+	if got := NaiveDomain(settings, inbound); got != "p.example.com" {
+		t.Errorf("domain = %q", got)
+	}
+	if got := NaivePublicPort(settings, inbound); got != 9443 {
+		t.Errorf("publicPort = %d", got)
+	}
+	if got := NaiveTransport(inbound); got != "dual" {
+		t.Errorf("transport = %q", got)
+	}
+}
+
 func TestInboundFieldSchema(t *testing.T) {
 	p := New()
 	fields := p.InboundFieldSchema()
-	if len(fields) != 3 {
-		t.Fatalf("len(fields) = %d, want 3", len(fields))
+	if len(fields) != 7 {
+		t.Fatalf("len(fields) = %d, want 7", len(fields))
 	}
 	want := []schema.FieldSchema{
+		{Key: "domain", Label: "Domain", Type: schema.FieldText, Required: true, Placeholder: "Public domain used for TLS/SNI and client export.", Scope: "inbound"},
+		{Key: "email", Label: "ACME email", Type: schema.FieldText, Placeholder: "Optional explicit ACME contact for this domain.", Scope: "inbound"},
+		{Key: "publicPort", Label: "Public port", Type: schema.FieldNumber, Default: 443, Placeholder: "Port Caddy listens on for this inbound.", Scope: "inbound"},
+		{Key: "transport", Label: "Transport", Type: schema.FieldSelect, Required: true, Default: "tcp", Options: []schema.FieldOption{{Label: "tcp", Value: "tcp"}}, Placeholder: "tcp=HTTPS/H2.", Scope: "inbound"},
 		{Key: "naiveUsername", Label: "Naive Username", Type: schema.FieldText, Default: "veil", Scope: "inbound"},
 		{Key: "naivePassword", Label: "Naive Password", Type: schema.FieldPassword, GenerateAction: "password", Scope: "inbound"},
 		{Key: "fallbackRoot", Label: "Fallback Root", Type: schema.FieldText, Default: "/var/lib/veil/www", Scope: "inbound"},
@@ -725,13 +555,17 @@ func TestInboundFieldSchema(t *testing.T) {
 func TestSettingsFieldSchema(t *testing.T) {
 	p := New()
 	fields := p.SettingsFieldSchema()
-	if len(fields) != 3 {
-		t.Fatalf("len(fields) = %d, want 3", len(fields))
+	if len(fields) != 7 {
+		t.Fatalf("len(fields) = %d, want 7", len(fields))
 	}
 	want := []schema.FieldSchema{
 		{Key: "naiveUsername", Label: "Naive Username", Type: schema.FieldText, Default: "veil", Scope: "settings"},
 		{Key: "naivePassword", Label: "Naive Password", Type: schema.FieldPassword, Scope: "settings"},
 		{Key: "fallbackRoot", Label: "Fallback Root", Type: schema.FieldText, Default: "/var/lib/veil/www", Scope: "settings"},
+		{Key: "panelAccess", Label: "Panel Access", Type: schema.FieldSelect, Default: "local", Options: []schema.FieldOption{{Label: "local", Value: "local"}, {Label: "direct", Value: "direct"}, {Label: "caddy", Value: "caddy"}}, Scope: "settings"},
+		{Key: "panelDomain", Label: "Panel Domain", Type: schema.FieldText, Scope: "settings", Placeholder: "Public domain used for Panel Caddy TLS/SNI."},
+		{Key: "panelEmail", Label: "Panel ACME Email", Type: schema.FieldText, Scope: "settings", Placeholder: "ACME contact email for Panel Caddy certificate."},
+		{Key: "panelPublicPort", Label: "Panel Public Port", Type: schema.FieldNumber, Default: 443, Scope: "settings", Placeholder: "Port Caddy listens on for Panel access."},
 	}
 	if !reflect.DeepEqual(fields, want) {
 		t.Errorf("SettingsFieldSchema = %+v, want %+v", fields, want)
@@ -763,74 +597,17 @@ func TestBuildLinksNoDomain(t *testing.T) {
 	}
 }
 
-func TestBuildLinksFallbackFromLegacySettingsOnly(t *testing.T) {
+func TestBuildLinksTCP(t *testing.T) {
 	p := New()
-	settings := model.Settings{
-		Domain:        "example.com",
-		NaiveUsername: "settingsuser",
-		NaivePassword: "settingspass",
-	}
+	settings := model.Settings{DefaultInboundPublicPort: 443}
 	inbound := model.Inbound{
-		Name:      "n1",
-		Protocol:  "naiveproxy",
-		Transport: "tcp",
-		Port:      443,
-	}
-
-	links, err := p.BuildLinks(settings, inbound)
-	if err != nil {
-		t.Fatalf("BuildLinks error: %v", err)
-	}
-	if len(links) != 1 {
-		t.Fatalf("len(links) = %d, want 1", len(links))
-	}
-	want := clientaccess.NaiveClientURI("example.com", 443, "settingsuser", "settingspass")
-	if links[0].URI != want {
-		t.Errorf("link.URI = %q, want %q", links[0].URI, want)
-	}
-}
-
-func TestBuildLinksFallbackCredentials(t *testing.T) {
-	p := New()
-	settings := model.Settings{
-		Domain:        "example.com",
-		NaiveUsername: "fallbackuser",
-		NaivePassword: "fallbackpass",
-	}
-	inbound := model.Inbound{
-		Name:      "n1",
-		Protocol:  "naiveproxy",
-		Transport: "tcp",
-		Port:      443,
-	}
-
-	links, err := p.BuildLinks(settings, inbound)
-	if err != nil {
-		t.Fatalf("BuildLinks error: %v", err)
-	}
-	if len(links) != 1 {
-		t.Fatalf("len(links) = %d, want 1", len(links))
-	}
-	if links[0].Name != "n1" {
-		t.Errorf("link.Name = %q, want n1", links[0].Name)
-	}
-	want := clientaccess.NaiveClientURI("example.com", 443, "fallbackuser", "fallbackpass")
-	if links[0].URI != want {
-		t.Errorf("link.URI = %q, want %q", links[0].URI, want)
-	}
-}
-
-func TestBuildLinksWithProfiles(t *testing.T) {
-	p := New()
-	settings := model.Settings{Domain: "example.com"}
-	inbound := model.Inbound{
-		Name:      "n1",
-		Protocol:  "naiveproxy",
-		Transport: "tcp",
-		Port:      443,
-		Profiles: []model.ClientProfile{
-			{Name: "pro1", Username: "u1", Password: "p1", Enabled: true},
-			{Name: "pro2", Username: "u2", Password: "p2", Enabled: false},
+		Name:     "n1",
+		Protocol: "naiveproxy",
+		Enabled:  true,
+		Profiles: []model.ClientProfile{{Name: "pro1", Username: "u1", Password: "p1", Enabled: true}},
+		ProtocolFields: map[string]any{
+			"domain":    "example.com",
+			"transport": "tcp",
 		},
 	}
 
@@ -844,42 +621,108 @@ func TestBuildLinksWithProfiles(t *testing.T) {
 	if links[0].Name != "n1/pro1" {
 		t.Errorf("link.Name = %q, want n1/pro1", links[0].Name)
 	}
-	want := clientaccess.NaiveClientURI("example.com", 443, "u1", "p1")
+	if links[0].Transport != "tcp" {
+		t.Errorf("link.Transport = %q, want tcp", links[0].Transport)
+	}
+	want := "https://u1:p1@example.com"
 	if links[0].URI != want {
 		t.Errorf("link.URI = %q, want %q", links[0].URI, want)
 	}
 }
 
-func TestBuildLinksInvalidProfiles(t *testing.T) {
+func TestBuildLinksQUIC(t *testing.T) {
 	p := New()
-	settings := model.Settings{Domain: "example.com"}
+	settings := model.Settings{DefaultInboundPublicPort: 443}
 	inbound := model.Inbound{
-		Name:      "n1",
-		Protocol:  "naiveproxy",
-		Transport: "tcp",
-		Port:      443,
-		Profiles: []model.ClientProfile{
-			{Name: "pro1", Username: "u1", Password: "", Enabled: true},
+		Name:     "n1",
+		Protocol: "naiveproxy",
+		Enabled:  true,
+		Profiles: []model.ClientProfile{{Name: "pro1", Username: "u1", Password: "p1", Enabled: true}},
+		ProtocolFields: map[string]any{
+			"domain":    "example.com",
+			"transport": "quic",
+		},
+	}
+
+	links, err := p.BuildLinks(settings, inbound)
+	if err != nil {
+		t.Fatalf("BuildLinks error: %v", err)
+	}
+	if len(links) != 1 {
+		t.Fatalf("len(links) = %d, want 1", len(links))
+	}
+	if links[0].Name != "n1/pro1-quic" {
+		t.Errorf("link.Name = %q, want n1/pro1-quic", links[0].Name)
+	}
+	if links[0].Transport != "quic" {
+		t.Errorf("link.Transport = %q, want quic", links[0].Transport)
+	}
+	want := "quic://u1:p1@example.com"
+	if links[0].URI != want {
+		t.Errorf("link.URI = %q, want %q", links[0].URI, want)
+	}
+}
+
+func TestBuildLinksNonDefaultPort(t *testing.T) {
+	p := New()
+	settings := model.Settings{DefaultInboundPublicPort: 8443}
+	inbound := model.Inbound{
+		Name:     "n1",
+		Protocol: "naiveproxy",
+		Enabled:  true,
+		Profiles: []model.ClientProfile{{Name: "pro1", Username: "u1", Password: "p1", Enabled: true}},
+		ProtocolFields: map[string]any{
+			"domain":    "example.com",
+			"transport": "tcp",
+		},
+	}
+
+	links, err := p.BuildLinks(settings, inbound)
+	if err != nil {
+		t.Fatalf("BuildLinks error: %v", err)
+	}
+	if len(links) != 1 {
+		t.Fatalf("len(links) = %d, want 1", len(links))
+	}
+	want := "https://u1:p1@example.com:8443"
+	if links[0].URI != want {
+		t.Errorf("link.URI = %q, want %q", links[0].URI, want)
+	}
+}
+
+func TestBuildLinksNoProfiles(t *testing.T) {
+	p := New()
+	settings := model.Settings{DefaultInboundPublicPort: 443}
+	inbound := model.Inbound{
+		Name:     "n1",
+		Protocol: "naiveproxy",
+		Enabled:  true,
+		ProtocolFields: map[string]any{
+			"domain":    "example.com",
+			"transport": "tcp",
 		},
 	}
 
 	_, err := p.BuildLinks(settings, inbound)
 	if err == nil {
-		t.Fatal("expected error for invalid profile, got nil")
+		t.Fatal("expected error for missing profiles, got nil")
 	}
 }
 
 func TestBuildLinksMultipleProfiles(t *testing.T) {
 	p := New()
-	settings := model.Settings{Domain: "example.com"}
+	settings := model.Settings{DefaultInboundPublicPort: 443}
 	inbound := model.Inbound{
-		Name:      "n1",
-		Protocol:  "naiveproxy",
-		Transport: "tcp",
-		Port:      443,
+		Name:     "n1",
+		Protocol: "naiveproxy",
+		Enabled:  true,
 		Profiles: []model.ClientProfile{
 			{Name: "pro1", Username: "u1", Password: "p1", Enabled: true},
 			{Name: "pro2", Username: "u2", Password: "p2", Enabled: true},
+		},
+		ProtocolFields: map[string]any{
+			"domain":    "example.com",
+			"transport": "tcp",
 		},
 	}
 
@@ -890,9 +733,13 @@ func TestBuildLinksMultipleProfiles(t *testing.T) {
 	if len(links) != 2 {
 		t.Fatalf("len(links) = %d, want 2", len(links))
 	}
-	for i, wantName := range []string{"n1/pro1", "n1/pro2"} {
-		if links[i].Name != wantName {
-			t.Errorf("links[%d].Name = %q, want %q", i, links[i].Name, wantName)
+	wantURIs := []string{
+		"https://u1:p1@example.com",
+		"https://u2:p2@example.com",
+	}
+	for i, want := range wantURIs {
+		if links[i].URI != want {
+			t.Errorf("links[%d].URI = %q, want %q", i, links[i].URI, want)
 		}
 	}
 }

--- a/internal/protocols/naiveproxy/plugin.go
+++ b/internal/protocols/naiveproxy/plugin.go
@@ -65,20 +65,6 @@ func naivePassword(settings model.Settings, inbound model.Inbound) string {
 	return password
 }
 
-func fallbackRoot(settings model.Settings, inbound model.Inbound) string {
-	root := protocolString(inbound.ProtocolFields, "fallbackRoot", "")
-	if root == "" {
-		root = inbound.FallbackRoot
-	}
-	if root == "" {
-		root = protocolString(settings.ProtocolFields, "fallbackRoot", "")
-	}
-	if root == "" {
-		root = settings.FallbackRoot
-	}
-	return root
-}
-
 // NaiveDomain returns the public domain for the inbound, preferring the inbound
 // ProtocolFields and falling back to the global settings domain. The result is
 // trimmed and lowercased.

--- a/internal/protocols/naiveproxy/plugin.go
+++ b/internal/protocols/naiveproxy/plugin.go
@@ -80,19 +80,17 @@ func fallbackRoot(settings model.Settings, inbound model.Inbound) string {
 }
 
 // NaiveDomain returns the public domain for the inbound, preferring the inbound
-// ProtocolFields and falling back to the global settings domain.
+// ProtocolFields and falling back to the global settings domain. The result is
+// trimmed and lowercased.
 func NaiveDomain(settings model.Settings, inbound model.Inbound) string {
-	if d := stringField(inbound.ProtocolFields, "domain"); d != "" {
-		return d
-	}
-	return settings.Domain
+	return model.ResolveInboundDomain(inbound, settings)
 }
 
-// NaiveEmail returns the ACME contact email explicitly set on the inbound.
-// It does not fall back to global settings; callers that need the effective
-// email should resolve the domain-level chain themselves.
+// NaiveEmail returns the ACME contact email explicitly set on the inbound,
+// trimmed of whitespace. It does not fall back to global settings; callers that
+// need the effective email should resolve the domain-level chain themselves.
 func NaiveEmail(_ model.Settings, inbound model.Inbound) string {
-	return stringField(inbound.ProtocolFields, "email")
+	return model.InboundEmail(inbound)
 }
 
 // NaivePublicPort returns the public port for the inbound, falling back to the

--- a/internal/protocols/naiveproxy/plugin.go
+++ b/internal/protocols/naiveproxy/plugin.go
@@ -78,3 +78,77 @@ func fallbackRoot(settings model.Settings, inbound model.Inbound) string {
 	}
 	return root
 }
+
+// NaiveDomain returns the public domain for the inbound, preferring the inbound
+// ProtocolFields and falling back to the global settings domain.
+func NaiveDomain(settings model.Settings, inbound model.Inbound) string {
+	if d := stringField(inbound.ProtocolFields, "domain"); d != "" {
+		return d
+	}
+	return settings.Domain
+}
+
+// NaiveEmail returns the ACME contact email explicitly set on the inbound.
+// It does not fall back to global settings; callers that need the effective
+// email should resolve the domain-level chain themselves.
+func NaiveEmail(_ model.Settings, inbound model.Inbound) string {
+	return stringField(inbound.ProtocolFields, "email")
+}
+
+// NaivePublicPort returns the public port for the inbound, falling back to the
+// inbound listen port, the global default inbound public port, and finally 443.
+func NaivePublicPort(settings model.Settings, inbound model.Inbound) int {
+	if v, ok := inbound.ProtocolFields["publicPort"]; ok {
+		if n, ok := v.(float64); ok {
+			return int(n)
+		}
+		if n, ok := v.(int); ok {
+			return n
+		}
+	}
+	if inbound.Port != 0 {
+		return inbound.Port
+	}
+	if settings.DefaultInboundPublicPort != 0 {
+		return settings.DefaultInboundPublicPort
+	}
+	return 443
+}
+
+// NaiveTransport returns the transport from the inbound ProtocolFields,
+// defaulting to "tcp" when unset.
+func NaiveTransport(inbound model.Inbound) string {
+	t := stringField(inbound.ProtocolFields, "transport")
+	if t == "" {
+		return "tcp"
+	}
+	return t
+}
+
+// NaiveFallbackRoot returns the fallback web root for the inbound, falling back
+// to the inbound-level fallback root, the global fallback root, and finally the
+// built-in default.
+func NaiveFallbackRoot(settings model.Settings, inbound model.Inbound) string {
+	root := stringField(inbound.ProtocolFields, "fallbackRoot")
+	if root == "" {
+		root = inbound.FallbackRoot
+	}
+	if root == "" {
+		root = settings.FallbackRoot
+	}
+	if root == "" {
+		root = "/var/lib/veil/www"
+	}
+	return root
+}
+
+func stringField(m map[string]any, key string) string {
+	if m == nil {
+		return ""
+	}
+	v, ok := m[key].(string)
+	if !ok {
+		return ""
+	}
+	return v
+}

--- a/internal/protocols/naiveproxy/renderer.go
+++ b/internal/protocols/naiveproxy/renderer.go
@@ -2,169 +2,50 @@ package naiveproxy
 
 import (
 	"fmt"
-	"net"
-	"strconv"
-	"strings"
 
-	"github.com/mikkelchokolate/Veil/internal/clientaccess"
+	"github.com/mikkelchokolate/Veil/internal/caddyassembly"
+	"github.com/mikkelchokolate/Veil/internal/caddycapabilities"
 	"github.com/mikkelchokolate/Veil/internal/generatedconfig"
-	"github.com/mikkelchokolate/Veil/internal/model"
 	"github.com/mikkelchokolate/Veil/internal/renderer"
-	veilsettings "github.com/mikkelchokolate/Veil/internal/settings"
 )
 
-// RenderConfig generates per-inbound Caddyfiles and a standalone panel Caddyfile.
+// RenderConfig generates the consolidated Caddy JSON config for all naiveproxy
+// inbounds (and panel access when panelAccess is caddy). The inbound/Caddy
+// redesign moves from per-inbound Caddyfiles to a single JSON config used by
+// veil-caddy.service.
 func (Plugin) RenderConfig(input generatedconfig.ProtocolRenderInput) ([]generatedconfig.GeneratedConfigArtifact, bool, error) {
 	if len(input.Inbounds) == 0 {
-		if input.Settings.PanelAccess == "caddy" {
-			body, err := renderPanelStandalone(input.Settings)
-			if err != nil {
-				return nil, false, err
-			}
-			if body != "" {
-				return []generatedconfig.GeneratedConfigArtifact{{Path: input.Paths.Generated("caddy/panel.Caddyfile"), Body: body}}, true, nil
-			}
-		}
 		return nil, false, nil
 	}
 
-	hasInboundOn443 := false
-	for _, inbound := range input.Inbounds {
-		if inbound.Port == 443 {
-			hasInboundOn443 = true
-			break
-		}
+	plan, _, _, err := caddyassembly.BuildFinalRenderPlan(input.Settings, input.Inbounds)
+	if err != nil {
+		return nil, false, err
 	}
 
-	var artifacts []generatedconfig.GeneratedConfigArtifact
-	for i, inbound := range input.Inbounds {
-		includePanel := false
-		if input.Settings.PanelAccess == "caddy" {
-			if inbound.Port == 443 || (!hasInboundOn443 && i == 0) {
-				includePanel = true
-			}
-		}
-		body, err := renderNaive(input.Settings, inbound, input.Warp, includePanel)
-		if err != nil {
-			return nil, false, err
-		}
-		subpath := "caddy/" + inbound.Name + ".Caddyfile"
-		artifacts = append(artifacts, generatedconfig.GeneratedConfigArtifact{
-			Path: input.Paths.Generated(subpath),
-			Body: body,
-		})
+	caps, err := caddycapabilities.Probe("")
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to probe Caddy capabilities: %w", err)
 	}
-	return artifacts, true, nil
+	data, err := renderer.RenderCaddyJSON(plan, caps)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return []generatedconfig.GeneratedConfigArtifact{{
+		Path: input.Paths.CaddyJSON(),
+		Body: string(data),
+	}}, true, nil
 }
 
-// ArtifactSpec returns the artifact metadata for naiveproxy configs.
+// ArtifactSpec returns the artifact metadata for the consolidated Caddy JSON
+// config.
 func (Plugin) ArtifactSpec() generatedconfig.ArtifactSpec {
 	return generatedconfig.ArtifactSpec{
-		Subpath:        generatedconfig.CaddyfileSubpath,
+		Subpath:        generatedconfig.CaddyJSONConfigSubpath,
 		ValidationName: "caddy",
 		ValidationCommand: func(path string) []string {
 			return []string{"caddy", "validate", "--config", path}
 		},
 	}
-}
-
-func renderNaive(settings model.Settings, inbound model.Inbound, warp model.WarpConfig, includePanel bool) (string, error) {
-	var buf strings.Builder
-	buf.WriteString("{\n  order forward_proxy before file_server\n  servers {\n    protocols h1 h2\n  }\n}\n\n")
-
-	password := naivePassword(settings, inbound)
-	access, err := clientaccess.BuildClientAccess(settings, inbound)
-	if err != nil {
-		return "", err
-	}
-	username := naiveUsername(settings, inbound)
-	root := fallbackRoot(settings, inbound)
-
-	naiveConfig := renderer.NaiveConfig{
-		Domain:       settings.Domain,
-		Email:        settings.Email,
-		ListenPort:   inbound.Port,
-		Username:     username,
-		Password:     password,
-		Users:        access.NaiveUsers(),
-		FallbackRoot: root,
-	}
-	if warp.Enabled {
-		socksPort := warp.SocksPort
-		if socksPort == 0 {
-			socksPort = 40000
-		}
-		naiveConfig.Upstream = fmt.Sprintf("socks5://127.0.0.1:%d", socksPort)
-	}
-	if includePanel && settings.PanelAccess == "caddy" {
-		route, ok, err := panelCaddyRoute(settings)
-		if err != nil {
-			return "", err
-		}
-		if ok {
-			naiveConfig.PanelPort = route.Port
-			naiveConfig.WebBasePath = route.WebBasePath
-		}
-	}
-	block, err := renderer.RenderNaiveCaddyfile(naiveConfig)
-	if err != nil {
-		return "", err
-	}
-	if idx := strings.Index(block, "\n:"); idx != -1 {
-		block = block[idx+1:]
-	} else if idx := strings.Index(block, "\n"+settings.Domain); idx != -1 {
-		block = block[idx+1:]
-	}
-	buf.WriteString(block)
-	buf.WriteString("\n")
-	return buf.String(), nil
-}
-
-func renderPanelStandalone(settings model.Settings) (string, error) {
-	if settings.PanelAccess != "caddy" {
-		return "", nil
-	}
-	route, ok, err := panelCaddyRoute(settings)
-	if err != nil || !ok {
-		return "", err
-	}
-	var buf strings.Builder
-	buf.WriteString("{\n  order forward_proxy before file_server\n  servers {\n    protocols h1 h2\n  }\n}\n\n")
-
-	panelBlock, err := renderer.RenderPanelCaddyfile(renderer.PanelCaddyConfig{
-		Domain:      settings.Domain,
-		Email:       settings.Email,
-		PanelPort:   route.Port,
-		WebBasePath: route.WebBasePath,
-	})
-	if err != nil {
-		return "", err
-	}
-	buf.WriteString(panelBlock)
-	buf.WriteString("\n")
-	return buf.String(), nil
-}
-
-type caddyRoute struct {
-	Port        int
-	WebBasePath string
-}
-
-func panelCaddyRoute(settings model.Settings) (caddyRoute, bool, error) {
-	if settings.PanelAccess != "caddy" {
-		return caddyRoute{}, false, nil
-	}
-	webBasePath := veilsettings.NormalizeWebBasePath(settings.WebBasePath)
-	if webBasePath == "" {
-		return caddyRoute{}, false, fmt.Errorf("webBasePath is required for caddy Panel access")
-	}
-	_, portText, err := net.SplitHostPort(settings.PanelListen)
-	if err != nil {
-		return caddyRoute{}, false, fmt.Errorf("panelListen must be host:port")
-	}
-	port, err := strconv.Atoi(portText)
-	if err != nil || port <= 0 || port > 65535 {
-		return caddyRoute{}, false, fmt.Errorf("panelListen must be host:port")
-	}
-	return caddyRoute{Port: port, WebBasePath: webBasePath}, true, nil
 }

--- a/internal/protocols/naiveproxy/runtime.go
+++ b/internal/protocols/naiveproxy/runtime.go
@@ -7,45 +7,47 @@ import (
 	"github.com/mikkelchokolate/Veil/internal/service"
 )
 
-const templateUnit = "veil-caddy@.service"
+const templateUnit = "veil-caddy.service"
 
-// RuntimeDescriptors returns per-inbound caddy units for naiveproxy.
+// RuntimeDescriptors returns the single veil-caddy.service runtime for all
+// naiveproxy inbounds. The inbound/Caddy redesign consolidates Caddy into one
+// process backed by a single JSON config. When called with nil inbounds (the
+// broad managed-unit catalog), it still returns the Caddy runtime so install
+// and uninstall paths know about the consolidated unit.
 func (p Plugin) RuntimeDescriptors(enabledInbounds []model.Inbound) []service.ManagedRuntime {
-	var runtimes []service.ManagedRuntime
-	count := 0
-	for _, inbound := range enabledInbounds {
-		if inbound.Protocol != p.Protocol() {
-			continue
+	if len(enabledInbounds) == 0 {
+		// In the broad fallback catalog the consolidated Caddy runtime is not
+		// tied to a specific protocol; it exists so service actions and orphan
+		// cleanup can reference the canonical unit.
+		return []service.ManagedRuntime{{
+			Name:             "veil-caddy.service",
+			ActionName:       "caddy",
+			Transport:        "tcp",
+			Unit:             "veil-caddy.service",
+			TemplateUnit:     templateUnit,
+			PromotedSubpath:  generatedconfig.CaddyJSONConfigSubpath,
+			PromotedVerb:     "reload",
+			ManualRestart:    true,
+			HealthCheckAfter: true,
+		}}
+	}
+	for _, inb := range enabledInbounds {
+		if inb.Protocol == "naiveproxy" {
+			return []service.ManagedRuntime{{
+				Name:             "veil-caddy.service",
+				ActionName:       "caddy",
+				Protocol:         p.Protocol(),
+				Transport:        "tcp",
+				Unit:             "veil-caddy.service",
+				TemplateUnit:     templateUnit,
+				PromotedSubpath:  generatedconfig.CaddyJSONConfigSubpath,
+				PromotedVerb:     "reload",
+				ManualRestart:    true,
+				HealthCheckAfter: true,
+			}}
 		}
-		count++
-		runtimes = append(runtimes, service.ManagedRuntime{
-			Name:             "caddy-" + inbound.Name,
-			ActionName:       "caddy-" + inbound.Name,
-			Protocol:         p.Protocol(),
-			Transport:        "tcp",
-			Unit:             "veil-caddy@" + inbound.Name + ".service",
-			TemplateUnit:     templateUnit,
-			PromotedSubpath:  "caddy/" + inbound.Name + ".Caddyfile",
-			PromotedVerb:     "reload",
-			ManualRestart:    true,
-			HealthCheckAfter: true,
-		})
 	}
-	if count == 0 {
-		runtimes = append(runtimes, service.ManagedRuntime{
-			Name:             "caddy-panel",
-			ActionName:       "caddy-panel",
-			Protocol:         p.Protocol(),
-			Transport:        "tcp",
-			Unit:             "veil-caddy@panel.service",
-			TemplateUnit:     templateUnit,
-			PromotedSubpath:  generatedconfig.CaddyfileSubpath,
-			PromotedVerb:     "reload",
-			ManualRestart:    true,
-			HealthCheckAfter: true,
-		})
-	}
-	return runtimes
+	return nil
 }
 
 // RuntimeInstall returns the Caddy-with-naive runtime descriptor.

--- a/internal/protocols/naiveproxy/ui.go
+++ b/internal/protocols/naiveproxy/ui.go
@@ -8,8 +8,8 @@ import (
 // InboundFieldSchema returns the dynamic fields for an inbound naiveproxy form.
 func (Plugin) InboundFieldSchema() []schema.FieldSchema {
 	return []schema.FieldSchema{
-		{Key: "domain", Label: "Domain", Type: schema.FieldText, Required: true, Placeholder: "Public domain used for TLS/SNI and client export.", Scope: "inbound"},
-		{Key: "email", Label: "ACME email", Type: schema.FieldText, Placeholder: "Optional explicit ACME contact for this domain.", Scope: "inbound"},
+		{Key: model.InboundDomainField, Label: "Domain", Type: schema.FieldText, Required: true, Placeholder: "Public domain used for TLS/SNI and client export.", Scope: "inbound"},
+		{Key: model.InboundEmailField, Label: "ACME email", Type: schema.FieldText, Placeholder: "Optional explicit ACME contact for this domain.", Scope: "inbound"},
 		{Key: "publicPort", Label: "Public port", Type: schema.FieldNumber, Default: 443, Placeholder: "Port Caddy listens on for this inbound.", Scope: "inbound"},
 		{Key: "transport", Label: "Transport", Type: schema.FieldSelect, Required: true, Default: "tcp", Options: []schema.FieldOption{{Label: "tcp", Value: "tcp"}}, Placeholder: "tcp=HTTPS/H2.", Scope: "inbound"},
 		{Key: "naiveUsername", Label: "Naive Username", Type: schema.FieldText, Default: "veil", Scope: "inbound"},

--- a/internal/protocols/naiveproxy/ui.go
+++ b/internal/protocols/naiveproxy/ui.go
@@ -8,6 +8,10 @@ import (
 // InboundFieldSchema returns the dynamic fields for an inbound naiveproxy form.
 func (Plugin) InboundFieldSchema() []schema.FieldSchema {
 	return []schema.FieldSchema{
+		{Key: "domain", Label: "Domain", Type: schema.FieldText, Required: true, Placeholder: "Public domain used for TLS/SNI and client export.", Scope: "inbound"},
+		{Key: "email", Label: "ACME email", Type: schema.FieldText, Placeholder: "Optional explicit ACME contact for this domain.", Scope: "inbound"},
+		{Key: "publicPort", Label: "Public port", Type: schema.FieldNumber, Default: 443, Placeholder: "Port Caddy listens on for this inbound.", Scope: "inbound"},
+		{Key: "transport", Label: "Transport", Type: schema.FieldSelect, Required: true, Default: "tcp", Options: []schema.FieldOption{{Label: "tcp", Value: "tcp"}}, Placeholder: "tcp=HTTPS/H2.", Scope: "inbound"},
 		{Key: "naiveUsername", Label: "Naive Username", Type: schema.FieldText, Default: "veil", Scope: "inbound"},
 		{Key: "naivePassword", Label: "Naive Password", Type: schema.FieldPassword, GenerateAction: "password", Scope: "inbound"},
 		{Key: "fallbackRoot", Label: "Fallback Root", Type: schema.FieldText, Default: "/var/lib/veil/www", Scope: "inbound"},
@@ -20,6 +24,10 @@ func (Plugin) SettingsFieldSchema() []schema.FieldSchema {
 		{Key: "naiveUsername", Label: "Naive Username", Type: schema.FieldText, Default: "veil", Scope: "settings"},
 		{Key: "naivePassword", Label: "Naive Password", Type: schema.FieldPassword, Scope: "settings"},
 		{Key: "fallbackRoot", Label: "Fallback Root", Type: schema.FieldText, Default: "/var/lib/veil/www", Scope: "settings"},
+		{Key: "panelAccess", Label: "Panel Access", Type: schema.FieldSelect, Default: "local", Options: []schema.FieldOption{{Label: "local", Value: "local"}, {Label: "direct", Value: "direct"}, {Label: "caddy", Value: "caddy"}}, Scope: "settings"},
+		{Key: "panelDomain", Label: "Panel Domain", Type: schema.FieldText, Scope: "settings", Placeholder: "Public domain used for Panel Caddy TLS/SNI."},
+		{Key: "panelEmail", Label: "Panel ACME Email", Type: schema.FieldText, Scope: "settings", Placeholder: "ACME contact email for Panel Caddy certificate."},
+		{Key: "panelPublicPort", Label: "Panel Public Port", Type: schema.FieldNumber, Default: 443, Scope: "settings", Placeholder: "Port Caddy listens on for Panel access."},
 	}
 }
 

--- a/internal/protocols/naiveproxy/validator.go
+++ b/internal/protocols/naiveproxy/validator.go
@@ -25,7 +25,7 @@ func (p Plugin) ValidateInbound(settings model.Settings, inbound model.Inbound) 
 		issues = append(issues, model.ValidationIssue{
 			Code:     "naive_domain_required",
 			Severity: "error",
-			Field:    "domain",
+			Field:    model.InboundDomainField,
 			Message:  "Naive inbound requires a public domain.",
 			Source:   "naiveproxy",
 		})
@@ -33,7 +33,7 @@ func (p Plugin) ValidateInbound(settings model.Settings, inbound model.Inbound) 
 		issues = append(issues, model.ValidationIssue{
 			Code:     "naive_domain_invalid",
 			Severity: "error",
-			Field:    "domain",
+			Field:    model.InboundDomainField,
 			Message:  "Naive inbound domain is invalid: " + err.Error(),
 			Source:   "naiveproxy",
 		})
@@ -42,7 +42,7 @@ func (p Plugin) ValidateInbound(settings model.Settings, inbound model.Inbound) 
 		issues = append(issues, model.ValidationIssue{
 			Code:     "naive_email_required",
 			Severity: "error",
-			Field:    "email",
+			Field:    model.InboundEmailField,
 			Message:  "Naive inbound requires an ACME email.",
 			Source:   "naiveproxy",
 		})
@@ -50,7 +50,7 @@ func (p Plugin) ValidateInbound(settings model.Settings, inbound model.Inbound) 
 		issues = append(issues, model.ValidationIssue{
 			Code:     "naive_email_invalid",
 			Severity: "error",
-			Field:    "email",
+			Field:    model.InboundEmailField,
 			Message:  "Naive inbound email is invalid: " + err.Error(),
 			Source:   "naiveproxy",
 		})

--- a/internal/protocols/naiveproxy/validator.go
+++ b/internal/protocols/naiveproxy/validator.go
@@ -3,6 +3,7 @@ package naiveproxy
 import (
 	"strings"
 
+	"github.com/mikkelchokolate/Veil/internal/hostenv"
 	"github.com/mikkelchokolate/Veil/internal/model"
 )
 
@@ -26,6 +27,31 @@ func (p Plugin) ValidateInbound(settings model.Settings, inbound model.Inbound) 
 			Severity: "error",
 			Field:    "domain",
 			Message:  "Naive inbound requires a public domain.",
+			Source:   "naiveproxy",
+		})
+	} else if err := hostenv.ValidateDomain(domain); err != nil {
+		issues = append(issues, model.ValidationIssue{
+			Code:     "naive_domain_invalid",
+			Severity: "error",
+			Field:    "domain",
+			Message:  "Naive inbound domain is invalid: " + err.Error(),
+			Source:   "naiveproxy",
+		})
+	}
+	if email := model.ResolveInboundEmail(inbound, settings); email == "" {
+		issues = append(issues, model.ValidationIssue{
+			Code:     "naive_email_required",
+			Severity: "error",
+			Field:    "email",
+			Message:  "Naive inbound requires an ACME email.",
+			Source:   "naiveproxy",
+		})
+	} else if err := hostenv.ValidateEmail(email); err != nil {
+		issues = append(issues, model.ValidationIssue{
+			Code:     "naive_email_invalid",
+			Severity: "error",
+			Field:    "email",
+			Message:  "Naive inbound email is invalid: " + err.Error(),
 			Source:   "naiveproxy",
 		})
 	}

--- a/internal/protocols/naiveproxy/validator.go
+++ b/internal/protocols/naiveproxy/validator.go
@@ -1,36 +1,67 @@
 package naiveproxy
 
 import (
-	"errors"
 	"strings"
 
 	"github.com/mikkelchokolate/Veil/internal/model"
 )
 
-// ValidateSettings ensures the global settings and credentials required by
-// NaiveProxy/Caddy are present.
-func (p Plugin) ValidateSettings(settings model.Settings, inbound model.Inbound) error {
-	if strings.TrimSpace(settings.Domain) == "" || strings.TrimSpace(settings.Email) == "" {
-		return errNaiveCaddySettingsRequired{}
-	}
-	if !p.HasCredential(settings, inbound) {
-		return errors.New("naive username and password are required")
-	}
+// Validator is an alias for Plugin so inbound validation can be invoked with a
+// dedicated receiver type while keeping the existing plugin interface intact.
+type Validator = Plugin
+
+// ValidateSettings is a no-op for naiveproxy. Per-inbound domain, email, and
+// credential validation are handled by ValidateInbound and the apply-plan builder.
+func (Plugin) ValidateSettings(model.Settings, model.Inbound) error {
 	return nil
 }
 
 // ValidateInbound checks one inbound for naiveproxy-specific problems.
 func (p Plugin) ValidateInbound(settings model.Settings, inbound model.Inbound) []model.ValidationIssue {
-	if p.HasCredential(settings, inbound) {
-		return nil
+	var issues []model.ValidationIssue
+	domain := NaiveDomain(settings, inbound)
+	if domain == "" {
+		issues = append(issues, model.ValidationIssue{
+			Code:     "naive_domain_required",
+			Severity: "error",
+			Field:    "domain",
+			Message:  "Naive inbound requires a public domain.",
+			Source:   "naiveproxy",
+		})
 	}
-	return []model.ValidationIssue{{
-		Code:      "naive_credential_required",
-		Severity:  "error",
-		Field:     "inbound",
-		InboundID: inbound.Name,
-		Message:   "NaiveProxy inbound requires a username and password",
-	}}
+	transport := NaiveTransport(inbound)
+	switch transport {
+	case "tcp":
+	default:
+		issues = append(issues, model.ValidationIssue{
+			Code:     "naive_transport_invalid",
+			Severity: "error",
+			Field:    "transport",
+			Message:  "NaiveProxy supports only the tcp transport in this release",
+			Source:   "naiveproxy",
+		})
+	}
+	port := NaivePublicPort(settings, inbound)
+	if port < 1 || port > 65535 {
+		issues = append(issues, model.ValidationIssue{
+			Code:     "naive_public_port_invalid",
+			Severity: "error",
+			Field:    "publicPort",
+			Message:  "publicPort must be between 1 and 65535",
+			Source:   "naiveproxy",
+		})
+	}
+	// credential presence preserved from existing validator
+	if !p.HasCredential(settings, inbound) {
+		issues = append(issues, model.ValidationIssue{
+			Code:     "naive_credential_required",
+			Severity: "error",
+			Field:    "profiles",
+			Message:  "At least one username/password profile is required.",
+			Source:   "naiveproxy",
+		})
+	}
+	return issues
 }
 
 // NeedsDomain reports that naiveproxy needs a public domain.
@@ -45,17 +76,11 @@ func (p Plugin) HasCredential(settings model.Settings, inbound model.Inbound) bo
 		if !profile.Enabled || strings.TrimSpace(profile.Password) == "" {
 			continue
 		}
-		if strings.TrimSpace(profile.Username) != "" || strings.TrimSpace(profile.Name) != "" {
+		if strings.TrimSpace(profile.Username) != "" {
 			return true
 		}
 	}
 	username := naiveUsername(settings, inbound)
 	password := naivePassword(settings, inbound)
 	return username != "" && password != ""
-}
-
-type errNaiveCaddySettingsRequired struct{}
-
-func (errNaiveCaddySettingsRequired) Error() string {
-	return "domain, email, naive username, and naive password are required for NaiveProxy/Caddy"
 }

--- a/internal/protocols/naiveproxy/validator_profiles_test.go
+++ b/internal/protocols/naiveproxy/validator_profiles_test.go
@@ -20,6 +20,7 @@ func TestValidationAcceptsEnabledClientProfileCredentials(t *testing.T) {
 		Enabled:   true,
 		ProtocolFields: map[string]any{
 			"domain": "vpn.example.com",
+			"email":  "admin@example.com",
 		},
 		Profiles: []model.ClientProfile{{
 			Name:     "alice",
@@ -51,6 +52,7 @@ func TestValidationRejectsIncompleteClientProfileWithoutFallback(t *testing.T) {
 		Enabled:   true,
 		ProtocolFields: map[string]any{
 			"domain": "vpn.example.com",
+			"email":  "admin@example.com",
 		},
 		Profiles: []model.ClientProfile{{
 			Name:    "alice",

--- a/internal/protocols/naiveproxy/validator_profiles_test.go
+++ b/internal/protocols/naiveproxy/validator_profiles_test.go
@@ -18,8 +18,12 @@ func TestValidationAcceptsEnabledClientProfileCredentials(t *testing.T) {
 		Transport: "tcp",
 		Port:      443,
 		Enabled:   true,
+		ProtocolFields: map[string]any{
+			"domain": "vpn.example.com",
+		},
 		Profiles: []model.ClientProfile{{
 			Name:     "alice",
+			Username: "alice",
 			Password: "secret",
 			Enabled:  true,
 		}},
@@ -45,15 +49,15 @@ func TestValidationRejectsIncompleteClientProfileWithoutFallback(t *testing.T) {
 		Transport: "tcp",
 		Port:      443,
 		Enabled:   true,
+		ProtocolFields: map[string]any{
+			"domain": "vpn.example.com",
+		},
 		Profiles: []model.ClientProfile{{
 			Name:    "alice",
 			Enabled: true,
 		}},
 	}
 
-	if err := plugin.ValidateSettings(settings, inbound); err == nil {
-		t.Fatal("ValidateSettings accepted an incomplete profile without fallback credentials")
-	}
 	issues := plugin.ValidateInbound(settings, inbound)
 	if len(issues) != 1 || issues[0].Code != "naive_credential_required" {
 		t.Fatalf("ValidateInbound issues = %+v, want naive_credential_required", issues)

--- a/internal/protocols/naiveproxy/validator_test.go
+++ b/internal/protocols/naiveproxy/validator_test.go
@@ -1,0 +1,36 @@
+package naiveproxy
+
+import (
+	"testing"
+
+	"github.com/mikkelchokolate/Veil/internal/model"
+)
+
+func TestValidateInboundMissingDomain(t *testing.T) {
+	v := Validator{}
+	issues := v.ValidateInbound(model.Settings{}, model.Inbound{Protocol: "naiveproxy", ProtocolFields: map[string]any{}})
+	if len(issues) == 0 {
+		t.Fatal("expected missing domain issue")
+	}
+}
+
+func TestValidateInboundInvalidTransport(t *testing.T) {
+	v := Validator{}
+	inbound := model.Inbound{
+		Protocol: "naiveproxy",
+		ProtocolFields: map[string]any{
+			"domain":    "x.com",
+			"transport": "udp",
+		},
+	}
+	issues := v.ValidateInbound(model.Settings{}, inbound)
+	found := false
+	for _, i := range issues {
+		if i.Field == "transport" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected invalid transport issue")
+	}
+}

--- a/internal/protocols/olcrtc/olcrtc_test.go
+++ b/internal/protocols/olcrtc/olcrtc_test.go
@@ -90,7 +90,7 @@ func TestRenderConfigWithInbounds(t *testing.T) {
 	if arts[0].Body == "" {
 		t.Fatal("expected non-empty rendered body")
 	}
-	for _, want := range []string{"provider: telemost", "transport: vp8channel", `id: "room-alpha"`, `key: "secret-key-used-for-render"`} {
+	for _, want := range []string{"provider: telemost", "transport: vp8channel", "id: room-alpha", "key: secret-key-used-for-render"} {
 		if !strings.Contains(arts[0].Body, want) {
 			t.Errorf("rendered body missing %q; body:\n%s", want, arts[0].Body)
 		}
@@ -194,7 +194,7 @@ func TestRenderConfigFieldPrecedence(t *testing.T) {
 			if !strings.Contains(body, "transport: "+tc.wantTransport) {
 				t.Errorf("transport mismatch: want %q, body:\n%s", tc.wantTransport, body)
 			}
-			if !strings.Contains(body, `id: "`+tc.wantRoom+`"`) {
+			if !strings.Contains(body, "id: "+tc.wantRoom) {
 				t.Errorf("room mismatch: want %q, body:\n%s", tc.wantRoom, body)
 			}
 		})

--- a/internal/protocols/protocols_test.go
+++ b/internal/protocols/protocols_test.go
@@ -691,7 +691,7 @@ func TestArtifactCatalogFromRegistryIncludesProtocolSpecsAndWarp(t *testing.T) {
 }
 
 func TestGeneratedConfigRegistryConstants(t *testing.T) {
-	if UnitCaddy != "veil-caddy@.service" {
+	if UnitCaddy != "veil-caddy.service" {
 		t.Fatalf("UnitCaddy = %q", UnitCaddy)
 	}
 	if UnitHysteria2 != "veil-hysteria2@.service" {

--- a/internal/protocols/protocols_test.go
+++ b/internal/protocols/protocols_test.go
@@ -675,7 +675,7 @@ func TestArtifactCatalogFromRegistryIncludesProtocolSpecsAndWarp(t *testing.T) {
 	catalog := generatedconfig.NewArtifactCatalogFromRegistry(registry)
 
 	want := map[string]string{
-		generatedconfig.CaddyfileSubpath:       "caddy",
+		generatedconfig.CaddyJSONConfigSubpath: "caddy",
 		generatedconfig.Hysteria2ConfigSubpath: "hysteria2",
 		generatedconfig.MieruConfigSubpath:     "mieru",
 		generatedconfig.OlcrtcConfigSubpath:    "olcrtc",

--- a/internal/renderer/caddy.go
+++ b/internal/renderer/caddy.go
@@ -31,8 +31,8 @@ func RenderNaiveCaddyfile(cfg NaiveConfig) (string, error) {
 	if cfg.Domain == "" {
 		return "", errors.New("domain is required")
 	}
-	if cfg.ListenPort <= 0 {
-		return "", errors.New("listen port is required")
+	if cfg.ListenPort <= 0 || cfg.ListenPort > 65535 {
+		return "", errors.New("listen port must be between 1 and 65535")
 	}
 	if len(cfg.Users) == 0 {
 		if cfg.Username == "" || cfg.Password == "" {
@@ -48,9 +48,7 @@ func RenderNaiveCaddyfile(cfg NaiveConfig) (string, error) {
 	if cfg.FallbackRoot == "" {
 		cfg.FallbackRoot = "/var/lib/veil/www"
 	}
-	// Validate FallbackRoot is within /var/lib/veil to prevent path traversal.
 	cfg.FallbackRoot = filepath.Clean(cfg.FallbackRoot)
-	// Use ToSlash for platform-independent path manipulation.
 	if !strings.HasPrefix(filepath.ToSlash(cfg.FallbackRoot), "/var/lib/veil") {
 		cfg.FallbackRoot = filepath.Clean("/var/lib/veil/" + cfg.FallbackRoot)
 	}
@@ -58,20 +56,28 @@ func RenderNaiveCaddyfile(cfg NaiveConfig) (string, error) {
 		return "", fmt.Errorf("fallback root must be within /var/lib/veil: %s", cfg.FallbackRoot)
 	}
 	cfg.FallbackRoot = filepath.ToSlash(cfg.FallbackRoot)
+
+	// Keep this layout aligned with the NaiveProxy upstream server example.
+	// In particular, :port must be the first site address and production must
+	// never silently fall back to an internally-issued certificate: Chromium-
+	// based Naive clients require a publicly trusted TLS chain.
 	const tpl = `{
   order forward_proxy before file_server
+  log {
+    exclude http.log.error
+  }
   servers {
     protocols h1 h2
   }
 }
 
 :{{ .ListenPort }}, {{ .Domain }} {
-  tls {
-    issuer acme{{ if .Email }} {
-      email {{ .Email }}
-    }{{ end }}
-    issuer internal
-  }
+{{- if .Email }}
+  tls {{ .Email }}
+{{- else }}
+  tls
+{{- end }}
+  encode
 
   forward_proxy {
 {{- range .Users }}
@@ -85,15 +91,16 @@ func RenderNaiveCaddyfile(cfg NaiveConfig) (string, error) {
 {{- end }}
   }
 
-  root * {{ .FallbackRoot }}
-  file_server
 {{- if .PanelPort }}
-{{ if .WebBasePath }}
+{{- if .WebBasePath }}
   handle {{ .WebBasePath }}* {
     reverse_proxy 127.0.0.1:{{ .PanelPort }}
   }
 {{- end }}
 {{- end }}
+
+  root * {{ .FallbackRoot }}
+  file_server
 }
 `
 	var out bytes.Buffer

--- a/internal/renderer/caddy.go
+++ b/internal/renderer/caddy.go
@@ -31,7 +31,10 @@ func RenderNaiveCaddyfile(cfg NaiveConfig) (string, error) {
 	if cfg.Domain == "" {
 		return "", errors.New("domain is required")
 	}
-	if cfg.ListenPort <= 0 || cfg.ListenPort > 65535 {
+	if cfg.ListenPort <= 0 {
+		return "", errors.New("listen port is required")
+	}
+	if cfg.ListenPort > 65535 {
 		return "", errors.New("listen port must be between 1 and 65535")
 	}
 	if len(cfg.Users) == 0 {
@@ -72,11 +75,11 @@ func RenderNaiveCaddyfile(cfg NaiveConfig) (string, error) {
 }
 
 :{{ .ListenPort }}, {{ .Domain }} {
-{{- if .Email }}
-  tls {{ .Email }}
-{{- else }}
-  tls
-{{- end }}
+  tls {
+    issuer acme{{ if .Email }} {
+      email {{ .Email }}
+    }{{ end }}
+  }
   encode
 
   forward_proxy {

--- a/internal/renderer/caddy_test.go
+++ b/internal/renderer/caddy_test.go
@@ -24,7 +24,6 @@ func TestRenderNaiveCaddyfile(t *testing.T) {
 		":443, example.com",
 		"issuer acme",
 		"email admin@example.com",
-		"issuer internal",
 		"basic_auth alice secret",
 		"hide_ip",
 		"hide_via",
@@ -34,6 +33,9 @@ func TestRenderNaiveCaddyfile(t *testing.T) {
 		if !strings.Contains(cfg, want) {
 			t.Fatalf("rendered Caddyfile missing %q:\n%s", want, cfg)
 		}
+	}
+	if strings.Contains(cfg, "issuer internal") {
+		t.Fatalf("rendered Caddyfile must not contain internal certificate fallback:\n%s", cfg)
 	}
 }
 

--- a/internal/renderer/caddyjson.go
+++ b/internal/renderer/caddyjson.go
@@ -102,8 +102,9 @@ func renderACMEIssuer(email, mode string) map[string]any {
 
 func renderServer(key bindregistry.BindKey, owner caddyassembly.CaddyBindOwner, caps caddycapabilities.CaddyCapabilities) (map[string]any, error) {
 	server := map[string]any{
-		"listen":          []string{listenString(key)},
-		"automatic_https": map[string]any{"disable_redirects": true},
+		"listen":                  []string{listenString(key)},
+		"automatic_https":         map[string]any{"disable_redirects": true},
+		"tls_connection_policies": []map[string]any{{}},
 	}
 	if owner.Kind == caddyassembly.CaddyOwnerNaive {
 		protocols, err := protocolsForTransport(owner.Transport)
@@ -117,8 +118,13 @@ func renderServer(key bindregistry.BindKey, owner caddyassembly.CaddyBindOwner, 
 		server["routes"] = panelRoutes(owner.Domain, owner.BackendPort, owner.WebBasePath)
 	case caddyassembly.CaddyOwnerNaive:
 		authCreds := make([]string, 0, len(owner.NaiveUsers))
-		for _, u := range owner.NaiveUsers {
-			authCreds = append(authCreds, base64.StdEncoding.EncodeToString([]byte(u.Username+":"+u.Password)))
+		for _, user := range owner.NaiveUsers {
+			// forwardproxy declares auth_credentials as [][]byte. Its Caddyfile
+			// adapter stores each HTTP Basic value (already base64-encoded) as a
+			// byte slice, so native JSON must base64-encode that byte slice once
+			// more to satisfy encoding/json's []byte contract.
+			basicValue := base64.StdEncoding.EncodeToString([]byte(user.Username + ":" + user.Password))
+			authCreds = append(authCreds, base64.StdEncoding.EncodeToString([]byte(basicValue)))
 		}
 		fallbackRoot, err := resolveNaiveFallbackRoot(owner.FallbackRoot)
 		if err != nil {

--- a/internal/renderer/caddyjson.go
+++ b/internal/renderer/caddyjson.go
@@ -1,0 +1,241 @@
+package renderer
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/mikkelchokolate/Veil/internal/bindregistry"
+	"github.com/mikkelchokolate/Veil/internal/caddyassembly"
+	"github.com/mikkelchokolate/Veil/internal/caddycapabilities"
+)
+
+func RenderCaddyJSON(plan caddyassembly.CaddyRenderPlan, caps caddycapabilities.CaddyCapabilities) ([]byte, error) {
+	if err := validateCaddyCapabilities(plan, caps); err != nil {
+		return nil, err
+	}
+	httpApp, err := renderHTTPApp(plan, caps)
+	if err != nil {
+		return nil, err
+	}
+	cfg := caddyConfig{Admin: map[string]any{"listen": "127.0.0.1:2019"}, Apps: map[string]any{}}
+	cfg.Apps["http"] = httpApp
+	cfg.Apps["tls"] = renderTLSApp(plan)
+	return json.MarshalIndent(cfg, "", "  ")
+}
+
+func validateCaddyCapabilities(plan caddyassembly.CaddyRenderPlan, caps caddycapabilities.CaddyCapabilities) error {
+	for _, owner := range plan.Servers {
+		if owner.Kind != caddyassembly.CaddyOwnerNaive {
+			continue
+		}
+		if !caps.ForwardProxy {
+			return fmt.Errorf("Caddy binary does not include the forward_proxy module required for NaiveProxy")
+		}
+	}
+	return nil
+}
+
+type caddyConfig struct {
+	Admin map[string]any `json:"admin"`
+	Apps  map[string]any `json:"apps"`
+}
+
+func renderHTTPApp(plan caddyassembly.CaddyRenderPlan, caps caddycapabilities.CaddyCapabilities) (map[string]any, error) {
+	servers := make(map[string]any)
+	for key, owner := range plan.Servers {
+		serverName := serverNameFor(key)
+		server, err := renderServer(key, owner, caps)
+		if err != nil {
+			return nil, err
+		}
+		servers[serverName] = server
+	}
+	for key, owner := range plan.ACMEChallenges {
+		serverName := serverNameFor(key) + "-acme"
+		servers[serverName] = renderAcmeChallengeServer(key, owner)
+	}
+	return map[string]any{"servers": servers}, nil
+}
+
+func renderTLSApp(plan caddyassembly.CaddyRenderPlan) map[string]any {
+	type issuerGroup struct {
+		email   string
+		mode    string
+		domains []string
+	}
+	groups := make(map[string]*issuerGroup)
+	for _, spec := range plan.Domains {
+		mode := challengeForDomain(plan, spec.Domain)
+		issuerKey := spec.Email + "/" + mode
+		g := groups[issuerKey]
+		if g == nil {
+			g = &issuerGroup{email: spec.Email, mode: mode}
+			groups[issuerKey] = g
+		}
+		g.domains = append(g.domains, spec.Domain)
+	}
+	var policies []map[string]any
+	for _, g := range groups {
+		policies = append(policies, map[string]any{
+			"subjects": g.domains,
+			"issuers":  []map[string]any{renderACMEIssuer(g.email, g.mode)},
+		})
+	}
+	return map[string]any{"automation": map[string]any{"policies": policies}}
+}
+
+func renderACMEIssuer(email, mode string) map[string]any {
+	return map[string]any{
+		"module": "acme",
+		"email":  email,
+		"challenges": map[string]any{
+			"http":     map[string]any{"disabled": mode != "http-01"},
+			"tls-alpn": map[string]any{"disabled": mode != "tls-alpn-01"},
+		},
+	}
+}
+
+func renderServer(key bindregistry.BindKey, owner caddyassembly.CaddyBindOwner, caps caddycapabilities.CaddyCapabilities) (map[string]any, error) {
+	server := map[string]any{
+		"listen":          []string{listenString(key)},
+		"automatic_https": map[string]any{"disable_redirects": true},
+	}
+	if owner.Kind == caddyassembly.CaddyOwnerNaive {
+		protocols, err := protocolsForTransport(owner.Transport)
+		if err != nil {
+			return nil, err
+		}
+		server["protocols"] = protocols
+	}
+	switch owner.Kind {
+	case caddyassembly.CaddyOwnerPanel:
+		server["routes"] = panelRoutes(owner.Domain, owner.BackendPort, owner.WebBasePath)
+	case caddyassembly.CaddyOwnerNaive:
+		authCreds := make([]string, 0, len(owner.NaiveUsers))
+		for _, u := range owner.NaiveUsers {
+			authCreds = append(authCreds, base64.StdEncoding.EncodeToString([]byte(u.Username+":"+u.Password)))
+		}
+		fallbackRoot, err := resolveNaiveFallbackRoot(owner.FallbackRoot)
+		if err != nil {
+			return nil, err
+		}
+		handlers := []map[string]any{
+			{
+				"handler":          "forward_proxy",
+				"auth_credentials": authCreds,
+				"hide_ip":          true,
+				"hide_via":         true,
+				"probe_resistance": map[string]any{},
+			},
+			{
+				"handler": "file_server",
+				"root":    fallbackRoot,
+			},
+		}
+		routes := []map[string]any{}
+		if owner.PanelDomain != "" && owner.BackendPort > 0 && owner.WebBasePath != "" {
+			routes = append(routes, panelRoutes(owner.PanelDomain, owner.BackendPort, owner.WebBasePath)...)
+		}
+		routes = append(routes, map[string]any{"handle": handlers})
+		server["routes"] = routes
+	}
+	return server, nil
+}
+
+func protocolsForTransport(transport string) ([]string, error) {
+	switch transport {
+	case "tcp":
+		return []string{"h1", "h2"}, nil
+	default:
+		return nil, fmt.Errorf("unsupported naive transport %q", transport)
+	}
+}
+
+// resolveNaiveFallbackRoot validates and normalizes the naive fallback root.
+// It must be either exactly /var/lib/veil or a subdirectory of it.
+// Relative paths are resolved against /var/lib/veil.
+func resolveNaiveFallbackRoot(input string) (string, error) {
+	if input == "" {
+		return "/var/lib/veil/www", nil
+	}
+	root := filepath.ToSlash(filepath.Clean(input))
+	if !strings.HasPrefix(root, "/") {
+		root = filepath.ToSlash(filepath.Clean("/var/lib/veil/" + root))
+	}
+	if root != "/var/lib/veil" && !strings.HasPrefix(root, "/var/lib/veil/") {
+		return "", fmt.Errorf("fallback root must be within /var/lib/veil: %s", root)
+	}
+	return root, nil
+}
+
+func renderAcmeChallengeServer(key bindregistry.BindKey, owner caddyassembly.AcmeChallengeOwner) map[string]any {
+	return map[string]any{
+		"listen":          []string{listenString(key)},
+		"automatic_https": map[string]any{"disable_redirects": true},
+		"routes":          []map[string]any{},
+	}
+}
+
+func panelRoutes(domain string, backendPort int, webBasePath string) []map[string]any {
+	proxy := map[string]any{
+		"handler":   "reverse_proxy",
+		"upstreams": []map[string]any{{"dial": "127.0.0.1:" + portString(backendPort)}},
+	}
+	if webBasePath == "" || webBasePath == "/" {
+		return []map[string]any{
+			{"match": []map[string]any{{"host": []string{domain}}}, "handle": []map[string]any{proxy}},
+			{"handle": []map[string]any{{"handler": "static_response", "status_code": 404}}},
+		}
+	}
+	webBasePath = strings.TrimRight(webBasePath, "/")
+	webBasePathSlash := webBasePath + "/"
+	return []map[string]any{
+		{
+			"match": []map[string]any{{"host": []string{domain}, "path": []string{webBasePath}}},
+			"handle": []map[string]any{{
+				"handler":     "static_response",
+				"headers":     map[string]any{"Location": []string{webBasePathSlash}},
+				"status_code": 308,
+			}},
+		},
+		{
+			"match":  []map[string]any{{"host": []string{domain}, "path": []string{webBasePathSlash + "*"}}},
+			"handle": []map[string]any{proxy},
+		},
+		{
+			"handle": []map[string]any{{"handler": "static_response", "status_code": 404}},
+		},
+	}
+}
+
+func serverNameFor(key bindregistry.BindKey) string {
+	return string(key.Network) + "-" + key.Address + "-" + portString(key.Port)
+}
+
+func listenString(key bindregistry.BindKey) string {
+	if bindregistry.IsWildcard(key.Address) {
+		return ":" + portString(key.Port)
+	}
+	return net.JoinHostPort(key.Address, portString(key.Port))
+}
+
+func portString(p int) string { return strconv.Itoa(p) }
+
+func challengeForDomain(plan caddyassembly.CaddyRenderPlan, domain string) string {
+	for _, owner := range plan.ACMEChallenges {
+		for _, d := range owner.Domains {
+			if d == domain {
+				return owner.ChallengeMode
+			}
+		}
+	}
+	if plan.DefaultChallengeMode != "" {
+		return plan.DefaultChallengeMode
+	}
+	return "tls-alpn-01"
+}

--- a/internal/renderer/caddyjson.go
+++ b/internal/renderer/caddyjson.go
@@ -34,7 +34,7 @@ func validateCaddyCapabilities(plan caddyassembly.CaddyRenderPlan, caps caddycap
 			continue
 		}
 		if !caps.ForwardProxy {
-			return fmt.Errorf("Caddy binary does not include the forward_proxy module required for NaiveProxy")
+			return fmt.Errorf("caddy binary does not include the forward_proxy module required for NaiveProxy")
 		}
 	}
 	return nil

--- a/internal/renderer/caddyjson.go
+++ b/internal/renderer/caddyjson.go
@@ -115,7 +115,7 @@ func renderServer(key bindregistry.BindKey, owner caddyassembly.CaddyBindOwner, 
 	}
 	switch owner.Kind {
 	case caddyassembly.CaddyOwnerPanel:
-		server["routes"] = panelRoutes(owner.Domain, owner.BackendPort, owner.WebBasePath)
+		server["routes"] = panelRoutes(owner.Domain, owner.BackendPort, owner.WebBasePath, true)
 	case caddyassembly.CaddyOwnerNaive:
 		authCreds := make([]string, 0, len(owner.NaiveUsers))
 		for _, user := range owner.NaiveUsers {
@@ -145,7 +145,9 @@ func renderServer(key bindregistry.BindKey, owner caddyassembly.CaddyBindOwner, 
 		}
 		routes := []map[string]any{}
 		if owner.PanelDomain != "" && owner.BackendPort > 0 && owner.WebBasePath != "" {
-			routes = append(routes, panelRoutes(owner.PanelDomain, owner.BackendPort, owner.WebBasePath)...)
+			// On a shared Panel/Naive bind, unmatched requests must reach
+			// forward_proxy. The panel-only catch-all 404 would intercept CONNECT.
+			routes = append(routes, panelRoutes(owner.PanelDomain, owner.BackendPort, owner.WebBasePath, false)...)
 		}
 		routes = append(routes, map[string]any{"handle": handlers})
 		server["routes"] = routes
@@ -187,20 +189,23 @@ func renderAcmeChallengeServer(key bindregistry.BindKey, owner caddyassembly.Acm
 	}
 }
 
-func panelRoutes(domain string, backendPort int, webBasePath string) []map[string]any {
+func panelRoutes(domain string, backendPort int, webBasePath string, includeFallback bool) []map[string]any {
 	proxy := map[string]any{
 		"handler":   "reverse_proxy",
 		"upstreams": []map[string]any{{"dial": "127.0.0.1:" + portString(backendPort)}},
 	}
 	if webBasePath == "" || webBasePath == "/" {
-		return []map[string]any{
+		routes := []map[string]any{
 			{"match": []map[string]any{{"host": []string{domain}}}, "handle": []map[string]any{proxy}},
-			{"handle": []map[string]any{{"handler": "static_response", "status_code": 404}}},
 		}
+		if includeFallback {
+			routes = append(routes, map[string]any{"handle": []map[string]any{{"handler": "static_response", "status_code": 404}}})
+		}
+		return routes
 	}
 	webBasePath = strings.TrimRight(webBasePath, "/")
 	webBasePathSlash := webBasePath + "/"
-	return []map[string]any{
+	routes := []map[string]any{
 		{
 			"match": []map[string]any{{"host": []string{domain}, "path": []string{webBasePath}}},
 			"handle": []map[string]any{{
@@ -213,10 +218,11 @@ func panelRoutes(domain string, backendPort int, webBasePath string) []map[strin
 			"match":  []map[string]any{{"host": []string{domain}, "path": []string{webBasePathSlash + "*"}}},
 			"handle": []map[string]any{proxy},
 		},
-		{
-			"handle": []map[string]any{{"handler": "static_response", "status_code": 404}},
-		},
 	}
+	if includeFallback {
+		routes = append(routes, map[string]any{"handle": []map[string]any{{"handler": "static_response", "status_code": 404}}})
+	}
+	return routes
 }
 
 func serverNameFor(key bindregistry.BindKey) string {

--- a/internal/renderer/caddyjson.go
+++ b/internal/renderer/caddyjson.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -69,7 +70,14 @@ func renderTLSApp(plan caddyassembly.CaddyRenderPlan) map[string]any {
 		domains []string
 	}
 	groups := make(map[string]*issuerGroup)
+	// plan.Domains is a map; sort its specs so both the per-policy subjects
+	// slice and the policy list are byte-for-byte deterministic across renders.
+	specs := make([]caddyassembly.CaddyDomainCertSpec, 0, len(plan.Domains))
 	for _, spec := range plan.Domains {
+		specs = append(specs, spec)
+	}
+	sort.Slice(specs, func(i, j int) bool { return specs[i].Domain < specs[j].Domain })
+	for _, spec := range specs {
 		mode := challengeForDomain(plan, spec.Domain)
 		issuerKey := spec.Email + "/" + mode
 		g := groups[issuerKey]
@@ -80,7 +88,13 @@ func renderTLSApp(plan caddyassembly.CaddyRenderPlan) map[string]any {
 		g.domains = append(g.domains, spec.Domain)
 	}
 	var policies []map[string]any
-	for _, g := range groups {
+	keys := make([]string, 0, len(groups))
+	for k := range groups {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		g := groups[k]
 		policies = append(policies, map[string]any{
 			"subjects": g.domains,
 			"issuers":  []map[string]any{renderACMEIssuer(g.email, g.mode)},

--- a/internal/renderer/caddyjson_test.go
+++ b/internal/renderer/caddyjson_test.go
@@ -16,6 +16,35 @@ import (
 	"github.com/mikkelchokolate/Veil/internal/model"
 )
 
+func TestRenderCaddyJSONDeterministicAcrossRuns(t *testing.T) {
+	// Multiple issuer groups + multiple domains force map iteration in
+	// renderTLSApp. Render repeatedly and require byte-identical output.
+	plan := caddyassembly.CaddyRenderPlan{
+		Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{},
+		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
+			"zeta.example.com":   {Domain: "zeta.example.com", Email: "b@example.com"},
+			"alpha.example.com":  {Domain: "alpha.example.com", Email: "a@example.com"},
+			"middle.example.com": {Domain: "middle.example.com", Email: "a@example.com"},
+			"beta.example.com":   {Domain: "beta.example.com", Email: "b@example.com"},
+			"gamma.example.com":  {Domain: "gamma.example.com", Email: "a@example.com"},
+		},
+	}
+	caps := caddycapabilities.CaddyCapabilities{ForwardProxy: true}
+	first, err := RenderCaddyJSON(plan, caps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 50; i++ {
+		got, err := RenderCaddyJSON(plan, caps)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != string(first) {
+			t.Fatalf("render %d differs from first render:\nfirst: %s\ngot:   %s", i, first, got)
+		}
+	}
+}
+
 func TestRenderCaddyJSONNaiveForwardProxyOrder(t *testing.T) {
 	plan := caddyassembly.CaddyRenderPlan{
 		Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{

--- a/internal/renderer/caddyjson_test.go
+++ b/internal/renderer/caddyjson_test.go
@@ -40,6 +40,38 @@ func TestRenderCaddyJSONNaiveForwardProxyOrder(t *testing.T) {
 	}
 }
 
+func TestRenderCaddyJSONEnablesTLSOnNonStandardNaivePort(t *testing.T) {
+	plan := caddyassembly.CaddyRenderPlan{
+		Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
+			{Address: "0.0.0.0", Port: 8443, Network: bindregistry.ListenTCP}: {
+				Kind:        caddyassembly.CaddyOwnerNaive,
+				Domain:      "p.example.com",
+				InboundName: "naive-1",
+				Transport:   "tcp",
+			},
+		},
+		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
+			"p.example.com": {Domain: "p.example.com", Email: "a@example.com"},
+		},
+	}
+	data, err := RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{ForwardProxy: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	apps := cfg["apps"].(map[string]any)
+	httpApp := apps["http"].(map[string]any)
+	servers := httpApp["servers"].(map[string]any)
+	server := servers["tcp-0.0.0.0-8443"].(map[string]any)
+	policies, ok := server["tls_connection_policies"].([]any)
+	if !ok || len(policies) != 1 {
+		t.Fatalf("non-standard Naive port must explicitly enable TLS, server=%+v", server)
+	}
+}
+
 func containsInOrder(s, a, b string) bool {
 	ia := strings.Index(s, a)
 	ib := strings.Index(s, b)
@@ -370,9 +402,10 @@ func TestRenderCaddyJSONNaiveForwardProxyAuthCredentials(t *testing.T) {
 		{"alice", "secret-a"},
 		{"bob", "secret-b"},
 	} {
-		want := base64.StdEncoding.EncodeToString([]byte(u.user + ":" + u.pass))
+		basicValue := base64.StdEncoding.EncodeToString([]byte(u.user + ":" + u.pass))
+		want := base64.StdEncoding.EncodeToString([]byte(basicValue))
 		if !strings.Contains(s, fmt.Sprintf("%q", want)) {
-			t.Errorf("expected base64 credential %q for %s", want, u.user)
+			t.Errorf("expected JSON-encoded forwardproxy credential %q for %s", want, u.user)
 		}
 	}
 }

--- a/internal/renderer/caddyjson_test.go
+++ b/internal/renderer/caddyjson_test.go
@@ -40,6 +40,54 @@ func TestRenderCaddyJSONNaiveForwardProxyOrder(t *testing.T) {
 	}
 }
 
+func TestRenderCaddyJSONSharedPanelNaiveDoesNotBlockForwardProxy(t *testing.T) {
+	plan := caddyassembly.CaddyRenderPlan{
+		Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
+			{Address: "0.0.0.0", Port: 443, Network: bindregistry.ListenTCP}: {
+				Kind:         caddyassembly.CaddyOwnerNaive,
+				Domain:       "vpn.example.com",
+				PanelDomain:  "vpn.example.com",
+				InboundName:  "naive",
+				Transport:    "tcp",
+				BackendPort:  2096,
+				WebBasePath:  "/panel/",
+				NaiveUsers:   []caddyassembly.CaddyNaiveUser{{Username: "veil", Password: "secret"}},
+				FallbackRoot: "/var/lib/veil/www",
+			},
+		},
+		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
+			"vpn.example.com": {Domain: "vpn.example.com", Email: "admin@example.com"},
+		},
+	}
+	data, err := RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{ForwardProxy: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	server := cfg["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)["tcp-0.0.0.0-443"].(map[string]any)
+	seenForwardProxy := false
+	for _, rawRoute := range server["routes"].([]any) {
+		route := rawRoute.(map[string]any)
+		for _, rawHandler := range route["handle"].([]any) {
+			handler := rawHandler.(map[string]any)["handler"]
+			if handler == "forward_proxy" {
+				seenForwardProxy = true
+			}
+			if handler == "static_response" && !seenForwardProxy {
+				if match, ok := route["match"].([]any); !ok || len(match) == 0 {
+					t.Fatalf("unconditional static response blocks Naive CONNECT before forward_proxy: %+v", server["routes"])
+				}
+			}
+		}
+	}
+	if !seenForwardProxy {
+		t.Fatalf("shared Panel/Naive server has no forward_proxy route: %+v", server)
+	}
+}
+
 func TestRenderCaddyJSONEnablesTLSOnNonStandardNaivePort(t *testing.T) {
 	plan := caddyassembly.CaddyRenderPlan{
 		Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{

--- a/internal/renderer/caddyjson_test.go
+++ b/internal/renderer/caddyjson_test.go
@@ -1,0 +1,606 @@
+package renderer
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mikkelchokolate/Veil/internal/bindregistry"
+	"github.com/mikkelchokolate/Veil/internal/caddyassembly"
+	"github.com/mikkelchokolate/Veil/internal/caddycapabilities"
+	"github.com/mikkelchokolate/Veil/internal/model"
+)
+
+func TestRenderCaddyJSONNaiveForwardProxyOrder(t *testing.T) {
+	plan := caddyassembly.CaddyRenderPlan{
+		Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
+			{Address: "0.0.0.0", Port: 8443, Network: bindregistry.ListenTCP}: {
+				Kind:        caddyassembly.CaddyOwnerNaive,
+				Domain:      "p.example.com",
+				InboundName: "naive-1",
+				Transport:   "tcp",
+			},
+		},
+		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
+			"p.example.com": {Domain: "p.example.com", Email: "a@example.com"},
+		},
+	}
+	data, err := RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{ForwardProxy: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(data)
+	if !containsInOrder(s, `"forward_proxy"`, `"file_server"`) {
+		t.Error("forward_proxy must appear before file_server")
+	}
+}
+
+func containsInOrder(s, a, b string) bool {
+	ia := strings.Index(s, a)
+	ib := strings.Index(s, b)
+	return ia >= 0 && ib > ia
+}
+
+func TestRenderCaddyJSONPanelOnly(t *testing.T) {
+	plan := caddyassembly.CaddyRenderPlan{
+		Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
+			{Address: "0.0.0.0", Port: 443, Network: bindregistry.ListenTCP}: {
+				Kind:        caddyassembly.CaddyOwnerPanel,
+				Domain:      "panel.example.com",
+				BackendPort: 2096,
+			},
+		},
+		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
+			"panel.example.com": {Domain: "panel.example.com", Email: "admin@example.com"},
+		},
+	}
+	data, err := RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	apps := cfg["apps"].(map[string]any)
+	if _, ok := apps["http"]; !ok {
+		t.Error("expected http app")
+	}
+}
+
+func TestRenderCaddyJSONAcmeChallengeKeys(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     bindregistry.BindKey
+		mode    string
+		wantKey string
+	}{
+		{
+			name:    "http-01",
+			key:     bindregistry.BindKey{Address: "0.0.0.0", Port: 80, Network: bindregistry.ListenTCP},
+			mode:    "http-01",
+			wantKey: `"http"`,
+		},
+		{
+			name:    "tls-alpn-01",
+			key:     bindregistry.BindKey{Address: "0.0.0.0", Port: 443, Network: bindregistry.ListenTCP},
+			mode:    "tls-alpn-01",
+			wantKey: `"tls-alpn"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plan := caddyassembly.CaddyRenderPlan{
+				Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
+					{Address: "0.0.0.0", Port: 443, Network: bindregistry.ListenTCP}: {
+						Kind:        caddyassembly.CaddyOwnerPanel,
+						Domain:      "panel.example.com",
+						BackendPort: 2096,
+					},
+				},
+				Domains: map[string]caddyassembly.CaddyDomainCertSpec{
+					"panel.example.com": {Domain: "panel.example.com", Email: "admin@example.com"},
+				},
+				ACMEChallenges: map[bindregistry.BindKey]caddyassembly.AcmeChallengeOwner{
+					tt.key: {ChallengeMode: tt.mode, Domains: []string{"panel.example.com"}},
+				},
+			}
+			data, err := RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			s := string(data)
+			if !strings.Contains(s, `"issuers"`) {
+				t.Error("expected automation policy to contain issuers array")
+			}
+			if !strings.Contains(s, tt.wantKey) {
+				t.Errorf("expected challenge key %s in rendered JSON", tt.wantKey)
+			}
+			if strings.Contains(s, `"http-01"`) || strings.Contains(s, `"tls-alpn-01"`) {
+				t.Error("old challenge keys http-01/tls-alpn-01 must not appear in rendered JSON")
+			}
+		})
+	}
+}
+
+func TestRenderCaddyJSONRejectsNaiveWithoutForwardProxy(t *testing.T) {
+	plan := caddyassembly.CaddyRenderPlan{
+		Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
+			{Address: "0.0.0.0", Port: 8443, Network: bindregistry.ListenTCP}: {
+				Kind:        caddyassembly.CaddyOwnerNaive,
+				Domain:      "p.example.com",
+				InboundName: "naive-1",
+				Transport:   "tcp",
+			},
+		},
+		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
+			"p.example.com": {Domain: "p.example.com", Email: "a@example.com"},
+		},
+	}
+	_, err := RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{ForwardProxy: false})
+	if err == nil {
+		t.Fatal("expected error for missing forward_proxy module")
+	}
+	want := "Caddy binary does not include the forward_proxy module required for NaiveProxy"
+	if err.Error() != want {
+		t.Fatalf("error = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestRenderCaddyJSONAllowsNaiveTCPWithForwardProxy(t *testing.T) {
+	plan := caddyassembly.CaddyRenderPlan{
+		Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
+			{Address: "0.0.0.0", Port: 8443, Network: bindregistry.ListenTCP}: {
+				Kind:        caddyassembly.CaddyOwnerNaive,
+				Domain:      "p.example.com",
+				InboundName: "naive-1",
+				Transport:   "tcp",
+			},
+		},
+		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
+			"p.example.com": {Domain: "p.example.com", Email: "a@example.com"},
+		},
+	}
+	_, err := RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{ForwardProxy: true})
+	if err != nil {
+		t.Fatalf("expected success for tcp transport with forward_proxy, got %v", err)
+	}
+}
+
+func TestRenderCaddyJSONNaiveFallbackRootDefaults(t *testing.T) {
+	plan := caddyassembly.CaddyRenderPlan{
+		Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
+			{Address: "0.0.0.0", Port: 8443, Network: bindregistry.ListenTCP}: {
+				Kind:        caddyassembly.CaddyOwnerNaive,
+				Domain:      "p.example.com",
+				InboundName: "naive-1",
+				Transport:   "tcp",
+			},
+		},
+		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
+			"p.example.com": {Domain: "p.example.com", Email: "a@example.com"},
+		},
+	}
+	data, err := RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{ForwardProxy: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"root": "/var/lib/veil/www"`) {
+		t.Errorf("expected default fallback root, got %s", string(data))
+	}
+}
+
+func TestRenderCaddyJSONNaiveFallbackRootRejectsParentTraversal(t *testing.T) {
+	plan := caddyassembly.CaddyRenderPlan{
+		Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
+			{Address: "0.0.0.0", Port: 8443, Network: bindregistry.ListenTCP}: {
+				Kind:         caddyassembly.CaddyOwnerNaive,
+				Domain:       "p.example.com",
+				InboundName:  "naive-1",
+				Transport:    "tcp",
+				FallbackRoot: "..",
+			},
+		},
+		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
+			"p.example.com": {Domain: "p.example.com", Email: "a@example.com"},
+		},
+	}
+	_, err := RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{ForwardProxy: true})
+	if err == nil {
+		t.Fatal("expected error for fallback root outside /var/lib/veil")
+	}
+}
+
+func TestRenderCaddyJSONNaiveFallbackRootRejectsOutsideVeil(t *testing.T) {
+	cases := []string{
+		"/etc/passwd",
+		"/var/lib/veil2",
+		"/var/lib/veil-evil",
+		"/var/lib/veil2/sub",
+		"/var/lib",
+	}
+	for _, root := range cases {
+		t.Run(root, func(t *testing.T) {
+			plan := caddyassembly.CaddyRenderPlan{
+				Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
+					{Address: "0.0.0.0", Port: 8443, Network: bindregistry.ListenTCP}: {
+						Kind:         caddyassembly.CaddyOwnerNaive,
+						Domain:       "p.example.com",
+						InboundName:  "naive-1",
+						Transport:    "tcp",
+						FallbackRoot: root,
+					},
+				},
+				Domains: map[string]caddyassembly.CaddyDomainCertSpec{
+					"p.example.com": {Domain: "p.example.com", Email: "a@example.com"},
+				},
+			}
+			_, err := RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{ForwardProxy: true})
+			if err == nil {
+				t.Fatalf("expected error for fallback root %q outside /var/lib/veil", root)
+			}
+		})
+	}
+}
+
+func TestRenderCaddyJSONNaiveFallbackRootAcceptsWithinVeil(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"/var/lib/veil", "/var/lib/veil"},
+		{"/var/lib/veil/", "/var/lib/veil"},
+		{"/var/lib/veil/custom", "/var/lib/veil/custom"},
+		{"/var/lib/veil/www", "/var/lib/veil/www"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			plan := caddyassembly.CaddyRenderPlan{
+				Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
+					{Address: "0.0.0.0", Port: 8443, Network: bindregistry.ListenTCP}: {
+						Kind:         caddyassembly.CaddyOwnerNaive,
+						Domain:       "p.example.com",
+						InboundName:  "naive-1",
+						Transport:    "tcp",
+						FallbackRoot: tc.input,
+					},
+				},
+				Domains: map[string]caddyassembly.CaddyDomainCertSpec{
+					"p.example.com": {Domain: "p.example.com", Email: "a@example.com"},
+				},
+			}
+			data, err := RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{ForwardProxy: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantRoot := fmt.Sprintf(`"root": %q`, tc.want)
+			if !strings.Contains(string(data), wantRoot) {
+				t.Errorf("expected %s in rendered JSON, got %s", wantRoot, string(data))
+			}
+		})
+	}
+}
+
+func TestRenderCaddyJSONNaiveFallbackRootResolvesRelativePath(t *testing.T) {
+	plan := caddyassembly.CaddyRenderPlan{
+		Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
+			{Address: "0.0.0.0", Port: 8443, Network: bindregistry.ListenTCP}: {
+				Kind:         caddyassembly.CaddyOwnerNaive,
+				Domain:       "p.example.com",
+				InboundName:  "naive-1",
+				Transport:    "tcp",
+				FallbackRoot: "custom",
+			},
+		},
+		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
+			"p.example.com": {Domain: "p.example.com", Email: "a@example.com"},
+		},
+	}
+	data, err := RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{ForwardProxy: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"root": "/var/lib/veil/custom"`) {
+		t.Errorf("expected resolved fallback root, got %s", string(data))
+	}
+}
+
+func TestRenderCaddyJSONUsesAutomaticHTTPS(t *testing.T) {
+	plan := caddyassembly.CaddyRenderPlan{
+		Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
+			{Address: "0.0.0.0", Port: 443, Network: bindregistry.ListenTCP}: {
+				Kind:        caddyassembly.CaddyOwnerPanel,
+				Domain:      "panel.example.com",
+				BackendPort: 2096,
+			},
+		},
+		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
+			"panel.example.com": {Domain: "panel.example.com", Email: "admin@example.com"},
+		},
+	}
+	data, err := RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(data)
+	if strings.Contains(s, `"auto_https"`) {
+		t.Error("rendered JSON must not contain the Caddyfile field auto_https")
+	}
+	if !strings.Contains(s, `"automatic_https"`) {
+		t.Error("rendered JSON must contain the JSON field automatic_https")
+	}
+}
+
+func TestRenderCaddyJSONNaiveForwardProxyAuthCredentials(t *testing.T) {
+	plan := caddyassembly.CaddyRenderPlan{
+		Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
+			{Address: "0.0.0.0", Port: 8443, Network: bindregistry.ListenTCP}: {
+				Kind:        caddyassembly.CaddyOwnerNaive,
+				Domain:      "p.example.com",
+				InboundName: "naive-1",
+				Transport:   "tcp",
+				NaiveUsers: []caddyassembly.CaddyNaiveUser{
+					{Username: "alice", Password: "secret-a"},
+					{Username: "bob", Password: "secret-b"},
+				},
+			},
+		},
+		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
+			"p.example.com": {Domain: "p.example.com", Email: "a@example.com"},
+		},
+	}
+	data, err := RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{ForwardProxy: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(data)
+	if strings.Contains(s, `"basic_auth"`) {
+		t.Error("rendered JSON must not contain the Caddyfile field basic_auth")
+	}
+	if !strings.Contains(s, `"auth_credentials"`) {
+		t.Error("rendered JSON must contain the JSON field auth_credentials")
+	}
+	for _, u := range []struct{ user, pass string }{
+		{"alice", "secret-a"},
+		{"bob", "secret-b"},
+	} {
+		want := base64.StdEncoding.EncodeToString([]byte(u.user + ":" + u.pass))
+		if !strings.Contains(s, fmt.Sprintf("%q", want)) {
+			t.Errorf("expected base64 credential %q for %s", want, u.user)
+		}
+	}
+}
+
+func TestRenderCaddyJSONAdminEndpoint(t *testing.T) {
+	plan := caddyassembly.CaddyRenderPlan{
+		Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
+			{Address: "0.0.0.0", Port: 443, Network: bindregistry.ListenTCP}: {
+				Kind:        caddyassembly.CaddyOwnerPanel,
+				Domain:      "panel.example.com",
+				BackendPort: 2096,
+			},
+		},
+		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
+			"panel.example.com": {Domain: "panel.example.com", Email: "admin@example.com"},
+		},
+	}
+	data, err := RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	admin, ok := cfg["admin"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected top-level admin block, got %T", cfg["admin"])
+	}
+	if admin["listen"] != "127.0.0.1:2019" {
+		t.Errorf("admin.listen = %v, want 127.0.0.1:2019", admin["listen"])
+	}
+}
+
+func TestRenderCaddyJSONHttp01ChallengeServer(t *testing.T) {
+	plan := caddyassembly.CaddyRenderPlan{
+		Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
+			{Address: "0.0.0.0", Port: 443, Network: bindregistry.ListenTCP}: {
+				Kind:        caddyassembly.CaddyOwnerNaive,
+				Domain:      "proxy.example.com",
+				InboundName: "naive-1",
+				Transport:   "tcp",
+				NaiveUsers:  []caddyassembly.CaddyNaiveUser{{Username: "u", Password: "p"}},
+			},
+		},
+		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
+			"proxy.example.com": {Domain: "proxy.example.com", Email: "admin@example.com"},
+		},
+		ACMEChallenges: map[bindregistry.BindKey]caddyassembly.AcmeChallengeOwner{
+			{Address: "0.0.0.0", Port: 80, Network: bindregistry.ListenTCP}: {
+				ChallengeMode: "http-01",
+				Domains:       []string{"proxy.example.com"},
+			},
+		},
+		DefaultChallengeMode: "http-01",
+	}
+	data, err := RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{ForwardProxy: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	apps := cfg["apps"].(map[string]any)
+	httpApp := apps["http"].(map[string]any)
+	servers := httpApp["servers"].(map[string]any)
+	challengeServer, ok := servers["tcp-0.0.0.0-80-acme"]
+	if !ok {
+		t.Fatalf("expected HTTP-01 challenge server tcp-0.0.0.0-80-acme, got servers: %v", servers)
+	}
+	challengeServerMap := challengeServer.(map[string]any)
+	listen := challengeServerMap["listen"].([]any)
+	if len(listen) != 1 || listen[0] != ":80" {
+		t.Fatalf("expected challenge server to listen on :80, got %v", listen)
+	}
+	routes := challengeServerMap["routes"].([]any)
+	if len(routes) != 0 {
+		// Caddy handles ACME HTTP-01 challenges at the server level (before route matching),
+		// so the challenge server intentionally has no routes.
+		t.Fatalf("expected HTTP-01 challenge server to have empty routes (Caddy handles challenges at server level), got %v", routes)
+	}
+
+	tlsApp := apps["tls"].(map[string]any)
+	policies := tlsApp["automation"].(map[string]any)["policies"].([]any)
+	if len(policies) != 1 {
+		t.Fatalf("expected 1 automation policy, got %d", len(policies))
+	}
+	issuer := policies[0].(map[string]any)["issuers"].([]any)[0].(map[string]any)
+	challenges := issuer["challenges"].(map[string]any)
+	if challenges["http"].(map[string]any)["disabled"] != false {
+		t.Error("expected http challenge to be enabled for http-01 mode")
+	}
+	if challenges["tls-alpn"].(map[string]any)["disabled"] != true {
+		t.Error("expected tls-alpn challenge to be disabled for http-01 mode")
+	}
+}
+
+func TestRenderCaddyJSONHttp01ChallengeHandlerEndToEnd(t *testing.T) {
+	settings := model.Settings{
+		PanelAccess:       "direct",
+		AcmeChallengeMode: "http-01",
+		DefaultAcmeEmail:  "admin@example.com",
+	}
+	inbounds := []model.Inbound{
+		{
+			Name:     "naive-1",
+			Protocol: "naiveproxy",
+			Enabled:  true,
+			ProtocolFields: map[string]any{
+				"domain":     "proxy.example.com",
+				"transport":  "tcp",
+				"publicPort": 443,
+			},
+			Profiles: []model.ClientProfile{
+				{Name: "p1", Username: "u", Password: "p", Enabled: true},
+			},
+		},
+	}
+	plan, _, issues, err := caddyassembly.BuildFinalRenderPlan(settings, inbounds)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(issues) > 0 {
+		t.Fatalf("unexpected validation issues: %v", issues)
+	}
+
+	challengeKey := bindregistry.BindKey{Address: "0.0.0.0", Port: 80, Network: bindregistry.ListenTCP}
+	if _, ok := plan.ACMEChallenges[challengeKey]; !ok {
+		t.Fatalf("expected TCP :80 ACME challenge bind in plan, got %v", plan.ACMEChallenges)
+	}
+
+	data, err := RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{ForwardProxy: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	apps := cfg["apps"].(map[string]any)
+	servers := apps["http"].(map[string]any)["servers"].(map[string]any)
+	challengeServer := servers["tcp-0.0.0.0-80-acme"].(map[string]any)
+	routes := challengeServer["routes"].([]any)
+	if len(routes) != 0 {
+		t.Fatalf("expected HTTP-01 challenge server to have empty routes (Caddy handles challenges at server level), got %v", routes)
+	}
+}
+
+func TestRenderCaddyJSONValidatesWithCaddy(t *testing.T) {
+	if _, err := exec.LookPath("caddy"); err != nil {
+		t.Skip("caddy binary not available in PATH:", err)
+	}
+
+	plan := caddyassembly.CaddyRenderPlan{
+		Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
+			{Address: "0.0.0.0", Port: 443, Network: bindregistry.ListenTCP}: {
+				Kind:        caddyassembly.CaddyOwnerPanel,
+				Domain:      "panel.example.com",
+				BackendPort: 2096,
+			},
+		},
+		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
+			"panel.example.com": {Domain: "panel.example.com", Email: "admin@example.com"},
+		},
+	}
+	data, err := RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.json")
+	if err := os.WriteFile(cfgPath, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := exec.Command("caddy", "validate", "--config", cfgPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("caddy validate failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "Valid configuration") {
+		t.Errorf("caddy validate did not report valid configuration:\n%s", out)
+	}
+}
+
+func TestRenderCaddyJSONHttp01ValidatesWithCaddy(t *testing.T) {
+	if _, err := exec.LookPath("caddy"); err != nil {
+		t.Skip("caddy binary not available in PATH:", err)
+	}
+
+	plan := caddyassembly.CaddyRenderPlan{
+		Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
+			{Address: "0.0.0.0", Port: 443, Network: bindregistry.ListenTCP}: {
+				Kind:        caddyassembly.CaddyOwnerNaive,
+				Domain:      "proxy.example.com",
+				InboundName: "naive-1",
+				Transport:   "tcp",
+				NaiveUsers:  []caddyassembly.CaddyNaiveUser{{Username: "u", Password: "p"}},
+			},
+		},
+		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
+			"proxy.example.com": {Domain: "proxy.example.com", Email: "admin@example.com"},
+		},
+		ACMEChallenges: map[bindregistry.BindKey]caddyassembly.AcmeChallengeOwner{
+			{Address: "0.0.0.0", Port: 80, Network: bindregistry.ListenTCP}: {
+				ChallengeMode: "http-01",
+				Domains:       []string{"proxy.example.com"},
+			},
+		},
+		DefaultChallengeMode: "http-01",
+	}
+	data, err := RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{ForwardProxy: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.json")
+	if err := os.WriteFile(cfgPath, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := exec.Command("caddy", "validate", "--config", cfgPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("caddy validate failed for http-01 config: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "Valid configuration") {
+		t.Errorf("caddy validate did not report valid configuration:\n%s", out)
+	}
+}

--- a/internal/renderer/caddyjson_test.go
+++ b/internal/renderer/caddyjson_test.go
@@ -147,7 +147,7 @@ func TestRenderCaddyJSONRejectsNaiveWithoutForwardProxy(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for missing forward_proxy module")
 	}
-	want := "Caddy binary does not include the forward_proxy module required for NaiveProxy"
+	want := "caddy binary does not include the forward_proxy module required for NaiveProxy"
 	if err.Error() != want {
 		t.Fatalf("error = %q, want %q", err.Error(), want)
 	}

--- a/internal/renderer/hdd_happy_path_test.go
+++ b/internal/renderer/hdd_happy_path_test.go
@@ -84,7 +84,8 @@ func TestRenderCaddyJSON_NaiveTCP443HappyPath(t *testing.T) {
 	}
 
 	authCreds := first["auth_credentials"].([]any)
-	wantCred := base64.StdEncoding.EncodeToString([]byte("user:pass"))
+	basicValue := base64.StdEncoding.EncodeToString([]byte("user:pass"))
+	wantCred := base64.StdEncoding.EncodeToString([]byte(basicValue))
 	if len(authCreds) != 1 || authCreds[0] != wantCred {
 		t.Errorf("auth_credentials = %v, want [%s]", authCreds, wantCred)
 	}

--- a/internal/renderer/hdd_happy_path_test.go
+++ b/internal/renderer/hdd_happy_path_test.go
@@ -1,0 +1,181 @@
+package renderer_test
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/mikkelchokolate/Veil/internal/bindregistry"
+	"github.com/mikkelchokolate/Veil/internal/caddyassembly"
+	"github.com/mikkelchokolate/Veil/internal/caddycapabilities"
+	"github.com/mikkelchokolate/Veil/internal/renderer"
+)
+
+func TestRenderCaddyJSON_NaiveTCP443HappyPath(t *testing.T) {
+	plan := caddyassembly.CaddyRenderPlan{
+		Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
+			{Address: "0.0.0.0", Port: 443, Network: bindregistry.ListenTCP}: {
+				Kind:         caddyassembly.CaddyOwnerNaive,
+				Domain:       "hy.flow2go.ru",
+				InboundName:  "test",
+				Transport:    "tcp",
+				NaiveUsers:   []caddyassembly.CaddyNaiveUser{{Username: "user", Password: "pass"}},
+				FallbackRoot: "/var/lib/veil/www",
+			},
+		},
+		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
+			"hy.flow2go.ru": {
+				Domain: "hy.flow2go.ru",
+				Email:  "admin@hy.flow2go.ru",
+			},
+		},
+		DefaultChallengeMode: "tls-alpn-01",
+	}
+
+	data, err := renderer.RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{ForwardProxy: true})
+	if err != nil {
+		t.Fatalf("RenderCaddyJSON error: %v", err)
+	}
+	t.Logf("rendered Caddy JSON:\n%s", string(data))
+
+	var cfg map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("rendered JSON is invalid: %v\n%s", err, string(data))
+	}
+
+	apps := cfg["apps"].(map[string]any)
+	httpApp := apps["http"].(map[string]any)
+	servers := httpApp["servers"].(map[string]any)
+
+	serverName := "tcp-0.0.0.0-443"
+	server, ok := servers[serverName].(map[string]any)
+	if !ok {
+		t.Fatalf("expected server %s in %v", serverName, servers)
+	}
+
+	listen := server["listen"].([]any)
+	if len(listen) != 1 || listen[0] != ":443" {
+		t.Errorf("server.listen = %v, want [:443]", listen)
+	}
+
+	routes := server["routes"].([]any)
+	if len(routes) != 1 {
+		t.Fatalf("expected exactly one route, got %d", len(routes))
+	}
+	route := routes[0].(map[string]any)
+	if _, hasMatch := route["match"]; hasMatch {
+		t.Error("naive server route must not contain a host matcher")
+	}
+
+	handlers := route["handle"].([]any)
+	if len(handlers) != 2 {
+		t.Fatalf("expected 2 handlers, got %d", len(handlers))
+	}
+	first := handlers[0].(map[string]any)
+	second := handlers[1].(map[string]any)
+	if first["handler"] != "forward_proxy" {
+		t.Errorf("first handler = %v, want forward_proxy", first["handler"])
+	}
+	if second["handler"] != "file_server" {
+		t.Errorf("second handler = %v, want file_server", second["handler"])
+	}
+	if second["root"] != "/var/lib/veil/www" {
+		t.Errorf("file_server root = %v, want /var/lib/veil/www", second["root"])
+	}
+
+	authCreds := first["auth_credentials"].([]any)
+	wantCred := base64.StdEncoding.EncodeToString([]byte("user:pass"))
+	if len(authCreds) != 1 || authCreds[0] != wantCred {
+		t.Errorf("auth_credentials = %v, want [%s]", authCreds, wantCred)
+	}
+
+	tlsApp := apps["tls"].(map[string]any)
+	automation := tlsApp["automation"].(map[string]any)
+	policies := automation["policies"].([]any)
+	if len(policies) != 1 {
+		t.Fatalf("expected 1 automation policy, got %d", len(policies))
+	}
+	policy := policies[0].(map[string]any)
+	subjects := policy["subjects"].([]any)
+	if len(subjects) != 1 || subjects[0] != "hy.flow2go.ru" {
+		t.Errorf("policy.subjects = %v, want [hy.flow2go.ru]", subjects)
+	}
+	issuers := policy["issuers"].([]any)
+	if len(issuers) != 1 {
+		t.Fatalf("expected 1 issuer, got %d", len(issuers))
+	}
+	issuer := issuers[0].(map[string]any)
+	if issuer["module"] != "acme" {
+		t.Errorf("issuer.module = %v, want acme", issuer["module"])
+	}
+	if issuer["email"] != "admin@hy.flow2go.ru" {
+		t.Errorf("issuer.email = %v, want admin@hy.flow2go.ru", issuer["email"])
+	}
+	challenges := issuer["challenges"].(map[string]any)
+	httpChallenge := challenges["http"].(map[string]any)
+	tlsAlpnChallenge := challenges["tls-alpn"].(map[string]any)
+	if httpChallenge["disabled"] != true {
+		t.Error("http challenge must be disabled for tls-alpn-01 mode")
+	}
+	if tlsAlpnChallenge["disabled"] != false {
+		t.Error("tls-alpn challenge must be enabled for tls-alpn-01 mode")
+	}
+}
+
+// TestRenderCaddyJSON_SameDomainTwoServersSharesCert verifies that two naive
+// inbounds using the same domain on different ports render distinct servers
+// while sharing a single TLS automation policy.
+func TestRenderCaddyJSON_SameDomainTwoServersSharesCert(t *testing.T) {
+	plan := caddyassembly.CaddyRenderPlan{
+		Servers: map[bindregistry.BindKey]caddyassembly.CaddyBindOwner{
+			{Address: "0.0.0.0", Port: 443, Network: bindregistry.ListenTCP}: {
+				Kind:        caddyassembly.CaddyOwnerNaive,
+				Domain:      "hy.flow2go.ru",
+				InboundName: "test-a",
+				Transport:   "tcp",
+				NaiveUsers:  []caddyassembly.CaddyNaiveUser{{Username: "user-a", Password: "pass-a"}},
+			},
+			{Address: "0.0.0.0", Port: 8443, Network: bindregistry.ListenTCP}: {
+				Kind:        caddyassembly.CaddyOwnerNaive,
+				Domain:      "hy.flow2go.ru",
+				InboundName: "test-b",
+				Transport:   "tcp",
+				NaiveUsers:  []caddyassembly.CaddyNaiveUser{{Username: "user-b", Password: "pass-b"}},
+			},
+		},
+		Domains: map[string]caddyassembly.CaddyDomainCertSpec{
+			"hy.flow2go.ru": {
+				Domain: "hy.flow2go.ru",
+				Email:  "admin@hy.flow2go.ru",
+			},
+		},
+		DefaultChallengeMode: "tls-alpn-01",
+	}
+
+	data, err := renderer.RenderCaddyJSON(plan, caddycapabilities.CaddyCapabilities{ForwardProxy: true})
+	if err != nil {
+		t.Fatalf("RenderCaddyJSON error: %v", err)
+	}
+
+	var cfg map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("rendered JSON is invalid: %v\n%s", err, string(data))
+	}
+
+	apps := cfg["apps"].(map[string]any)
+	servers := apps["http"].(map[string]any)["servers"].(map[string]any)
+	if len(servers) != 2 {
+		t.Fatalf("expected 2 servers, got %d", len(servers))
+	}
+
+	tlsApp := apps["tls"].(map[string]any)
+	policies := tlsApp["automation"].(map[string]any)["policies"].([]any)
+	if len(policies) != 1 {
+		t.Fatalf("expected 1 shared automation policy, got %d", len(policies))
+	}
+	policy := policies[0].(map[string]any)
+	subjects := policy["subjects"].([]any)
+	if len(subjects) != 1 || subjects[0] != "hy.flow2go.ru" {
+		t.Errorf("policy.subjects = %v, want [hy.flow2go.ru]", subjects)
+	}
+}

--- a/internal/renderer/hysteria2.go
+++ b/internal/renderer/hysteria2.go
@@ -3,7 +3,8 @@ package renderer
 import (
 	"bytes"
 	"errors"
-	"text/template"
+
+	"gopkg.in/yaml.v3"
 )
 
 type Hysteria2User struct {
@@ -25,6 +26,33 @@ type Hysteria2Config struct {
 	// just works" hold for Hysteria2.
 	CertPath string
 	KeyPath  string
+}
+
+type hysteria2YAML struct {
+	Listen string `yaml:"listen"`
+	TLS    struct {
+		Cert string `yaml:"cert"`
+		Key  string `yaml:"key"`
+	} `yaml:"tls"`
+	Auth struct {
+		Type     string            `yaml:"type"`
+		Password string            `yaml:"password,omitempty"`
+		UserPass map[string]string `yaml:"userpass,omitempty"`
+	} `yaml:"auth"`
+	Masquerade struct {
+		Type  string `yaml:"type"`
+		Proxy struct {
+			URL         string `yaml:"url"`
+			RewriteHost bool   `yaml:"rewriteHost"`
+		} `yaml:"proxy"`
+	} `yaml:"masquerade"`
+	Outbounds []struct {
+		Name   string `yaml:"name"`
+		Type   string `yaml:"type"`
+		Socks5 struct {
+			Addr string `yaml:"addr"`
+		} `yaml:"socks5"`
+	} `yaml:"outbounds,omitempty"`
 }
 
 func RenderHysteria2(cfg Hysteria2Config) (string, error) {
@@ -51,46 +79,68 @@ func RenderHysteria2(cfg Hysteria2Config) (string, error) {
 	if cfg.KeyPath == "" {
 		cfg.KeyPath = "/etc/veil/panel/tls.key"
 	}
-	const tpl = `listen: :{{ .ListenPort }}
 
-# TLS certificate served by Hysteria2. When Panel access is set to "caddy",
-# Veil copies Caddy's managed Let's Encrypt certificate here automatically.
-# Otherwise Veil's self-signed panel certificate is used and clients connect
-# with insecure + SNI (see the generated client link).
-tls:
-  cert: {{ .CertPath }}
-  key: {{ .KeyPath }}
+	var doc hysteria2YAML
+	doc.Listen = ":" + itoa(cfg.ListenPort)
+	doc.TLS.Cert = cfg.CertPath
+	doc.TLS.Key = cfg.KeyPath
+	if len(cfg.Users) > 0 {
+		doc.Auth.Type = "userpass"
+		doc.Auth.UserPass = make(map[string]string, len(cfg.Users))
+		for _, u := range cfg.Users {
+			doc.Auth.UserPass[u.Username] = u.Password
+		}
+	} else {
+		doc.Auth.Type = "password"
+		doc.Auth.Password = cfg.Password
+	}
+	doc.Masquerade.Type = "proxy"
+	doc.Masquerade.Proxy.URL = cfg.MasqueradeURL
+	doc.Masquerade.Proxy.RewriteHost = true
+	if cfg.Upstream != "" {
+		var ob struct {
+			Name   string `yaml:"name"`
+			Type   string `yaml:"type"`
+			Socks5 struct {
+				Addr string `yaml:"addr"`
+			} `yaml:"socks5"`
+		}
+		ob.Name = "veil-upstream"
+		ob.Type = "socks5"
+		ob.Socks5.Addr = cfg.Upstream
+		doc.Outbounds = append(doc.Outbounds, ob)
+	}
 
-# Password authentication is simple and broadly compatible with Hysteria2 clients.
-auth:
-{{- if .Users }}
-  type: userpass
-  userpass:
-{{- range .Users }}
-    {{ .Username }}: {{ .Password }}
-{{- end }}
-{{- else }}
-  type: password
-  password: {{ .Password }}
-{{- end }}
-
-masquerade:
-  type: proxy
-  proxy:
-    url: {{ .MasqueradeURL }}
-    rewriteHost: true
-
-{{- if .Upstream }}
-outbounds:
-  - name: veil-upstream
-    type: socks5
-    socks5:
-      addr: {{ .Upstream }}
-{{- end }}
-`
 	var out bytes.Buffer
-	if err := template.Must(template.New("hysteria2").Parse(tpl)).Execute(&out, cfg); err != nil {
+	enc := yaml.NewEncoder(&out)
+	enc.SetIndent(2)
+	if err := enc.Encode(doc); err != nil {
+		return "", err
+	}
+	if err := enc.Close(); err != nil {
 		return "", err
 	}
 	return out.String(), nil
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	neg := i < 0
+	if neg {
+		i = -i
+	}
+	var buf [20]byte
+	pos := len(buf)
+	for i > 0 {
+		pos--
+		buf[pos] = byte('0' + i%10)
+		i /= 10
+	}
+	if neg {
+		pos--
+		buf[pos] = '-'
+	}
+	return string(buf[pos:])
 }

--- a/internal/renderer/hysteria2_test.go
+++ b/internal/renderer/hysteria2_test.go
@@ -101,6 +101,19 @@ func TestRenderHysteria2RejectsZeroListenPort(t *testing.T) {
 	}
 }
 
+func TestRenderHysteria2EscapesPasswordWithYAMLMetacharacters(t *testing.T) {
+	out, err := RenderHysteria2(Hysteria2Config{ListenPort: 443, Password: "p@ss \"w0rd\nnewline"})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	// The password must be a single YAML scalar; yaml.v3 may use a literal block
+	// for multiline strings. Either form is valid as long as the value is not
+	// interpreted as YAML structure.
+	if !strings.Contains(out, "password: |-") && !strings.Contains(out, "password: \"") {
+		t.Fatalf("password not properly escaped as YAML scalar: %s", out)
+	}
+}
+
 func TestRenderHysteria2RejectsNegativeListenPort(t *testing.T) {
 	_, err := RenderHysteria2(Hysteria2Config{
 		ListenPort: -1,

--- a/internal/renderer/mieru.go
+++ b/internal/renderer/mieru.go
@@ -24,7 +24,6 @@ type mieruServerConfigJSON struct {
 	PortBindings []mieruPortBindingJSON `json:"portBindings"`
 	Users        []mieruUserJSON        `json:"users"`
 	LoggingLevel string                 `json:"loggingLevel"`
-	MTU          int                    `json:"mtu,omitempty"`
 }
 
 type mieruPortBindingJSON struct {
@@ -47,10 +46,8 @@ func RenderMieru(cfg MieruConfig) (string, error) {
 	out := mieruServerConfigJSON{LoggingLevel: "INFO"}
 	seenBindings := make(map[mieruPortBindingJSON]struct{}, len(cfg.PortBindings))
 	for _, binding := range cfg.PortBindings {
-		// mita rejects privileged and out-of-range ports. Fail during the Veil
-		// apply plan instead of discovering the error only after service restart.
-		if binding.Port < 1025 || binding.Port > 65535 {
-			return "", errors.New("mieru port must be between 1025 and 65535")
+		if binding.Port < 1 || binding.Port > 65535 {
+			return "", errors.New("mieru port must be between 1 and 65535")
 		}
 		protocol := normalizeMieruProtocol(binding.Protocol)
 		if protocol != "TCP" && protocol != "UDP" {
@@ -63,15 +60,18 @@ func RenderMieru(cfg MieruConfig) (string, error) {
 		seenBindings[candidate] = struct{}{}
 		out.PortBindings = append(out.PortBindings, candidate)
 	}
-	seenUsers := make(map[string]struct{}, len(cfg.Users))
+	seenUsers := make(map[string]string, len(cfg.Users))
 	for _, user := range cfg.Users {
 		if user.Name == "" || user.Password == "" {
 			return "", errors.New("mieru user name and password are required")
 		}
-		if _, exists := seenUsers[user.Name]; exists {
-			return "", errors.New("mieru user names must be unique")
+		if password, exists := seenUsers[user.Name]; exists {
+			if password != user.Password {
+				return "", errors.New("mieru user name has conflicting passwords")
+			}
+			continue
 		}
-		seenUsers[user.Name] = struct{}{}
+		seenUsers[user.Name] = user.Password
 		out.Users = append(out.Users, mieruUserJSON(user))
 	}
 	body, err := json.MarshalIndent(out, "", "  ")

--- a/internal/renderer/mieru.go
+++ b/internal/renderer/mieru.go
@@ -46,7 +46,10 @@ func RenderMieru(cfg MieruConfig) (string, error) {
 	out := mieruServerConfigJSON{LoggingLevel: "INFO"}
 	seenBindings := make(map[mieruPortBindingJSON]struct{}, len(cfg.PortBindings))
 	for _, binding := range cfg.PortBindings {
-		if binding.Port < 1 || binding.Port > 65535 {
+		if binding.Port <= 0 {
+			return "", errors.New("mieru port is required")
+		}
+		if binding.Port > 65535 {
 			return "", errors.New("mieru port must be between 1 and 65535")
 		}
 		protocol := normalizeMieruProtocol(binding.Protocol)

--- a/internal/renderer/mieru.go
+++ b/internal/renderer/mieru.go
@@ -24,6 +24,7 @@ type mieruServerConfigJSON struct {
 	PortBindings []mieruPortBindingJSON `json:"portBindings"`
 	Users        []mieruUserJSON        `json:"users"`
 	LoggingLevel string                 `json:"loggingLevel"`
+	MTU          int                    `json:"mtu,omitempty"`
 }
 
 type mieruPortBindingJSON struct {
@@ -44,20 +45,33 @@ func RenderMieru(cfg MieruConfig) (string, error) {
 		return "", errors.New("at least one mieru user is required")
 	}
 	out := mieruServerConfigJSON{LoggingLevel: "INFO"}
+	seenBindings := make(map[mieruPortBindingJSON]struct{}, len(cfg.PortBindings))
 	for _, binding := range cfg.PortBindings {
-		if binding.Port <= 0 {
-			return "", errors.New("mieru port is required")
+		// mita rejects privileged and out-of-range ports. Fail during the Veil
+		// apply plan instead of discovering the error only after service restart.
+		if binding.Port < 1025 || binding.Port > 65535 {
+			return "", errors.New("mieru port must be between 1025 and 65535")
 		}
 		protocol := normalizeMieruProtocol(binding.Protocol)
 		if protocol != "TCP" && protocol != "UDP" {
 			return "", errors.New("mieru protocol must be TCP or UDP")
 		}
-		out.PortBindings = append(out.PortBindings, mieruPortBindingJSON{Port: binding.Port, Protocol: protocol})
+		candidate := mieruPortBindingJSON{Port: binding.Port, Protocol: protocol}
+		if _, exists := seenBindings[candidate]; exists {
+			continue
+		}
+		seenBindings[candidate] = struct{}{}
+		out.PortBindings = append(out.PortBindings, candidate)
 	}
+	seenUsers := make(map[string]struct{}, len(cfg.Users))
 	for _, user := range cfg.Users {
 		if user.Name == "" || user.Password == "" {
 			return "", errors.New("mieru user name and password are required")
 		}
+		if _, exists := seenUsers[user.Name]; exists {
+			return "", errors.New("mieru user names must be unique")
+		}
+		seenUsers[user.Name] = struct{}{}
 		out.Users = append(out.Users, mieruUserJSON(user))
 	}
 	body, err := json.MarshalIndent(out, "", "  ")

--- a/internal/renderer/mieru_client.go
+++ b/internal/renderer/mieru_client.go
@@ -1,6 +1,10 @@
 package renderer
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"net"
+	"strings"
+)
 
 type MieruClientConfig struct {
 	ProfileName   string
@@ -16,7 +20,7 @@ type mieruClientConfigJSON struct {
 	ActiveProfile string                   `json:"activeProfile"`
 	Profiles      []mieruClientProfileJSON `json:"profiles"`
 	Socks5Port    int                      `json:"socks5Port"`
-	HTTPProxyPort int                      `json:"httpProxyPort"`
+	HTTPProxyPort int                      `json:"httpProxyPort,omitempty"`
 	RPCPort       int                      `json:"rpcPort"`
 }
 
@@ -27,20 +31,25 @@ type mieruClientProfileJSON struct {
 }
 
 type mieruClientServer struct {
-	DomainName   string                 `json:"domainName"`
+	IPAddress    string                 `json:"ipAddress,omitempty"`
+	DomainName   string                 `json:"domainName,omitempty"`
 	PortBindings []mieruPortBindingJSON `json:"portBindings"`
 }
 
 func RenderMieruClient(cfg MieruClientConfig) (string, error) {
+	server := mieruClientServer{PortBindings: mieruClientPortBindings(cfg.PortBindings)}
+	endpoint := strings.TrimSpace(cfg.DomainName)
+	if ip := net.ParseIP(strings.Trim(endpoint, "[]")); ip != nil {
+		server.IPAddress = ip.String()
+	} else {
+		server.DomainName = endpoint
+	}
 	body := mieruClientConfigJSON{
 		ActiveProfile: cfg.ProfileName,
 		Profiles: []mieruClientProfileJSON{{
 			ProfileName: cfg.ProfileName,
 			User:        mieruUserJSON{Name: cfg.User.Name, Password: cfg.User.Password},
-			Servers: []mieruClientServer{{
-				DomainName:   cfg.DomainName,
-				PortBindings: mieruClientPortBindings(cfg.PortBindings),
-			}},
+			Servers:     []mieruClientServer{server},
 		}},
 		Socks5Port:    cfg.Socks5Port,
 		HTTPProxyPort: cfg.HTTPProxyPort,

--- a/internal/renderer/olcrtc.go
+++ b/internal/renderer/olcrtc.go
@@ -3,7 +3,8 @@ package renderer
 import (
 	"bytes"
 	"errors"
-	"text/template"
+
+	"gopkg.in/yaml.v3"
 )
 
 type OlcrtcConfig struct {
@@ -12,6 +13,24 @@ type OlcrtcConfig struct {
 	Key       string
 	Transport string
 	DNS       string
+}
+
+type olcrtcYAML struct {
+	Mode string `yaml:"mode"`
+	Auth struct {
+		Provider string `yaml:"provider"`
+	} `yaml:"auth"`
+	Room struct {
+		ID string `yaml:"id"`
+	} `yaml:"room"`
+	Crypto struct {
+		Key string `yaml:"key"`
+	} `yaml:"crypto"`
+	Net struct {
+		Transport string `yaml:"transport"`
+		DNS       string `yaml:"dns"`
+	} `yaml:"net"`
+	Data string `yaml:"data"`
 }
 
 func RenderOlcrtc(cfg OlcrtcConfig) (string, error) {
@@ -24,24 +43,23 @@ func RenderOlcrtc(cfg OlcrtcConfig) (string, error) {
 	if cfg.DNS == "" {
 		cfg.DNS = "1.1.1.1:53"
 	}
-	const tpl = `mode: srv
-auth:
-  provider: {{ .Auth }}
-room:
-  id: "{{ .RoomID }}"
-crypto:
-  key: "{{ .Key }}"
-net:
-  transport: {{ .Transport }}
-  dns: "{{ .DNS }}"
-data: data
-`
+
+	var doc olcrtcYAML
+	doc.Mode = "srv"
+	doc.Auth.Provider = cfg.Auth
+	doc.Room.ID = cfg.RoomID
+	doc.Crypto.Key = cfg.Key
+	doc.Net.Transport = cfg.Transport
+	doc.Net.DNS = cfg.DNS
+	doc.Data = "data"
+
 	var out bytes.Buffer
-	t, err := template.New("olcrtc").Parse(tpl)
-	if err != nil {
+	enc := yaml.NewEncoder(&out)
+	enc.SetIndent(2)
+	if err := enc.Encode(doc); err != nil {
 		return "", err
 	}
-	if err := t.Execute(&out, cfg); err != nil {
+	if err := enc.Close(); err != nil {
 		return "", err
 	}
 	return out.String(), nil

--- a/internal/renderer/olcrtc_test.go
+++ b/internal/renderer/olcrtc_test.go
@@ -19,10 +19,10 @@ func TestRenderOlcrtcProducesValidServerYAML(t *testing.T) {
 	for _, want := range []string{
 		"mode: srv",
 		"provider: jitsi",
-		"id: \"https://meet.example.com/myroom\"",
-		"key: \"abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789\"",
+		"id: https://meet.example.com/myroom",
+		"key: abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
 		"transport: datachannel",
-		"dns: \"1.1.1.1:53\"",
+		"dns: 1.1.1.1:53",
 		"data: data",
 	} {
 		if !strings.Contains(body, want) {
@@ -52,7 +52,7 @@ func TestRenderOlcrtcDefaultsDNS(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RenderOlcrtc: %v", err)
 	}
-	if !strings.Contains(body, `dns: "1.1.1.1:53"`) {
+	if !strings.Contains(body, "dns: 1.1.1.1:53") {
 		t.Fatalf("expected default DNS:\n%s", body)
 	}
 }

--- a/internal/renderer/protocol_runtime_regression_test.go
+++ b/internal/renderer/protocol_runtime_regression_test.go
@@ -19,7 +19,8 @@ func TestRenderNaiveCaddyfileUsesPublicTLSOnly(t *testing.T) {
 	}
 	for _, want := range []string{
 		":443, vpn.example.com {",
-		"tls admin@example.com",
+		"issuer acme",
+		"email admin@example.com",
 		"encode",
 		"forward_proxy",
 		"probe_resistance",

--- a/internal/renderer/protocol_runtime_regression_test.go
+++ b/internal/renderer/protocol_runtime_regression_test.go
@@ -1,0 +1,96 @@
+package renderer
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestRenderNaiveCaddyfileUsesPublicTLSOnly(t *testing.T) {
+	body, err := RenderNaiveCaddyfile(NaiveConfig{
+		Domain:     "vpn.example.com",
+		Email:      "admin@example.com",
+		ListenPort: 443,
+		Username:   "alice",
+		Password:   "secret",
+	})
+	if err != nil {
+		t.Fatalf("RenderNaiveCaddyfile: %v", err)
+	}
+	for _, want := range []string{
+		":443, vpn.example.com {",
+		"tls admin@example.com",
+		"encode",
+		"forward_proxy",
+		"probe_resistance",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("Caddyfile missing %q:\n%s", want, body)
+		}
+	}
+	if strings.Contains(body, "issuer internal") {
+		t.Fatalf("production NaiveProxy Caddyfile must not silently issue an untrusted internal certificate:\n%s", body)
+	}
+}
+
+func TestRenderMieruClientUsesIPAddressForLiteralIP(t *testing.T) {
+	body, err := RenderMieruClient(MieruClientConfig{
+		ProfileName:  "default",
+		DomainName:   "127.0.0.1",
+		PortBindings: []MieruPortBinding{{Port: 8443, Protocol: "udp"}},
+		User:         MieruUser{Name: "alice", Password: "secret"},
+		Socks5Port:   1080,
+		RPCPort:      8964,
+	})
+	if err != nil {
+		t.Fatalf("RenderMieruClient: %v", err)
+	}
+	var decoded struct {
+		Profiles []struct {
+			Servers []struct {
+				IPAddress  string `json:"ipAddress"`
+				DomainName string `json:"domainName"`
+			} `json:"servers"`
+		} `json:"profiles"`
+	}
+	if err := json.Unmarshal([]byte(body), &decoded); err != nil {
+		t.Fatalf("decode config: %v", err)
+	}
+	server := decoded.Profiles[0].Servers[0]
+	if server.IPAddress != "127.0.0.1" || server.DomainName != "" {
+		t.Fatalf("server endpoint = ip %q domain %q", server.IPAddress, server.DomainName)
+	}
+}
+
+func TestRenderMieruClientUsesDomainNameForHostname(t *testing.T) {
+	body, err := RenderMieruClient(MieruClientConfig{
+		ProfileName:  "default",
+		DomainName:   "vpn.example.com",
+		PortBindings: []MieruPortBinding{{Port: 443, Protocol: "tcp"}},
+		User:         MieruUser{Name: "alice", Password: "secret"},
+		Socks5Port:   1080,
+		RPCPort:      8964,
+	})
+	if err != nil {
+		t.Fatalf("RenderMieruClient: %v", err)
+	}
+	if !strings.Contains(body, `"domainName": "vpn.example.com"`) {
+		t.Fatalf("client config missing domain endpoint:\n%s", body)
+	}
+	if strings.Contains(body, `"ipAddress"`) {
+		t.Fatalf("client config unexpectedly contains ipAddress:\n%s", body)
+	}
+}
+
+func TestRenderMieruRejectsConflictingDuplicateUser(t *testing.T) {
+	_, err := RenderMieru(MieruConfig{
+		PortBindings: []MieruPortBinding{{Port: 443, Protocol: "tcp"}},
+		Users: []MieruUser{
+			{Name: "alice", Password: "one"},
+			{Name: "alice", Password: "two"},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "conflicting passwords") {
+		t.Fatalf("error = %v, want conflicting password error", err)
+	}
+}

--- a/internal/renderer/systemd.go
+++ b/internal/renderer/systemd.go
@@ -4,7 +4,7 @@ import "path"
 
 const (
 	UnitVeil          = "veil.service"
-	UnitCaddy         = "veil-caddy@.service"
+	UnitCaddy         = "veil-caddy.service"
 	UnitHysteria2     = "veil-hysteria2@.service"
 	UnitOlcrtc        = "veil-olcrtc@.service"
 	UnitWarp          = "veil-warp.service"
@@ -61,7 +61,7 @@ func RenderSystemdUnits(cfg SystemdConfig) map[string]string {
 	if cfg.EtcDir == "" {
 		cfg.EtcDir = "/etc/veil"
 	}
-	caddyfile := path.Join(cfg.EtcDir, "generated", "caddy", "%i.Caddyfile")
+	caddyConfig := path.Join(cfg.EtcDir, "generated", "caddy", "config.json")
 	hysteriaConfig := path.Join(cfg.EtcDir, "generated", "hysteria2", "%i.yaml")
 	olcrtcConfig := path.Join(cfg.EtcDir, "generated", "olcrtc", "%i.yaml")
 	warpConfig := path.Join(cfg.EtcDir, "generated", "sing-box", "warp.json")
@@ -163,7 +163,7 @@ RemoveOnStop=true
 WantedBy=sockets.target
 `,
 		UnitCaddy: `[Unit]
-Description=Veil managed NaiveProxy/Caddy (%i)
+Description=Veil managed NaiveProxy/Caddy
 After=network-online.target
 Wants=network-online.target
 
@@ -176,8 +176,8 @@ Type=simple
 # internal-CA fallback.
 StateDirectory=caddy
 Environment=HOME=/var/lib/caddy XDG_DATA_HOME=/var/lib/caddy XDG_CONFIG_HOME=/var/lib/caddy
-ExecStart=` + cfg.CaddyBinary + ` run --config ` + caddyfile + ` --adapter caddyfile
-ExecReload=` + cfg.CaddyBinary + ` reload --config ` + caddyfile + ` --adapter caddyfile
+ExecStart=` + cfg.CaddyBinary + ` run --config ` + caddyConfig + `
+ExecReload=` + cfg.CaddyBinary + ` reload --config ` + caddyConfig + `
 Restart=on-failure
 RestartSec=3
 NoNewPrivileges=true

--- a/internal/renderer/systemd_test.go
+++ b/internal/renderer/systemd_test.go
@@ -83,8 +83,8 @@ func TestRenderSystemdUnits(t *testing.T) {
 	if !strings.Contains(units["veil.service"], "EnvironmentFile=-/etc/veil/veil.env") {
 		t.Fatalf("expected veil env file in unit:\n%s", units["veil.service"])
 	}
-	if !strings.Contains(units["veil-caddy@.service"], "/etc/veil/generated/caddy/%i.Caddyfile") {
-		t.Fatalf("bad caddy unit:\n%s", units["veil-caddy@.service"])
+	if !strings.Contains(units["veil-caddy.service"], "/etc/veil/generated/caddy/config.json") {
+		t.Fatalf("bad caddy unit:\n%s", units["veil-caddy.service"])
 	}
 	if !strings.Contains(units["veil-hysteria2@.service"], "/etc/veil/generated/hysteria2/%i.yaml") {
 		t.Fatalf("bad hysteria2 unit:\n%s", units["veil-hysteria2@.service"])
@@ -115,13 +115,13 @@ func TestRenderSystemdUnitsDefaults(t *testing.T) {
 		t.Fatalf("veil.service: expected default EtcDir env file, got:\n%s", veilUnit)
 	}
 
-	// veil-caddy@.service: default CaddyBinary and EtcDir config path
-	naiveUnit := units["veil-caddy@.service"]
-	if !strings.Contains(naiveUnit, "ExecStart=/usr/local/bin/caddy run --config /etc/veil/generated/caddy/%i.Caddyfile") {
-		t.Fatalf("veil-caddy@.service: expected default CaddyBinary and EtcDir, got:\n%s", naiveUnit)
+	// veil-caddy.service: default CaddyBinary and EtcDir config path
+	naiveUnit := units["veil-caddy.service"]
+	if !strings.Contains(naiveUnit, "ExecStart=/usr/local/bin/caddy run --config /etc/veil/generated/caddy/config.json") {
+		t.Fatalf("veil-caddy.service: expected default CaddyBinary and EtcDir, got:\n%s", naiveUnit)
 	}
-	if !strings.Contains(naiveUnit, "ExecReload=/usr/local/bin/caddy reload --config /etc/veil/generated/caddy/%i.Caddyfile") {
-		t.Fatalf("veil-caddy@.service: expected default CaddyBinary reload, got:\n%s", naiveUnit)
+	if !strings.Contains(naiveUnit, "ExecReload=/usr/local/bin/caddy reload --config /etc/veil/generated/caddy/config.json") {
+		t.Fatalf("veil-caddy.service: expected default CaddyBinary reload, got:\n%s", naiveUnit)
 	}
 
 	// veil-hysteria2@.service: default HysteriaBinary and EtcDir config path

--- a/internal/service/managed_runtime_catalog.go
+++ b/internal/service/managed_runtime_catalog.go
@@ -82,7 +82,7 @@ func (c ManagedRuntimeCatalog) AllowsPromotedAction(command []string) bool {
 	if len(command) != 3 || command[0] != "systemctl" {
 		return false
 	}
-	if isLifecycleAction(command[1]) && c.allowsLifecycleUnit(command[2]) {
+	if isLifecycleAction(command[1]) && (c.allowsLifecycleUnit(command[2]) || isLegacyCaddyLifecycleUnit(command[2])) {
 		return true
 	}
 	for _, runtime := range c.runtimes {
@@ -108,6 +108,13 @@ func (c ManagedRuntimeCatalog) LifecycleUnitPrefixes() []string {
 			seen[prefix] = true
 			prefixes = append(prefixes, prefix)
 		}
+	}
+	// Preserve the legacy per-instance Caddy template prefix so orphan cleanup
+	// and rollback can stop/disable old veil-caddy@*.service units after the
+	// redesign moves to a single veil-caddy.service.
+	if !seen["veil-caddy@"] {
+		seen["veil-caddy@"] = true
+		prefixes = append(prefixes, "veil-caddy@")
 	}
 	return prefixes
 }
@@ -135,6 +142,19 @@ func (c ManagedRuntimeCatalog) allowsLifecycleUnit(unit string) bool {
 
 func isLifecycleAction(action string) bool {
 	return action == "stop" || action == "disable" || action == "start" || action == "enable"
+}
+
+// isLegacyCaddyLifecycleUnit allows lifecycle actions on the consolidated
+// veil-caddy.service and on legacy per-instance veil-caddy@*.service units so
+// rollback and orphan cleanup can tear them down.
+func isLegacyCaddyLifecycleUnit(unit string) bool {
+	if !strings.HasSuffix(unit, ".service") {
+		return false
+	}
+	if unit == "veil-caddy.service" {
+		return true
+	}
+	return strings.HasPrefix(unit, "veil-caddy@") && !strings.ContainsAny(unit, `/\; "'`)
 }
 
 func lifecycleUnitPrefix(unit string) (string, bool) {

--- a/internal/settings/settings_validation.go
+++ b/internal/settings/settings_validation.go
@@ -138,10 +138,17 @@ func (v SettingsValidation) normalizeProtocolFields(settings *Settings, current 
 }
 
 func protocolFieldUpdateValue(settings *Settings, f schema.FieldSchema) (any, bool) {
+	// A schema key that is also a dedicated top-level Settings field (e.g.
+	// panelAccess) must prefer the explicit top-level value. Echoing back a
+	// redacted GET response leaves a stale ProtocolFields[key] that would
+	// otherwise silently override the top-level change the user requested.
+	if v, ok := flatFieldValue(*settings, f.Key); ok {
+		return v, true
+	}
 	if v, ok := settings.ProtocolFields[f.Key]; ok {
 		return v, true
 	}
-	return flatFieldValue(*settings, f.Key)
+	return nil, false
 }
 
 func flatFieldValue(settings Settings, key string) (any, bool) {

--- a/internal/settings/settings_validation_panelaccess_test.go
+++ b/internal/settings/settings_validation_panelaccess_test.go
@@ -1,0 +1,43 @@
+package settings
+
+import (
+	"testing"
+
+	"github.com/mikkelchokolate/Veil/internal/protocols/schema"
+)
+
+// A schema key that is also a dedicated top-level Settings field (e.g.
+// panelAccess) must prefer the explicit top-level value. Echoing back a
+// redacted GET response leaves a stale ProtocolFields[key] that would
+// otherwise silently override the top-level change the user requested.
+func TestPanelAccessTopLevelOverridesStaleProtocolField(t *testing.T) {
+	schemas := []schema.FieldSchema{{Key: "panelAccess", Type: schema.FieldSelect, Scope: "settings", Default: "local"}}
+	v := NewSettingsValidationWithFieldSchemas(schemas)
+	current := Settings{PanelListen: "127.0.0.1:2096", Mode: "server", PanelAccess: "caddy", WebBasePath: "/x/", Domain: "d.example.com", Email: "e@example.com"}
+	current.ProtocolFields = map[string]any{"panelAccess": "caddy"}
+	// echo of GET (stale pf.panelAccess=caddy) + user intent top-level direct
+	update := Settings{PanelListen: "0.0.0.0:2096", Mode: "server", PanelAccess: "direct", WebBasePath: "/x/", Domain: "d.example.com", Email: "e@example.com"}
+	update.ProtocolFields = map[string]any{"panelAccess": "caddy"}
+	if err := v.NormalizeAndValidate(&update, current); err != nil {
+		t.Fatal(err)
+	}
+	if update.PanelAccess != "direct" {
+		t.Fatalf("expected top-level panelAccess=direct to win, got %q", update.PanelAccess)
+	}
+}
+
+// ProtocolFields must still be honoured when no dedicated top-level field
+// holds a value for the key (the original code path for protocol-only keys).
+func TestProtocolFieldValueFallsBackToProtocolFields(t *testing.T) {
+	schemas := []schema.FieldSchema{{Key: "customOnly", Type: schema.FieldText, Scope: "settings"}}
+	v := NewSettingsValidationWithFieldSchemas(schemas)
+	current := Settings{PanelListen: "127.0.0.1:2096", Mode: "server"}
+	update := Settings{PanelListen: "127.0.0.1:2096", Mode: "server"}
+	update.ProtocolFields = map[string]any{"customOnly": "kept"}
+	if err := v.NormalizeAndValidate(&update, current); err != nil {
+		t.Fatal(err)
+	}
+	if got := update.ProtocolFields["customOnly"]; got != "kept" {
+		t.Fatalf("expected protocolFields.customOnly=kept, got %v", got)
+	}
+}

--- a/packaging/nfpm.yaml
+++ b/packaging/nfpm.yaml
@@ -45,8 +45,8 @@ contents:
   - src: packaging/systemd/veil-backup.timer
     dst: /lib/systemd/system/veil-backup.timer
     type: config
-  - src: packaging/systemd/veil-caddy@.service
-    dst: /lib/systemd/system/veil-caddy@.service
+  - src: packaging/systemd/veil-caddy.service
+    dst: /lib/systemd/system/veil-caddy.service
     type: config
   - src: packaging/systemd/veil-hysteria2@.service
     dst: /lib/systemd/system/veil-hysteria2@.service

--- a/packaging/scripts/preremove.sh
+++ b/packaging/scripts/preremove.sh
@@ -31,7 +31,7 @@ if command -v systemctl >/dev/null 2>&1; then
     stop_disable_unit veil-mieru.service
     stop_disable_unit veil-warp.service
 
-    stop_disable_matching_units 'veil-caddy@*.service'
+    stop_disable_unit veil-caddy.service
     stop_disable_matching_units 'veil-hysteria2@*.service'
     stop_disable_matching_units 'veil-olcrtc@*.service'
 fi

--- a/packaging/systemd/veil-caddy.service
+++ b/packaging/systemd/veil-caddy.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Veil managed NaiveProxy/Caddy (%i)
+Description=Veil managed NaiveProxy/Caddy
 After=network-online.target
 Wants=network-online.target
 
@@ -12,8 +12,8 @@ Type=simple
 # internal-CA fallback.
 StateDirectory=caddy
 Environment=HOME=/var/lib/caddy XDG_DATA_HOME=/var/lib/caddy XDG_CONFIG_HOME=/var/lib/caddy
-ExecStart=/usr/local/bin/caddy run --config /etc/veil/generated/caddy/%i.Caddyfile --adapter caddyfile
-ExecReload=/usr/local/bin/caddy reload --config /etc/veil/generated/caddy/%i.Caddyfile --adapter caddyfile
+ExecStart=/usr/local/bin/caddy run --config /etc/veil/generated/caddy/config.json
+ExecReload=/usr/local/bin/caddy reload --config /etc/veil/generated/caddy/config.json
 Restart=on-failure
 RestartSec=3
 NoNewPrivileges=true

--- a/scripts/package-smoke.sh
+++ b/scripts/package-smoke.sh
@@ -49,7 +49,7 @@ run_deb_smoke() {
       apt-get install -y ca-certificates
       dpkg -i /packages/old/*.deb
       test -x /usr/local/bin/veil
-      for unit in veil.service veil-helper.service veil-helper.socket veil-backup.service veil-backup.timer veil-caddy@.service veil-hysteria2@.service veil-mieru.service veil-olcrtc@.service veil-warp.service; do
+      for unit in veil.service veil-helper.service veil-helper.socket veil-backup.service veil-backup.timer veil-caddy.service veil-hysteria2@.service veil-mieru.service veil-olcrtc@.service veil-warp.service; do
         test -f "/lib/systemd/system/$unit"
       done
       id veil

--- a/test/e2e/caddy_capability_test.go
+++ b/test/e2e/caddy_capability_test.go
@@ -1,0 +1,18 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"os/exec"
+)
+
+func init() {
+	caddyPath, err := exec.LookPath("caddy")
+	if err != nil {
+		return
+	}
+	// The production veil-caddy unit grants CAP_NET_BIND_SERVICE. Mirror that
+	// execution boundary so Caddy can create its automatic HTTP redirect
+	// listener while the Naive data path is validated over HTTPS.
+	_ = exec.Command("sudo", "setcap", "cap_net_bind_service=+ep", caddyPath).Run()
+}

--- a/test/e2e/management_flow_test.go
+++ b/test/e2e/management_flow_test.go
@@ -162,7 +162,7 @@ func TestVersionAndDoctorCLI(t *testing.T) {
 func TestRejectsDuplicatePortsEndToEnd(t *testing.T) {
 	srv := startServer(t, serverOptions{token: "tok"})
 
-	resp := srv.do(http.MethodPut, "/api/settings", `{"panelListen":"127.0.0.1:2096","mode":"dev","domain":"vpn.example.com","email":"admin@example.com","naiveUsername":"sysadmin","naivePassword":"syspassword"}`)
+	resp := srv.do(http.MethodPut, "/api/settings", `{"panelListen":"127.0.0.1:2096","mode":"dev","domain":"vpn.example.com","defaultAcmeEmail":"admin@example.com","naiveUsername":"sysadmin","naivePassword":"syspassword"}`)
 	drain(resp)
 
 	// First NaiveProxy inbound on port 20001

--- a/test/e2e/proxy_binary_data_path_test.go
+++ b/test/e2e/proxy_binary_data_path_test.go
@@ -270,6 +270,11 @@ func TestHysteria2DataPath(t *testing.T) {
 	if err != nil {
 		t.Skip("hysteria binary not found in PATH, skipping data-path test")
 	}
+	testHysteria2DataPath(t, hysteriaPath)
+}
+
+func testHysteria2DataPath(t *testing.T, hysteriaPath string) {
+	t.Helper()
 
 	// 1. Start backend HTTP server
 	expectedResponse := "hello from hysteria2"
@@ -467,7 +472,9 @@ socks5:
 	}
 }
 
-// TestNaiveProxyDataPath tests data flow through a real Caddy/NaiveProxy server/client if caddy and naive binaries are installed.
+// TestNaiveProxyDataPath tests data flow through a real Caddy/NaiveProxy
+// server/client when the optional client binary is installed. The strict CI
+// variant calls the same implementation but requires both binaries.
 func TestNaiveProxyDataPath(t *testing.T) {
 	caddyPath, err := exec.LookPath("caddy")
 	if err != nil {
@@ -477,187 +484,9 @@ func TestNaiveProxyDataPath(t *testing.T) {
 	if err != nil {
 		t.Skip("naive binary not found in PATH, skipping data-path test")
 	}
-
-	// 1. Start backend HTTP server
-	expectedResponse := "hello from naiveproxy"
-	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(expectedResponse))
-	}))
-	defer backend.Close()
-
-	// 2. Start Veil serving panel
-	srv := startServer(t, serverOptions{token: "e2e-secret-token"})
-
-	// Configure settings and inbound
-	inboundPort := freePort(t)
-	resp := srv.do(http.MethodPut, "/api/settings", `{"panelListen":"127.0.0.1:2096","mode":"dev","domain":"vpn.example.com","defaultAcmeEmail":"test@example.com","naiveUsername":"test-user","naivePassword":"test-pass"}`)
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("settings expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp))
-	}
-	drain(resp)
-
-	resp = srv.do(http.MethodPost, "/api/inbounds", fmt.Sprintf(`{"name":"naive-tcp","protocol":"naiveproxy","transport":"tcp","port":%d,"enabled":true,"password":"secret-pass","naiveUsername":"naive-user","naivePassword":"naive-pass"}`, inboundPort))
-	if resp.StatusCode != http.StatusCreated {
-		t.Fatalf("inbound expected 201, got %d: %v", resp.StatusCode, readJSON(t, resp))
-	}
-	drain(resp)
-
-	// Apply settings
-	resp = srv.do(http.MethodPost, "/api/apply/plan", "")
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("apply plan expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp))
-	}
-	drain(resp)
-
-	resp = srv.do(http.MethodPost, "/api/apply", `{"confirm":true}`)
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("apply expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp))
-	}
-	drain(resp)
-
-	// 3. Modify generated Caddyfile to run over HTTP (remove domain name and tls directives)
-	serverConfig := filepath.Join(srv.applyRoot, "generated", "caddy", "naive-tcp.Caddyfile")
-	caddyfileContent, err := os.ReadFile(serverConfig)
-	if err != nil {
-		t.Fatalf("read caddyfile: %v", err)
-	}
-
-	// Change format: ":port, vpn.example.com {" -> "127.0.0.1:port {"
-	caddyfile := string(caddyfileContent)
-	caddyfile = strings.Replace(caddyfile, fmt.Sprintf(":%d, vpn.example.com", inboundPort), fmt.Sprintf("127.0.0.1:%d", inboundPort), 1)
-
-	// Remove tls directive
-	reTls := regexp.MustCompile(`(?m)^\s*tls\s+\S+\s*$`)
-	caddyfile = reTls.ReplaceAllString(caddyfile, "")
-
-	tempDir := t.TempDir()
-	tempCaddyfile := filepath.Join(tempDir, "Caddyfile")
-	if err := os.WriteFile(tempCaddyfile, []byte(caddyfile), 0o600); err != nil {
-		t.Fatalf("write modified caddyfile: %v", err)
-	}
-
-	// 4. Start Caddy server
-	cmdServer := exec.Command(caddyPath, "run", "--config", tempCaddyfile, "--adapter", "caddyfile")
-	if err := cmdServer.Start(); err != nil {
-		t.Fatalf("start caddy server: %v", err)
-	}
-	defer func() {
-		if cmdServer.Process != nil {
-			_ = cmdServer.Process.Kill()
-		}
-	}()
-
-	// Wait for Caddy server to listen
-	serverAddr := fmt.Sprintf("127.0.0.1:%d", inboundPort)
-	if err := waitListen(serverAddr, 5*time.Second); err != nil {
-		t.Fatalf("caddy server did not listen: %v", err)
-	}
-
-	// 5. Get client links
-	resp = srv.do(http.MethodGet, "/api/client-links", "")
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("client links expected 200, got %d", resp.StatusCode)
-	}
-	linksBody := readJSON(t, resp)
-	artifactsRaw, _ := json.Marshal(linksBody["links"])
-	var artifacts []struct {
-		Name     string `json:"name"`
-		Protocol string `json:"protocol"`
-		Kind     string `json:"kind"`
-		URI      string `json:"uri"`
-	}
-	if err := json.Unmarshal(artifactsRaw, &artifacts); err != nil {
-		t.Fatalf("decode artifacts: %v", err)
-	}
-
-	var uri string
-	for _, art := range artifacts {
-		if art.Protocol == "naiveproxy" {
-			uri = art.URI
-			break
-		}
-	}
-	if uri == "" {
-		t.Fatal("naiveproxy client URI not found")
-	}
-
-	// 6. Build client configuration JSON using HTTP
-	parsed, err := url.Parse(uri)
-	if err != nil {
-		t.Fatalf("parse URI: %v", err)
-	}
-	username := parsed.User.Username()
-	password, _ := parsed.User.Password()
-	socksPort := freePort(t)
-
-	// Since we are running Caddy over plain HTTP to avoid cert validation,
-	// we configure the proxy using http://
-	clientConfig := map[string]any{
-		"listen":  fmt.Sprintf("socks://127.0.0.1:%d", socksPort),
-		"proxy":   fmt.Sprintf("http://%s:%s@127.0.0.1:%d", username, password, inboundPort),
-		"padding": true,
-	}
-
-	clientJSON, err := json.Marshal(clientConfig)
-	if err != nil {
-		t.Fatalf("marshal client config: %v", err)
-	}
-
-	tempClientJSON := filepath.Join(tempDir, "client.json")
-	if err := os.WriteFile(tempClientJSON, clientJSON, 0o600); err != nil {
-		t.Fatalf("write client JSON: %v", err)
-	}
-
-	// 7. Start naive client
-	cmdClient := exec.Command(naivePath, tempClientJSON)
-	if err := cmdClient.Start(); err != nil {
-		t.Fatalf("start naive client: %v", err)
-	}
-	defer func() {
-		if cmdClient.Process != nil {
-			_ = cmdClient.Process.Kill()
-		}
-	}()
-
-	// Wait for client SOCKS5 to start listening
-	socksAddr := fmt.Sprintf("127.0.0.1:%d", socksPort)
-	if err := waitListen(socksAddr, 5*time.Second); err != nil {
-		t.Fatalf("naive client SOCKS5 did not listen: %v", err)
-	}
-
-	// 8. Test proxying through client SOCKS5
-	dialer, err := proxy.SOCKS5("tcp", socksAddr, nil, proxy.Direct)
-	if err != nil {
-		t.Fatalf("create SOCKS5 dialer: %v", err)
-	}
-
-	httpClient := &http.Client{
-		Transport: &http.Transport{
-			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-				return dialer.Dial(network, addr)
-			},
-		},
-		Timeout: 5 * time.Second,
-	}
-
-	res, err := httpClient.Get(backend.URL)
-	if err != nil {
-		t.Fatalf("GET request failed: %v", err)
-	}
-	defer res.Body.Close()
-
-	body, err := io.ReadAll(res.Body)
-	if err != nil {
-		t.Fatalf("read response body: %v", err)
-	}
-
-	if string(body) != expectedResponse {
-		t.Fatalf("expected response %q, got %q", expectedResponse, string(body))
-	}
+	testNaiveProxyDataPath(t, caddyPath, naivePath)
 }
 
-// waitListen helper checks if the port starts listening within the duration
 func waitListen(addr string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {

--- a/test/e2e/proxy_binary_data_path_test.go
+++ b/test/e2e/proxy_binary_data_path_test.go
@@ -491,7 +491,7 @@ func TestNaiveProxyDataPath(t *testing.T) {
 
 	// Configure settings and inbound
 	inboundPort := freePort(t)
-	resp := srv.do(http.MethodPut, "/api/settings", `{"panelListen":"127.0.0.1:2096","mode":"dev","domain":"vpn.example.com","email":"test@example.com","naiveUsername":"test-user","naivePassword":"test-pass"}`)
+	resp := srv.do(http.MethodPut, "/api/settings", `{"panelListen":"127.0.0.1:2096","mode":"dev","domain":"vpn.example.com","defaultAcmeEmail":"test@example.com","naiveUsername":"test-user","naivePassword":"test-pass"}`)
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("settings expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp))
 	}

--- a/test/e2e/required_protocol_data_path_test.go
+++ b/test/e2e/required_protocol_data_path_test.go
@@ -30,13 +30,8 @@ func requiredBinary(t *testing.T, name string) string {
 	return path
 }
 
-func TestRequiredMieruTCPDataPath(t *testing.T) {
-	testRequiredMieruDataPath(t, "tcp")
-}
-
-func TestRequiredMieruUDPDataPath(t *testing.T) {
-	testRequiredMieruDataPath(t, "udp")
-}
+func TestRequiredMieruTCPDataPath(t *testing.T) { testRequiredMieruDataPath(t, "tcp") }
+func TestRequiredMieruUDPDataPath(t *testing.T) { testRequiredMieruDataPath(t, "udp") }
 
 func testRequiredMieruDataPath(t *testing.T, transport string) {
 	t.Helper()
@@ -49,6 +44,16 @@ func testRequiredMieruDataPath(t *testing.T, transport string) {
 		_, _ = w.Write([]byte(expectedResponse))
 	}))
 	defer backend.Close()
+
+	// Mieru intentionally rejects literal loopback/private destinations unless
+	// the server-side user is granted that privilege. Use a non-special test
+	// hostname so the SOCKS request exercises normal domain egress while DNS
+	// still resolves to the local controlled backend.
+	const backendHost = "veil-protocol-e2e.test"
+	if err := exec.Command("sudo", "sh", "-c", "printf '127.0.0.1 "+backendHost+"\\n' >> /etc/hosts").Run(); err != nil {
+		t.Fatalf("register local E2E hostname: %v", err)
+	}
+	backendURL := strings.Replace(backend.URL, "127.0.0.1", backendHost, 1)
 
 	srv := startServer(t, serverOptions{token: "e2e-secret-token"})
 	inboundPort := freePort(t)
@@ -64,17 +69,7 @@ func testRequiredMieruDataPath(t *testing.T, transport string) {
 		t.Fatalf("inbound expected 201, got %d: %v", resp.StatusCode, readJSON(t, resp))
 	}
 	drain(resp)
-
-	resp = srv.do(http.MethodPost, "/api/apply/plan", "")
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("apply plan expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp))
-	}
-	drain(resp)
-	resp = srv.do(http.MethodPost, "/api/apply", `{"confirm":true}`)
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("apply expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp))
-	}
-	drain(resp)
+	applyPanelConfiguration(t, srv)
 
 	serverConfig := filepath.Join(srv.applyRoot, "generated", "mieru", "server_config.json")
 	serverRuntime := t.TempDir()
@@ -82,9 +77,7 @@ func testRequiredMieruDataPath(t *testing.T, transport string) {
 	serverPB := filepath.Join(serverRuntime, "server.conf.pb")
 	serverLogPath := filepath.Join(serverRuntime, "mita.log")
 	serverLog, err := os.Create(serverLogPath)
-	if err != nil {
-		t.Fatal(err)
-	}
+	if err != nil { t.Fatal(err) }
 	defer serverLog.Close()
 	serverEnv := append(os.Environ(),
 		"MITA_CONFIG_FILE="+serverPB,
@@ -93,12 +86,8 @@ func testRequiredMieruDataPath(t *testing.T, transport string) {
 		"MITA_LOG_NO_TIMESTAMP=true",
 	)
 	cmdServer := exec.Command(mitaPath, "run")
-	cmdServer.Env = serverEnv
-	cmdServer.Stdout = serverLog
-	cmdServer.Stderr = serverLog
-	if err := cmdServer.Start(); err != nil {
-		t.Fatalf("start mita daemon: %v", err)
-	}
+	cmdServer.Env, cmdServer.Stdout, cmdServer.Stderr = serverEnv, serverLog, serverLog
+	if err := cmdServer.Start(); err != nil { t.Fatalf("start mita daemon: %v", err) }
 	defer func() { _ = cmdServer.Process.Kill() }()
 	if err := waitUnixSocket(serverSocket, 15*time.Second); err != nil {
 		logBytes, _ := os.ReadFile(serverLogPath)
@@ -108,82 +97,50 @@ func testRequiredMieruDataPath(t *testing.T, transport string) {
 	runMieruControl(t, serverEnv, mitaPath, serverLogPath, "start")
 
 	resp = srv.do(http.MethodGet, "/api/client-links", "")
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("client links expected 200, got %d", resp.StatusCode)
-	}
+	if resp.StatusCode != http.StatusOK { t.Fatalf("client links expected 200, got %d", resp.StatusCode) }
 	linksBody := readJSON(t, resp)
 	artifactsRaw, _ := json.Marshal(linksBody["artifacts"])
 	var artifacts []struct {
 		Protocol string `json:"protocol"`
-		Kind     string `json:"kind"`
-		Content  string `json:"content"`
+		Kind string `json:"kind"`
+		Content string `json:"content"`
 	}
-	if err := json.Unmarshal(artifactsRaw, &artifacts); err != nil {
-		t.Fatalf("decode artifacts: %v", err)
-	}
+	if err := json.Unmarshal(artifactsRaw, &artifacts); err != nil { t.Fatal(err) }
 	var clientConfigJSON string
 	for _, artifact := range artifacts {
-		if artifact.Protocol == "mieru" && artifact.Kind == "client_config" {
-			clientConfigJSON = artifact.Content
-			break
-		}
+		if artifact.Protocol == "mieru" && artifact.Kind == "client_config" { clientConfigJSON = artifact.Content; break }
 	}
-	if clientConfigJSON == "" {
-		t.Fatal("panel did not return a Mieru client configuration")
-	}
+	if clientConfigJSON == "" { t.Fatal("panel did not return a Mieru client configuration") }
 
 	var clientMap map[string]any
-	if err := json.Unmarshal([]byte(clientConfigJSON), &clientMap); err != nil {
-		t.Fatalf("unmarshal client config: %v", err)
-	}
+	if err := json.Unmarshal([]byte(clientConfigJSON), &clientMap); err != nil { t.Fatal(err) }
 	socksPort := freePort(t)
 	clientMap["socks5Port"] = socksPort
 	clientMap["socks5ListenLAN"] = false
-
 	profiles, ok := clientMap["profiles"].([]any)
-	if !ok || len(profiles) == 0 {
-		t.Fatalf("Mieru config has no profiles: %s", clientConfigJSON)
-	}
+	if !ok || len(profiles) == 0 { t.Fatalf("Mieru config has no profiles: %s", clientConfigJSON) }
 	profile, ok := profiles[0].(map[string]any)
-	if !ok {
-		t.Fatalf("Mieru profile has unexpected shape: %T", profiles[0])
-	}
+	if !ok { t.Fatalf("Mieru profile has unexpected shape: %T", profiles[0]) }
 	servers, ok := profile["servers"].([]any)
-	if !ok || len(servers) == 0 {
-		t.Fatalf("Mieru profile has no servers: %s", clientConfigJSON)
-	}
+	if !ok || len(servers) == 0 { t.Fatalf("Mieru profile has no servers: %s", clientConfigJSON) }
 	server, ok := servers[0].(map[string]any)
-	if !ok {
-		t.Fatalf("Mieru server has unexpected shape: %T", servers[0])
-	}
+	if !ok { t.Fatalf("Mieru server has unexpected shape: %T", servers[0]) }
 	delete(server, "domainName")
 	server["ipAddress"] = "127.0.0.1"
 
 	modifiedClientJSON, err := json.Marshal(clientMap)
-	if err != nil {
-		t.Fatal(err)
-	}
+	if err != nil { t.Fatal(err) }
 	clientRuntime := t.TempDir()
 	clientFile := filepath.Join(clientRuntime, "client.json")
-	if err := os.WriteFile(clientFile, modifiedClientJSON, 0o600); err != nil {
-		t.Fatal(err)
-	}
+	if err := os.WriteFile(clientFile, modifiedClientJSON, 0o600); err != nil { t.Fatal(err) }
 	clientLogPath := filepath.Join(clientRuntime, "mieru.log")
 	clientLog, err := os.Create(clientLogPath)
-	if err != nil {
-		t.Fatal(err)
-	}
+	if err != nil { t.Fatal(err) }
 	defer clientLog.Close()
 	cmdClient := exec.Command(mieruPath, "run")
-	cmdClient.Env = append(os.Environ(),
-		"MIERU_CONFIG_JSON_FILE="+clientFile,
-		"MIERU_LOG_NO_TIMESTAMP=true",
-	)
-	cmdClient.Stdout = clientLog
-	cmdClient.Stderr = clientLog
-	if err := cmdClient.Start(); err != nil {
-		t.Fatalf("start mieru client: %v", err)
-	}
+	cmdClient.Env = append(os.Environ(), "MIERU_CONFIG_JSON_FILE="+clientFile, "MIERU_LOG_NO_TIMESTAMP=true")
+	cmdClient.Stdout, cmdClient.Stderr = clientLog, clientLog
+	if err := cmdClient.Start(); err != nil { t.Fatalf("start mieru client: %v", err) }
 	defer func() { _ = cmdClient.Process.Kill() }()
 
 	socksAddr := fmt.Sprintf("127.0.0.1:%d", socksPort)
@@ -192,7 +149,17 @@ func testRequiredMieruDataPath(t *testing.T, transport string) {
 		clientBytes, _ := os.ReadFile(clientLogPath)
 		t.Fatalf("Mieru %s client did not listen: %v\nserver log:\n%s\nclient log:\n%s\nclient config:\n%s", transport, err, serverBytes, clientBytes, modifiedClientJSON)
 	}
-	assertHTTPThroughSOCKS(t, socksAddr, backend.URL, expectedResponse)
+	assertHTTPThroughSOCKS(t, socksAddr, backendURL, expectedResponse)
+}
+
+func applyPanelConfiguration(t *testing.T, srv *testServer) {
+	t.Helper()
+	resp := srv.do(http.MethodPost, "/api/apply/plan", "")
+	if resp.StatusCode != http.StatusOK { t.Fatalf("apply plan expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp)) }
+	drain(resp)
+	resp = srv.do(http.MethodPost, "/api/apply", `{"confirm":true}`)
+	if resp.StatusCode != http.StatusOK { t.Fatalf("apply expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp)) }
+	drain(resp)
 }
 
 func runMieruControl(t *testing.T, env []string, binary, logPath string, args ...string) {
@@ -212,9 +179,7 @@ func waitUnixSocket(path string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		info, err := os.Stat(path)
-		if err == nil && info.Mode()&os.ModeSocket != 0 {
-			return nil
-		}
+		if err == nil && info.Mode()&os.ModeSocket != 0 { return nil }
 		time.Sleep(50 * time.Millisecond)
 	}
 	return fmt.Errorf("Unix socket %s did not appear within %v", path, timeout)
@@ -223,7 +188,6 @@ func waitUnixSocket(path string, timeout time.Duration) error {
 func TestRequiredNaiveProxyDataPath(t *testing.T) {
 	caddyPath := requiredBinary(t, "caddy")
 	naivePath := requiredBinary(t, "naive")
-
 	expectedResponse := "hello from naiveproxy"
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -234,51 +198,28 @@ func TestRequiredNaiveProxyDataPath(t *testing.T) {
 	srv := startServer(t, serverOptions{token: "e2e-secret-token"})
 	inboundPort := freePort(t)
 	resp := srv.do(http.MethodPut, "/api/settings", `{"panelListen":"127.0.0.1:2096","mode":"dev","domain":"vpn.example.com","email":"test@example.com"}`)
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("settings expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp))
-	}
+	if resp.StatusCode != http.StatusOK { t.Fatalf("settings expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp)) }
 	drain(resp)
 	resp = srv.do(http.MethodPost, "/api/inbounds", fmt.Sprintf(`{"name":"naive-tcp","protocol":"naiveproxy","transport":"tcp","port":%d,"enabled":true,"naiveUsername":"naive-user","naivePassword":"naive-pass"}`, inboundPort))
-	if resp.StatusCode != http.StatusCreated {
-		t.Fatalf("inbound expected 201, got %d: %v", resp.StatusCode, readJSON(t, resp))
-	}
+	if resp.StatusCode != http.StatusCreated { t.Fatalf("inbound expected 201, got %d: %v", resp.StatusCode, readJSON(t, resp)) }
 	drain(resp)
-	resp = srv.do(http.MethodPost, "/api/apply/plan", "")
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("apply plan expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp))
-	}
-	drain(resp)
-	resp = srv.do(http.MethodPost, "/api/apply", `{"confirm":true}`)
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("apply expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp))
-	}
-	drain(resp)
+	applyPanelConfiguration(t, srv)
 
 	generatedPath := filepath.Join(srv.applyRoot, "generated", "caddy", "naive-tcp.Caddyfile")
 	generated, err := os.ReadFile(generatedPath)
-	if err != nil {
-		t.Fatal(err)
-	}
+	if err != nil { t.Fatal(err) }
 	caddyfile := strings.Replace(string(generated), fmt.Sprintf(":%d, vpn.example.com", inboundPort), fmt.Sprintf("http://127.0.0.1:%d", inboundPort), 1)
 	caddyfile, err = removeCaddyDirectiveBlock(caddyfile, "tls")
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	if err != nil { t.Fatal(err) }
 	tempDir := t.TempDir()
 	caddyfilePath := filepath.Join(tempDir, "Caddyfile")
-	if err := os.WriteFile(caddyfilePath, []byte(caddyfile), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	if err := os.WriteFile(caddyfilePath, []byte(caddyfile), 0o600); err != nil { t.Fatal(err) }
 	serverLogPath := filepath.Join(tempDir, "caddy.log")
 	serverLog, _ := os.Create(serverLogPath)
 	defer serverLog.Close()
 	cmdServer := exec.Command(caddyPath, "run", "--config", caddyfilePath, "--adapter", "caddyfile")
-	cmdServer.Stdout = serverLog
-	cmdServer.Stderr = serverLog
-	if err := cmdServer.Start(); err != nil {
-		t.Fatalf("start caddy: %v", err)
-	}
+	cmdServer.Stdout, cmdServer.Stderr = serverLog, serverLog
+	if err := cmdServer.Start(); err != nil { t.Fatalf("start caddy: %v", err) }
 	defer func() { _ = cmdServer.Process.Kill() }()
 	serverAddr := fmt.Sprintf("127.0.0.1:%d", inboundPort)
 	if err := waitListen(serverAddr, 15*time.Second); err != nil {
@@ -287,54 +228,33 @@ func TestRequiredNaiveProxyDataPath(t *testing.T) {
 	}
 
 	resp = srv.do(http.MethodGet, "/api/client-links", "")
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("client links expected 200, got %d", resp.StatusCode)
-	}
+	if resp.StatusCode != http.StatusOK { t.Fatalf("client links expected 200, got %d", resp.StatusCode) }
 	linksBody := readJSON(t, resp)
 	linksRaw, _ := json.Marshal(linksBody["links"])
-	var links []struct {
-		Protocol string `json:"protocol"`
-		URI      string `json:"uri"`
-	}
-	if err := json.Unmarshal(linksRaw, &links); err != nil {
-		t.Fatal(err)
-	}
+	var links []struct { Protocol string `json:"protocol"`; URI string `json:"uri"` }
+	if err := json.Unmarshal(linksRaw, &links); err != nil { t.Fatal(err) }
 	var accessURI string
-	for _, link := range links {
-		if link.Protocol == "naiveproxy" {
-			accessURI = link.URI
-			break
-		}
-	}
-	if accessURI == "" {
-		t.Fatal("panel did not return a NaiveProxy access URI")
-	}
+	for _, link := range links { if link.Protocol == "naiveproxy" { accessURI = link.URI; break } }
+	if accessURI == "" { t.Fatal("panel did not return a NaiveProxy access URI") }
 	parsed, err := url.Parse(accessURI)
-	if err != nil {
-		t.Fatal(err)
-	}
+	if err != nil { t.Fatal(err) }
 	username := parsed.User.Username()
 	password, _ := parsed.User.Password()
 	socksPort := freePort(t)
 	clientConfig := map[string]any{
-		"listen":  fmt.Sprintf("socks://127.0.0.1:%d", socksPort),
-		"proxy":   fmt.Sprintf("http://%s:%s@127.0.0.1:%d", url.QueryEscape(username), url.QueryEscape(password), inboundPort),
+		"listen": fmt.Sprintf("socks://127.0.0.1:%d", socksPort),
+		"proxy": fmt.Sprintf("http://%s:%s@127.0.0.1:%d", url.QueryEscape(username), url.QueryEscape(password), inboundPort),
 		"padding": true,
 	}
 	clientJSON, _ := json.Marshal(clientConfig)
 	clientPath := filepath.Join(tempDir, "naive.json")
-	if err := os.WriteFile(clientPath, clientJSON, 0o600); err != nil {
-		t.Fatal(err)
-	}
+	if err := os.WriteFile(clientPath, clientJSON, 0o600); err != nil { t.Fatal(err) }
 	clientLogPath := filepath.Join(tempDir, "naive.log")
 	clientLog, _ := os.Create(clientLogPath)
 	defer clientLog.Close()
 	cmdClient := exec.Command(naivePath, clientPath)
-	cmdClient.Stdout = clientLog
-	cmdClient.Stderr = clientLog
-	if err := cmdClient.Start(); err != nil {
-		t.Fatalf("start naive: %v", err)
-	}
+	cmdClient.Stdout, cmdClient.Stderr = clientLog, clientLog
+	if err := cmdClient.Start(); err != nil { t.Fatalf("start naive: %v", err) }
 	defer func() { _ = cmdClient.Process.Kill() }()
 	socksAddr := fmt.Sprintf("127.0.0.1:%d", socksPort)
 	if err := waitListen(socksAddr, 15*time.Second); err != nil {
@@ -346,23 +266,17 @@ func TestRequiredNaiveProxyDataPath(t *testing.T) {
 
 func removeCaddyDirectiveBlock(input, directive string) (string, error) {
 	lines := strings.Split(input, "\n")
-	start := -1
-	depth := 0
+	start, depth := -1, 0
 	for i, line := range lines {
 		trimmed := strings.TrimSpace(line)
 		if start == -1 {
 			if strings.HasPrefix(trimmed, directive+" ") || trimmed == directive+"{" || trimmed == directive+" {" {
-				if strings.Contains(trimmed, "{") {
-					start = i
-					depth = strings.Count(line, "{") - strings.Count(line, "}")
-				}
+				if strings.Contains(trimmed, "{") { start, depth = i, strings.Count(line, "{")-strings.Count(line, "}") }
 			}
 			continue
 		}
 		depth += strings.Count(line, "{") - strings.Count(line, "}")
-		if depth == 0 {
-			return strings.Join(append(lines[:start], lines[i+1:]...), "\n"), nil
-		}
+		if depth == 0 { return strings.Join(append(lines[:start], lines[i+1:]...), "\n"), nil }
 	}
 	return "", fmt.Errorf("Caddy directive block %q not found or unbalanced", directive)
 }
@@ -370,25 +284,15 @@ func removeCaddyDirectiveBlock(input, directive string) (string, error) {
 func assertHTTPThroughSOCKS(t *testing.T, socksAddr, targetURL, expected string) {
 	t.Helper()
 	dialer, err := proxy.SOCKS5("tcp", socksAddr, nil, proxy.Direct)
-	if err != nil {
-		t.Fatal(err)
-	}
+	if err != nil { t.Fatal(err) }
 	client := &http.Client{
-		Transport: &http.Transport{DialContext: func(_ context.Context, network, addr string) (net.Conn, error) {
-			return dialer.Dial(network, addr)
-		}},
+		Transport: &http.Transport{DialContext: func(_ context.Context, network, addr string) (net.Conn, error) { return dialer.Dial(network, addr) }},
 		Timeout: 10 * time.Second,
 	}
 	resp, err := client.Get(targetURL)
-	if err != nil {
-		t.Fatalf("GET through SOCKS failed: %v", err)
-	}
+	if err != nil { t.Fatalf("GET through SOCKS failed: %v", err) }
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(body) != expected {
-		t.Fatalf("response = %q, want %q", body, expected)
-	}
+	if err != nil { t.Fatal(err) }
+	if string(body) != expected { t.Fatalf("response = %q, want %q", body, expected) }
 }

--- a/test/e2e/required_protocol_data_path_test.go
+++ b/test/e2e/required_protocol_data_path_test.go
@@ -30,6 +30,10 @@ func requiredBinary(t *testing.T, name string) string {
 	return path
 }
 
+func TestRequiredHysteria2DataPath(t *testing.T) {
+	testHysteria2DataPath(t, requiredBinary(t, "hysteria"))
+}
+
 func TestRequiredMieruTCPDataPath(t *testing.T) {
 	testRequiredMieruDataPath(t, "tcp")
 }
@@ -50,10 +54,8 @@ func testRequiredMieruDataPath(t *testing.T, transport string) {
 	}))
 	defer backend.Close()
 
-	const backendHost = "veil-protocol-e2e.test"
-	if err := exec.Command("sudo", "sh", "-c", "printf '127.0.0.1 "+backendHost+"\\n' >> /etc/hosts").Run(); err != nil {
-		t.Fatalf("register local E2E hostname: %v", err)
-	}
+	backendHost := "veil-mieru-" + transport + "-e2e.test"
+	registerLoopbackHostname(t, backendHost)
 	backendURL := strings.Replace(backend.URL, "127.0.0.1", backendHost, 1)
 
 	srv := startServer(t, serverOptions{token: "e2e-secret-token"})
@@ -238,12 +240,20 @@ func waitUnixSocket(path string, timeout time.Duration) error {
 func TestRequiredNaiveProxyDataPath(t *testing.T) {
 	caddyPath := requiredBinary(t, "caddy")
 	naivePath := requiredBinary(t, "naive")
+	testNaiveProxyDataPath(t, caddyPath, naivePath)
+}
+
+func testNaiveProxyDataPath(t *testing.T, caddyPath, naivePath string) {
+	t.Helper()
 	expectedResponse := "hello from naiveproxy"
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(expectedResponse))
 	}))
 	defer backend.Close()
+	const backendHost = "veil-naive-e2e.test"
+	registerLoopbackHostname(t, backendHost)
+	backendURL := strings.Replace(backend.URL, "127.0.0.1", backendHost, 1)
 
 	srv := startServer(t, serverOptions{token: "e2e-secret-token"})
 	inboundPort := freePort(t)
@@ -260,7 +270,7 @@ func TestRequiredNaiveProxyDataPath(t *testing.T) {
 	drain(resp)
 	applyPanelConfiguration(t, srv)
 
-	generatedPath := filepath.Join(srv.applyRoot, "generated", "caddy", "naive-tcp.Caddyfile")
+	generatedPath := filepath.Join(srv.applyRoot, "generated", "caddy", "config.json")
 	generated, err := os.ReadFile(generatedPath)
 	if err != nil {
 		t.Fatal(err)
@@ -284,15 +294,19 @@ func TestRequiredNaiveProxyDataPath(t *testing.T) {
 		t.Fatalf("refresh test trust store: %v: %s", err, output)
 	}
 
-	caddyfile := strings.Replace(string(generated), fmt.Sprintf(":%d, vpn.example.com", inboundPort), fmt.Sprintf("https://localhost:%d", inboundPort), 1)
-	caddyfile, err = removeCaddyDirectiveBlock(caddyfile, "tls")
+	testConfig, err := configureNaiveCaddyJSONForLocalTLS(
+		generated,
+		fmt.Sprintf("127.0.0.1:%d", inboundPort),
+		fmt.Sprintf("127.0.0.1:%d", freePort(t)),
+		certPath,
+		keyPath,
+		backendHost,
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
-	caddyfile = strings.Replace(caddyfile, "  encode", fmt.Sprintf("  tls %s %s\n  encode", certPath, keyPath), 1)
-
-	caddyfilePath := filepath.Join(tempDir, "Caddyfile")
-	if err := os.WriteFile(caddyfilePath, []byte(caddyfile), 0o600); err != nil {
+	caddyConfigPath := filepath.Join(tempDir, "caddy.json")
+	if err := os.WriteFile(caddyConfigPath, testConfig, 0o600); err != nil {
 		t.Fatal(err)
 	}
 	serverLogPath := filepath.Join(tempDir, "caddy.log")
@@ -302,7 +316,7 @@ func TestRequiredNaiveProxyDataPath(t *testing.T) {
 	}
 	defer serverLog.Close()
 
-	cmdServer := exec.Command(caddyPath, "run", "--config", caddyfilePath, "--adapter", "caddyfile")
+	cmdServer := exec.Command(caddyPath, "run", "--config", caddyConfigPath)
 	cmdServer.Stdout = serverLog
 	cmdServer.Stderr = serverLog
 	if err := cmdServer.Start(); err != nil {
@@ -312,7 +326,7 @@ func TestRequiredNaiveProxyDataPath(t *testing.T) {
 	serverAddr := fmt.Sprintf("127.0.0.1:%d", inboundPort)
 	if err := waitListen(serverAddr, 15*time.Second); err != nil {
 		logBytes, _ := os.ReadFile(serverLogPath)
-		t.Fatalf("Caddy did not listen: %v\nCaddyfile:\n%s\nlog:\n%s", err, caddyfile, logBytes)
+		t.Fatalf("Caddy did not listen: %v\nCaddy JSON:\n%s\nlog:\n%s", err, testConfig, logBytes)
 	}
 
 	resp = srv.do(http.MethodGet, "/api/client-links", "")
@@ -379,34 +393,123 @@ func TestRequiredNaiveProxyDataPath(t *testing.T) {
 		clientBytes, _ := os.ReadFile(clientLogPath)
 		t.Fatalf("Naive client did not listen: %v\nclient log:\n%s\nconfig:\n%s", err, clientBytes, clientJSON)
 	}
-	if err := assertHTTPThroughSOCKSResult(socksAddr, backend.URL, expectedResponse); err != nil {
+	if err := assertHTTPThroughSOCKSResult(socksAddr, backendURL, expectedResponse); err != nil {
 		serverBytes, _ := os.ReadFile(serverLogPath)
 		clientBytes, _ := os.ReadFile(clientLogPath)
-		t.Fatalf("Naive HTTPS data path failed: %v\nCaddyfile:\n%s\nserver log:\n%s\nclient log:\n%s\nclient config:\n%s", err, caddyfile, serverBytes, clientBytes, clientJSON)
+		t.Fatalf("Naive HTTPS data path failed: %v\nCaddy JSON:\n%s\nserver log:\n%s\nclient log:\n%s\nclient config:\n%s", err, testConfig, serverBytes, clientBytes, clientJSON)
 	}
 }
 
-func removeCaddyDirectiveBlock(input, directive string) (string, error) {
-	lines := strings.Split(input, "\n")
-	start := -1
-	depth := 0
-	for i, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if start == -1 {
-			if strings.HasPrefix(trimmed, directive+" ") || trimmed == directive+"{" || trimmed == directive+" {" {
-				if strings.Contains(trimmed, "{") {
-					start = i
-					depth = strings.Count(line, "{") - strings.Count(line, "}")
-				}
-			}
+func configureNaiveCaddyJSONForLocalTLS(input []byte, listenAddr, adminAddr, certPath, keyPath, allowedBackendHost string) ([]byte, error) {
+	var cfg map[string]any
+	if err := json.Unmarshal(input, &cfg); err != nil {
+		return nil, fmt.Errorf("decode generated Caddy JSON: %w", err)
+	}
+	admin, ok := cfg["admin"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("generated Caddy JSON has no admin object")
+	}
+	admin["listen"] = adminAddr
+	cfg["logging"] = map[string]any{
+		"logs": map[string]any{
+			"default": map[string]any{"level": "DEBUG"},
+		},
+	}
+	apps, ok := cfg["apps"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("generated Caddy JSON has no apps object")
+	}
+	httpApp, ok := apps["http"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("generated Caddy JSON has no http app")
+	}
+	servers, ok := httpApp["servers"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("generated Caddy JSON has no HTTP servers")
+	}
+	var naiveServer map[string]any
+	for _, rawServer := range servers {
+		server, ok := rawServer.(map[string]any)
+		if !ok || !caddyServerHasHandler(server, "forward_proxy") {
 			continue
 		}
-		depth += strings.Count(line, "{") - strings.Count(line, "}")
-		if depth == 0 {
-			return strings.Join(append(lines[:start], lines[i+1:]...), "\n"), nil
+		if naiveServer != nil {
+			return nil, fmt.Errorf("generated Caddy JSON contains multiple NaiveProxy servers")
+		}
+		naiveServer = server
+	}
+	if naiveServer == nil {
+		return nil, fmt.Errorf("generated Caddy JSON contains no NaiveProxy server")
+	}
+	if _, ok := naiveServer["tls_connection_policies"]; !ok {
+		return nil, fmt.Errorf("generated NaiveProxy server does not explicitly enable TLS")
+	}
+	forwardProxy := caddyServerHandler(naiveServer, "forward_proxy")
+	if forwardProxy == nil {
+		return nil, fmt.Errorf("generated NaiveProxy server has no forward_proxy handler")
+	}
+	// The module's secure default ACL denies loopback networks. Allow only the
+	// synthetic test hostname so the real proxy can reach the local HTTP backend
+	// without weakening production renderer defaults.
+	forwardProxy["acl"] = []map[string]any{{
+		"subjects": []string{allowedBackendHost},
+		"allow":    true,
+	}}
+	naiveServer["listen"] = []string{listenAddr}
+	httpApp["servers"] = map[string]any{"naive-e2e": naiveServer}
+	apps["tls"] = map[string]any{
+		"certificates": map[string]any{
+			"load_files": []map[string]any{{
+				"certificate": certPath,
+				"key":         keyPath,
+			}},
+		},
+	}
+	return json.MarshalIndent(cfg, "", "  ")
+}
+
+func caddyServerHasHandler(server map[string]any, handlerName string) bool {
+	return caddyServerHandler(server, handlerName) != nil
+}
+
+func caddyServerHandler(server map[string]any, handlerName string) map[string]any {
+	routes, _ := server["routes"].([]any)
+	for _, rawRoute := range routes {
+		route, _ := rawRoute.(map[string]any)
+		handlers, _ := route["handle"].([]any)
+		for _, rawHandler := range handlers {
+			handler, _ := rawHandler.(map[string]any)
+			if handler["handler"] == handlerName {
+				return handler
+			}
 		}
 	}
-	return "", fmt.Errorf("Caddy directive block %q not found or unbalanced", directive)
+	return nil
+}
+
+func registerLoopbackHostname(t *testing.T, hostname string) {
+	t.Helper()
+	if hostname == "" || strings.ContainsAny(hostname, " \t\r\n") {
+		t.Fatalf("invalid E2E hostname %q", hostname)
+	}
+	cmd := exec.Command("sudo", "tee", "-a", "/etc/hosts")
+	cmd.Stdin = strings.NewReader("127.0.0.1 " + hostname + "\n")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("register local E2E hostname: %v: %s", err, output)
+	}
+	t.Cleanup(func() {
+		const cleanup = `
+from pathlib import Path
+import sys
+p = Path("/etc/hosts")
+hostname = sys.argv[1]
+lines = [line for line in p.read_text().splitlines() if hostname not in line.split()]
+p.write_text("\n".join(lines) + "\n")
+`
+		if output, err := exec.Command("sudo", "python3", "-c", cleanup, hostname).CombinedOutput(); err != nil {
+			t.Errorf("remove local E2E hostname: %v: %s", err, output)
+		}
+	})
 }
 
 func assertHTTPThroughSOCKS(t *testing.T, socksAddr, targetURL, expected string) {

--- a/test/e2e/required_protocol_data_path_test.go
+++ b/test/e2e/required_protocol_data_path_test.go
@@ -265,13 +265,32 @@ func TestRequiredNaiveProxyDataPath(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	caddyfile := strings.Replace(string(generated), fmt.Sprintf(":%d, vpn.example.com", inboundPort), fmt.Sprintf("http://127.0.0.1:%d", inboundPort), 1)
+
+	tempDir := t.TempDir()
+	certPath := filepath.Join(tempDir, "localhost.crt")
+	keyPath := filepath.Join(tempDir, "localhost.key")
+	if err := generateSelfSignedCert(certPath, keyPath); err != nil {
+		t.Fatalf("generate trusted test certificate: %v", err)
+	}
+	caPath := "/usr/local/share/ca-certificates/veil-naive-e2e.crt"
+	if output, err := exec.Command("sudo", "install", "-m", "0644", certPath, caPath).CombinedOutput(); err != nil {
+		t.Fatalf("install test certificate: %v: %s", err, output)
+	}
+	defer func() {
+		_ = exec.Command("sudo", "rm", "-f", caPath).Run()
+		_ = exec.Command("sudo", "update-ca-certificates").Run()
+	}()
+	if output, err := exec.Command("sudo", "update-ca-certificates").CombinedOutput(); err != nil {
+		t.Fatalf("refresh test trust store: %v: %s", err, output)
+	}
+
+	caddyfile := strings.Replace(string(generated), fmt.Sprintf(":%d, vpn.example.com", inboundPort), fmt.Sprintf("https://localhost:%d", inboundPort), 1)
 	caddyfile, err = removeCaddyDirectiveBlock(caddyfile, "tls")
 	if err != nil {
 		t.Fatal(err)
 	}
+	caddyfile = strings.Replace(caddyfile, "  encode", fmt.Sprintf("  tls %s %s\n  encode", certPath, keyPath), 1)
 
-	tempDir := t.TempDir()
 	caddyfilePath := filepath.Join(tempDir, "Caddyfile")
 	if err := os.WriteFile(caddyfilePath, []byte(caddyfile), 0o600); err != nil {
 		t.Fatal(err)
@@ -329,8 +348,9 @@ func TestRequiredNaiveProxyDataPath(t *testing.T) {
 	socksPort := freePort(t)
 	clientConfig := map[string]any{
 		"listen":  fmt.Sprintf("socks://127.0.0.1:%d", socksPort),
-		"proxy":   fmt.Sprintf("http://%s:%s@127.0.0.1:%d", url.QueryEscape(username), url.QueryEscape(password), inboundPort),
+		"proxy":   fmt.Sprintf("https://%s:%s@localhost:%d", url.QueryEscape(username), url.QueryEscape(password), inboundPort),
 		"padding": true,
+		"log":     "",
 	}
 	clientJSON, err := json.Marshal(clientConfig)
 	if err != nil {
@@ -359,7 +379,11 @@ func TestRequiredNaiveProxyDataPath(t *testing.T) {
 		clientBytes, _ := os.ReadFile(clientLogPath)
 		t.Fatalf("Naive client did not listen: %v\nclient log:\n%s\nconfig:\n%s", err, clientBytes, clientJSON)
 	}
-	assertHTTPThroughSOCKS(t, socksAddr, backend.URL, expectedResponse)
+	if err := assertHTTPThroughSOCKSResult(socksAddr, backend.URL, expectedResponse); err != nil {
+		serverBytes, _ := os.ReadFile(serverLogPath)
+		clientBytes, _ := os.ReadFile(clientLogPath)
+		t.Fatalf("Naive HTTPS data path failed: %v\nCaddyfile:\n%s\nserver log:\n%s\nclient log:\n%s\nclient config:\n%s", err, caddyfile, serverBytes, clientBytes, clientJSON)
+	}
 }
 
 func removeCaddyDirectiveBlock(input, directive string) (string, error) {
@@ -387,9 +411,15 @@ func removeCaddyDirectiveBlock(input, directive string) (string, error) {
 
 func assertHTTPThroughSOCKS(t *testing.T, socksAddr, targetURL, expected string) {
 	t.Helper()
+	if err := assertHTTPThroughSOCKSResult(socksAddr, targetURL, expected); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertHTTPThroughSOCKSResult(socksAddr, targetURL, expected string) error {
 	dialer, err := proxy.SOCKS5("tcp", socksAddr, nil, proxy.Direct)
 	if err != nil {
-		t.Fatal(err)
+		return err
 	}
 	client := &http.Client{
 		Transport: &http.Transport{
@@ -401,14 +431,15 @@ func assertHTTPThroughSOCKS(t *testing.T, socksAddr, targetURL, expected string)
 	}
 	resp, err := client.Get(targetURL)
 	if err != nil {
-		t.Fatalf("GET through SOCKS failed: %v", err)
+		return fmt.Errorf("GET through SOCKS failed: %w", err)
 	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		t.Fatal(err)
+		return err
 	}
 	if string(body) != expected {
-		t.Fatalf("response = %q, want %q", body, expected)
+		return fmt.Errorf("response = %q, want %q", body, expected)
 	}
+	return nil
 }

--- a/test/e2e/required_protocol_data_path_test.go
+++ b/test/e2e/required_protocol_data_path_test.go
@@ -14,7 +14,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -78,21 +77,35 @@ func testRequiredMieruDataPath(t *testing.T, transport string) {
 	drain(resp)
 
 	serverConfig := filepath.Join(srv.applyRoot, "generated", "mieru", "server_config.json")
-	serverLogPath := filepath.Join(t.TempDir(), "mita.log")
+	serverRuntime := t.TempDir()
+	serverSocket := filepath.Join(serverRuntime, "mita.sock")
+	serverPB := filepath.Join(serverRuntime, "server.conf.pb")
+	serverLogPath := filepath.Join(serverRuntime, "mita.log")
 	serverLog, err := os.Create(serverLogPath)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer serverLog.Close()
-
+	serverEnv := append(os.Environ(),
+		"MITA_CONFIG_FILE="+serverPB,
+		"MITA_UDS_PATH="+serverSocket,
+		"MITA_INSECURE_UDS=1",
+		"MITA_LOG_NO_TIMESTAMP=true",
+	)
 	cmdServer := exec.Command(mitaPath, "run")
-	cmdServer.Env = append(os.Environ(), "MITA_CONFIG_JSON_FILE="+serverConfig)
+	cmdServer.Env = serverEnv
 	cmdServer.Stdout = serverLog
 	cmdServer.Stderr = serverLog
 	if err := cmdServer.Start(); err != nil {
-		t.Fatalf("start mita: %v", err)
+		t.Fatalf("start mita daemon: %v", err)
 	}
 	defer func() { _ = cmdServer.Process.Kill() }()
+	if err := waitUnixSocket(serverSocket, 15*time.Second); err != nil {
+		logBytes, _ := os.ReadFile(serverLogPath)
+		t.Fatalf("mita control socket did not appear: %v\nlog:\n%s", err, logBytes)
+	}
+	runMieruControl(t, serverEnv, mitaPath, serverLogPath, "apply", "config", serverConfig)
+	runMieruControl(t, serverEnv, mitaPath, serverLogPath, "start")
 
 	resp = srv.do(http.MethodGet, "/api/client-links", "")
 	if resp.StatusCode != http.StatusOK {
@@ -150,24 +163,39 @@ func testRequiredMieruDataPath(t *testing.T, transport string) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	clientFile := filepath.Join(t.TempDir(), "client.json")
+	clientRuntime := t.TempDir()
+	clientFile := filepath.Join(clientRuntime, "client.json")
 	if err := os.WriteFile(clientFile, modifiedClientJSON, 0o600); err != nil {
 		t.Fatal(err)
 	}
-	clientLogPath := filepath.Join(t.TempDir(), "mieru.log")
+	clientSocket := filepath.Join(clientRuntime, "mieru.sock")
+	clientPB := filepath.Join(clientRuntime, "client.conf.pb")
+	clientLogPath := filepath.Join(clientRuntime, "mieru.log")
 	clientLog, err := os.Create(clientLogPath)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer clientLog.Close()
+	clientEnv := append(os.Environ(),
+		"MIERU_CONFIG_FILE="+clientPB,
+		"MIERU_UDS_PATH="+clientSocket,
+		"MIERU_INSECURE_UDS=1",
+		"MIERU_LOG_NO_TIMESTAMP=true",
+	)
 	cmdClient := exec.Command(mieruPath, "run")
-	cmdClient.Env = append(os.Environ(), "MIERU_CONFIG_JSON_FILE="+clientFile)
+	cmdClient.Env = clientEnv
 	cmdClient.Stdout = clientLog
 	cmdClient.Stderr = clientLog
 	if err := cmdClient.Start(); err != nil {
-		t.Fatalf("start mieru: %v", err)
+		t.Fatalf("start mieru daemon: %v", err)
 	}
 	defer func() { _ = cmdClient.Process.Kill() }()
+	if err := waitUnixSocket(clientSocket, 15*time.Second); err != nil {
+		logBytes, _ := os.ReadFile(clientLogPath)
+		t.Fatalf("mieru control socket did not appear: %v\nlog:\n%s", err, logBytes)
+	}
+	runMieruControl(t, clientEnv, mieruPath, clientLogPath, "apply", "config", clientFile)
+	runMieruControl(t, clientEnv, mieruPath, clientLogPath, "start")
 
 	socksAddr := fmt.Sprintf("127.0.0.1:%d", socksPort)
 	if err := waitListen(socksAddr, 15*time.Second); err != nil {
@@ -176,6 +204,29 @@ func testRequiredMieruDataPath(t *testing.T, transport string) {
 		t.Fatalf("Mieru %s client did not listen: %v\nserver log:\n%s\nclient log:\n%s\nclient config:\n%s", transport, err, serverBytes, clientBytes, modifiedClientJSON)
 	}
 	assertHTTPThroughSOCKS(t, socksAddr, backend.URL, expectedResponse)
+}
+
+func runMieruControl(t *testing.T, env []string, binary, logPath string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(binary, args...)
+	cmd.Env = env
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		logBytes, _ := os.ReadFile(logPath)
+		t.Fatalf("%s %s failed: %v\noutput:\n%s\ndaemon log:\n%s", binary, strings.Join(args, " "), err, output, logBytes)
+	}
+}
+
+func waitUnixSocket(path string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		info, err := os.Stat(path)
+		if err == nil && info.Mode()&os.ModeSocket != 0 {
+			return nil
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return fmt.Errorf("Unix socket %s did not appear within %v", path, timeout)
 }
 
 func TestRequiredNaiveProxyDataPath(t *testing.T) {
@@ -218,11 +269,10 @@ func TestRequiredNaiveProxyDataPath(t *testing.T) {
 		t.Fatal(err)
 	}
 	caddyfile := strings.Replace(string(generated), fmt.Sprintf(":%d, vpn.example.com", inboundPort), fmt.Sprintf("127.0.0.1:%d", inboundPort), 1)
-	// The data-path test runs on loopback without public DNS. Remove only the
-	// generated TLS block; renderer tests separately require public ACME and
-	// reject the production-incompatible internal issuer.
-	tlsBlock := regexp.MustCompile(`(?ms)^\s*tls\s*\{.*?^\s*\}\s*$`)
-	caddyfile = tlsBlock.ReplaceAllString(caddyfile, "")
+	caddyfile, err = removeCaddyDirectiveBlock(caddyfile, "tls")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	tempDir := t.TempDir()
 	caddyfilePath := filepath.Join(tempDir, "Caddyfile")
@@ -301,6 +351,29 @@ func TestRequiredNaiveProxyDataPath(t *testing.T) {
 		t.Fatalf("Naive client did not listen: %v\nclient log:\n%s\nconfig:\n%s", err, clientBytes, clientJSON)
 	}
 	assertHTTPThroughSOCKS(t, socksAddr, backend.URL, expectedResponse)
+}
+
+func removeCaddyDirectiveBlock(input, directive string) (string, error) {
+	lines := strings.Split(input, "\n")
+	start := -1
+	depth := 0
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if start == -1 {
+			if strings.HasPrefix(trimmed, directive+" ") || trimmed == directive+"{" || trimmed == directive+" {" {
+				if strings.Contains(trimmed, "{") {
+					start = i
+					depth = strings.Count(line, "{") - strings.Count(line, "}")
+				}
+			}
+			continue
+		}
+		depth += strings.Count(line, "{") - strings.Count(line, "}")
+		if depth == 0 {
+			return strings.Join(append(lines[:start], lines[i+1:]...), "\n"), nil
+		}
+	}
+	return "", fmt.Errorf("Caddy directive block %q not found or unbalanced", directive)
 }
 
 func assertHTTPThroughSOCKS(t *testing.T, socksAddr, targetURL, expected string) {

--- a/test/e2e/required_protocol_data_path_test.go
+++ b/test/e2e/required_protocol_data_path_test.go
@@ -257,7 +257,8 @@ func testNaiveProxyDataPath(t *testing.T, caddyPath, naivePath string) {
 
 	srv := startServer(t, serverOptions{token: "e2e-secret-token"})
 	inboundPort := freePort(t)
-	resp := srv.do(http.MethodPut, "/api/settings", `{"panelListen":"127.0.0.1:2096","mode":"dev","domain":"vpn.example.com","defaultAcmeEmail":"test@example.com"}`)
+	settingsBody := fmt.Sprintf(`{"panelListen":"127.0.0.1:2096","panelAccess":"caddy","webBasePath":"/panel-e2e/","panelDomain":"vpn.example.com","panelEmail":"test@example.com","panelPublicPort":%d,"mode":"dev","domain":"vpn.example.com","email":"test@example.com","defaultAcmeEmail":"test@example.com"}`, inboundPort)
+	resp := srv.do(http.MethodPut, "/api/settings", settingsBody)
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("settings expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp))
 	}

--- a/test/e2e/required_protocol_data_path_test.go
+++ b/test/e2e/required_protocol_data_path_test.go
@@ -30,8 +30,13 @@ func requiredBinary(t *testing.T, name string) string {
 	return path
 }
 
-func TestRequiredMieruTCPDataPath(t *testing.T) { testRequiredMieruDataPath(t, "tcp") }
-func TestRequiredMieruUDPDataPath(t *testing.T) { testRequiredMieruDataPath(t, "udp") }
+func TestRequiredMieruTCPDataPath(t *testing.T) {
+	testRequiredMieruDataPath(t, "tcp")
+}
+
+func TestRequiredMieruUDPDataPath(t *testing.T) {
+	testRequiredMieruDataPath(t, "udp")
+}
 
 func testRequiredMieruDataPath(t *testing.T, transport string) {
 	t.Helper()
@@ -45,10 +50,6 @@ func testRequiredMieruDataPath(t *testing.T, transport string) {
 	}))
 	defer backend.Close()
 
-	// Mieru intentionally rejects literal loopback/private destinations unless
-	// the server-side user is granted that privilege. Use a non-special test
-	// hostname so the SOCKS request exercises normal domain egress while DNS
-	// still resolves to the local controlled backend.
 	const backendHost = "veil-protocol-e2e.test"
 	if err := exec.Command("sudo", "sh", "-c", "printf '127.0.0.1 "+backendHost+"\\n' >> /etc/hosts").Run(); err != nil {
 		t.Fatalf("register local E2E hostname: %v", err)
@@ -77,8 +78,11 @@ func testRequiredMieruDataPath(t *testing.T, transport string) {
 	serverPB := filepath.Join(serverRuntime, "server.conf.pb")
 	serverLogPath := filepath.Join(serverRuntime, "mita.log")
 	serverLog, err := os.Create(serverLogPath)
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer serverLog.Close()
+
 	serverEnv := append(os.Environ(),
 		"MITA_CONFIG_FILE="+serverPB,
 		"MITA_UDS_PATH="+serverSocket,
@@ -86,9 +90,14 @@ func testRequiredMieruDataPath(t *testing.T, transport string) {
 		"MITA_LOG_NO_TIMESTAMP=true",
 	)
 	cmdServer := exec.Command(mitaPath, "run")
-	cmdServer.Env, cmdServer.Stdout, cmdServer.Stderr = serverEnv, serverLog, serverLog
-	if err := cmdServer.Start(); err != nil { t.Fatalf("start mita daemon: %v", err) }
+	cmdServer.Env = serverEnv
+	cmdServer.Stdout = serverLog
+	cmdServer.Stderr = serverLog
+	if err := cmdServer.Start(); err != nil {
+		t.Fatalf("start mita daemon: %v", err)
+	}
 	defer func() { _ = cmdServer.Process.Kill() }()
+
 	if err := waitUnixSocket(serverSocket, 15*time.Second); err != nil {
 		logBytes, _ := os.ReadFile(serverLogPath)
 		t.Fatalf("mita control socket did not appear: %v\nlog:\n%s", err, logBytes)
@@ -97,50 +106,84 @@ func testRequiredMieruDataPath(t *testing.T, transport string) {
 	runMieruControl(t, serverEnv, mitaPath, serverLogPath, "start")
 
 	resp = srv.do(http.MethodGet, "/api/client-links", "")
-	if resp.StatusCode != http.StatusOK { t.Fatalf("client links expected 200, got %d", resp.StatusCode) }
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("client links expected 200, got %d", resp.StatusCode)
+	}
 	linksBody := readJSON(t, resp)
 	artifactsRaw, _ := json.Marshal(linksBody["artifacts"])
 	var artifacts []struct {
 		Protocol string `json:"protocol"`
-		Kind string `json:"kind"`
-		Content string `json:"content"`
+		Kind     string `json:"kind"`
+		Content  string `json:"content"`
 	}
-	if err := json.Unmarshal(artifactsRaw, &artifacts); err != nil { t.Fatal(err) }
+	if err := json.Unmarshal(artifactsRaw, &artifacts); err != nil {
+		t.Fatal(err)
+	}
+
 	var clientConfigJSON string
 	for _, artifact := range artifacts {
-		if artifact.Protocol == "mieru" && artifact.Kind == "client_config" { clientConfigJSON = artifact.Content; break }
+		if artifact.Protocol == "mieru" && artifact.Kind == "client_config" {
+			clientConfigJSON = artifact.Content
+			break
+		}
 	}
-	if clientConfigJSON == "" { t.Fatal("panel did not return a Mieru client configuration") }
+	if clientConfigJSON == "" {
+		t.Fatal("panel did not return a Mieru client configuration")
+	}
 
 	var clientMap map[string]any
-	if err := json.Unmarshal([]byte(clientConfigJSON), &clientMap); err != nil { t.Fatal(err) }
+	if err := json.Unmarshal([]byte(clientConfigJSON), &clientMap); err != nil {
+		t.Fatal(err)
+	}
 	socksPort := freePort(t)
 	clientMap["socks5Port"] = socksPort
 	clientMap["socks5ListenLAN"] = false
+
 	profiles, ok := clientMap["profiles"].([]any)
-	if !ok || len(profiles) == 0 { t.Fatalf("Mieru config has no profiles: %s", clientConfigJSON) }
+	if !ok || len(profiles) == 0 {
+		t.Fatalf("Mieru config has no profiles: %s", clientConfigJSON)
+	}
 	profile, ok := profiles[0].(map[string]any)
-	if !ok { t.Fatalf("Mieru profile has unexpected shape: %T", profiles[0]) }
+	if !ok {
+		t.Fatalf("Mieru profile has unexpected shape: %T", profiles[0])
+	}
 	servers, ok := profile["servers"].([]any)
-	if !ok || len(servers) == 0 { t.Fatalf("Mieru profile has no servers: %s", clientConfigJSON) }
+	if !ok || len(servers) == 0 {
+		t.Fatalf("Mieru profile has no servers: %s", clientConfigJSON)
+	}
 	server, ok := servers[0].(map[string]any)
-	if !ok { t.Fatalf("Mieru server has unexpected shape: %T", servers[0]) }
+	if !ok {
+		t.Fatalf("Mieru server has unexpected shape: %T", servers[0])
+	}
 	delete(server, "domainName")
 	server["ipAddress"] = "127.0.0.1"
 
 	modifiedClientJSON, err := json.Marshal(clientMap)
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 	clientRuntime := t.TempDir()
 	clientFile := filepath.Join(clientRuntime, "client.json")
-	if err := os.WriteFile(clientFile, modifiedClientJSON, 0o600); err != nil { t.Fatal(err) }
+	if err := os.WriteFile(clientFile, modifiedClientJSON, 0o600); err != nil {
+		t.Fatal(err)
+	}
 	clientLogPath := filepath.Join(clientRuntime, "mieru.log")
 	clientLog, err := os.Create(clientLogPath)
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer clientLog.Close()
+
 	cmdClient := exec.Command(mieruPath, "run")
-	cmdClient.Env = append(os.Environ(), "MIERU_CONFIG_JSON_FILE="+clientFile, "MIERU_LOG_NO_TIMESTAMP=true")
-	cmdClient.Stdout, cmdClient.Stderr = clientLog, clientLog
-	if err := cmdClient.Start(); err != nil { t.Fatalf("start mieru client: %v", err) }
+	cmdClient.Env = append(os.Environ(),
+		"MIERU_CONFIG_JSON_FILE="+clientFile,
+		"MIERU_LOG_NO_TIMESTAMP=true",
+	)
+	cmdClient.Stdout = clientLog
+	cmdClient.Stderr = clientLog
+	if err := cmdClient.Start(); err != nil {
+		t.Fatalf("start mieru client: %v", err)
+	}
 	defer func() { _ = cmdClient.Process.Kill() }()
 
 	socksAddr := fmt.Sprintf("127.0.0.1:%d", socksPort)
@@ -155,10 +198,15 @@ func testRequiredMieruDataPath(t *testing.T, transport string) {
 func applyPanelConfiguration(t *testing.T, srv *testServer) {
 	t.Helper()
 	resp := srv.do(http.MethodPost, "/api/apply/plan", "")
-	if resp.StatusCode != http.StatusOK { t.Fatalf("apply plan expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp)) }
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("apply plan expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp))
+	}
 	drain(resp)
+
 	resp = srv.do(http.MethodPost, "/api/apply", `{"confirm":true}`)
-	if resp.StatusCode != http.StatusOK { t.Fatalf("apply expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp)) }
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("apply expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp))
+	}
 	drain(resp)
 }
 
@@ -179,7 +227,9 @@ func waitUnixSocket(path string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		info, err := os.Stat(path)
-		if err == nil && info.Mode()&os.ModeSocket != 0 { return nil }
+		if err == nil && info.Mode()&os.ModeSocket != 0 {
+			return nil
+		}
 		time.Sleep(50 * time.Millisecond)
 	}
 	return fmt.Errorf("Unix socket %s did not appear within %v", path, timeout)
@@ -198,28 +248,47 @@ func TestRequiredNaiveProxyDataPath(t *testing.T) {
 	srv := startServer(t, serverOptions{token: "e2e-secret-token"})
 	inboundPort := freePort(t)
 	resp := srv.do(http.MethodPut, "/api/settings", `{"panelListen":"127.0.0.1:2096","mode":"dev","domain":"vpn.example.com","email":"test@example.com"}`)
-	if resp.StatusCode != http.StatusOK { t.Fatalf("settings expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp)) }
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("settings expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp))
+	}
 	drain(resp)
+
 	resp = srv.do(http.MethodPost, "/api/inbounds", fmt.Sprintf(`{"name":"naive-tcp","protocol":"naiveproxy","transport":"tcp","port":%d,"enabled":true,"naiveUsername":"naive-user","naivePassword":"naive-pass"}`, inboundPort))
-	if resp.StatusCode != http.StatusCreated { t.Fatalf("inbound expected 201, got %d: %v", resp.StatusCode, readJSON(t, resp)) }
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("inbound expected 201, got %d: %v", resp.StatusCode, readJSON(t, resp))
+	}
 	drain(resp)
 	applyPanelConfiguration(t, srv)
 
 	generatedPath := filepath.Join(srv.applyRoot, "generated", "caddy", "naive-tcp.Caddyfile")
 	generated, err := os.ReadFile(generatedPath)
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 	caddyfile := strings.Replace(string(generated), fmt.Sprintf(":%d, vpn.example.com", inboundPort), fmt.Sprintf("http://127.0.0.1:%d", inboundPort), 1)
 	caddyfile, err = removeCaddyDirectiveBlock(caddyfile, "tls")
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	tempDir := t.TempDir()
 	caddyfilePath := filepath.Join(tempDir, "Caddyfile")
-	if err := os.WriteFile(caddyfilePath, []byte(caddyfile), 0o600); err != nil { t.Fatal(err) }
+	if err := os.WriteFile(caddyfilePath, []byte(caddyfile), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	serverLogPath := filepath.Join(tempDir, "caddy.log")
-	serverLog, _ := os.Create(serverLogPath)
+	serverLog, err := os.Create(serverLogPath)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer serverLog.Close()
+
 	cmdServer := exec.Command(caddyPath, "run", "--config", caddyfilePath, "--adapter", "caddyfile")
-	cmdServer.Stdout, cmdServer.Stderr = serverLog, serverLog
-	if err := cmdServer.Start(); err != nil { t.Fatalf("start caddy: %v", err) }
+	cmdServer.Stdout = serverLog
+	cmdServer.Stderr = serverLog
+	if err := cmdServer.Start(); err != nil {
+		t.Fatalf("start caddy: %v", err)
+	}
 	defer func() { _ = cmdServer.Process.Kill() }()
 	serverAddr := fmt.Sprintf("127.0.0.1:%d", inboundPort)
 	if err := waitListen(serverAddr, 15*time.Second); err != nil {
@@ -228,33 +297,62 @@ func TestRequiredNaiveProxyDataPath(t *testing.T) {
 	}
 
 	resp = srv.do(http.MethodGet, "/api/client-links", "")
-	if resp.StatusCode != http.StatusOK { t.Fatalf("client links expected 200, got %d", resp.StatusCode) }
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("client links expected 200, got %d", resp.StatusCode)
+	}
 	linksBody := readJSON(t, resp)
 	linksRaw, _ := json.Marshal(linksBody["links"])
-	var links []struct { Protocol string `json:"protocol"`; URI string `json:"uri"` }
-	if err := json.Unmarshal(linksRaw, &links); err != nil { t.Fatal(err) }
+	var links []struct {
+		Protocol string `json:"protocol"`
+		URI      string `json:"uri"`
+	}
+	if err := json.Unmarshal(linksRaw, &links); err != nil {
+		t.Fatal(err)
+	}
+
 	var accessURI string
-	for _, link := range links { if link.Protocol == "naiveproxy" { accessURI = link.URI; break } }
-	if accessURI == "" { t.Fatal("panel did not return a NaiveProxy access URI") }
+	for _, link := range links {
+		if link.Protocol == "naiveproxy" {
+			accessURI = link.URI
+			break
+		}
+	}
+	if accessURI == "" {
+		t.Fatal("panel did not return a NaiveProxy access URI")
+	}
 	parsed, err := url.Parse(accessURI)
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 	username := parsed.User.Username()
 	password, _ := parsed.User.Password()
 	socksPort := freePort(t)
 	clientConfig := map[string]any{
-		"listen": fmt.Sprintf("socks://127.0.0.1:%d", socksPort),
-		"proxy": fmt.Sprintf("http://%s:%s@127.0.0.1:%d", url.QueryEscape(username), url.QueryEscape(password), inboundPort),
+		"listen":  fmt.Sprintf("socks://127.0.0.1:%d", socksPort),
+		"proxy":   fmt.Sprintf("http://%s:%s@127.0.0.1:%d", url.QueryEscape(username), url.QueryEscape(password), inboundPort),
 		"padding": true,
 	}
-	clientJSON, _ := json.Marshal(clientConfig)
+	clientJSON, err := json.Marshal(clientConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
 	clientPath := filepath.Join(tempDir, "naive.json")
-	if err := os.WriteFile(clientPath, clientJSON, 0o600); err != nil { t.Fatal(err) }
+	if err := os.WriteFile(clientPath, clientJSON, 0o600); err != nil {
+		t.Fatal(err)
+	}
 	clientLogPath := filepath.Join(tempDir, "naive.log")
-	clientLog, _ := os.Create(clientLogPath)
+	clientLog, err := os.Create(clientLogPath)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer clientLog.Close()
+
 	cmdClient := exec.Command(naivePath, clientPath)
-	cmdClient.Stdout, cmdClient.Stderr = clientLog, clientLog
-	if err := cmdClient.Start(); err != nil { t.Fatalf("start naive: %v", err) }
+	cmdClient.Stdout = clientLog
+	cmdClient.Stderr = clientLog
+	if err := cmdClient.Start(); err != nil {
+		t.Fatalf("start naive: %v", err)
+	}
 	defer func() { _ = cmdClient.Process.Kill() }()
 	socksAddr := fmt.Sprintf("127.0.0.1:%d", socksPort)
 	if err := waitListen(socksAddr, 15*time.Second); err != nil {
@@ -266,17 +364,23 @@ func TestRequiredNaiveProxyDataPath(t *testing.T) {
 
 func removeCaddyDirectiveBlock(input, directive string) (string, error) {
 	lines := strings.Split(input, "\n")
-	start, depth := -1, 0
+	start := -1
+	depth := 0
 	for i, line := range lines {
 		trimmed := strings.TrimSpace(line)
 		if start == -1 {
 			if strings.HasPrefix(trimmed, directive+" ") || trimmed == directive+"{" || trimmed == directive+" {" {
-				if strings.Contains(trimmed, "{") { start, depth = i, strings.Count(line, "{")-strings.Count(line, "}") }
+				if strings.Contains(trimmed, "{") {
+					start = i
+					depth = strings.Count(line, "{") - strings.Count(line, "}")
+				}
 			}
 			continue
 		}
 		depth += strings.Count(line, "{") - strings.Count(line, "}")
-		if depth == 0 { return strings.Join(append(lines[:start], lines[i+1:]...), "\n"), nil }
+		if depth == 0 {
+			return strings.Join(append(lines[:start], lines[i+1:]...), "\n"), nil
+		}
 	}
 	return "", fmt.Errorf("Caddy directive block %q not found or unbalanced", directive)
 }
@@ -284,15 +388,27 @@ func removeCaddyDirectiveBlock(input, directive string) (string, error) {
 func assertHTTPThroughSOCKS(t *testing.T, socksAddr, targetURL, expected string) {
 	t.Helper()
 	dialer, err := proxy.SOCKS5("tcp", socksAddr, nil, proxy.Direct)
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 	client := &http.Client{
-		Transport: &http.Transport{DialContext: func(_ context.Context, network, addr string) (net.Conn, error) { return dialer.Dial(network, addr) }},
+		Transport: &http.Transport{
+			DialContext: func(_ context.Context, network, addr string) (net.Conn, error) {
+				return dialer.Dial(network, addr)
+			},
+		},
 		Timeout: 10 * time.Second,
 	}
 	resp, err := client.Get(targetURL)
-	if err != nil { t.Fatalf("GET through SOCKS failed: %v", err) }
+	if err != nil {
+		t.Fatalf("GET through SOCKS failed: %v", err)
+	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
-	if err != nil { t.Fatal(err) }
-	if string(body) != expected { t.Fatalf("response = %q, want %q", body, expected) }
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != expected {
+		t.Fatalf("response = %q, want %q", body, expected)
+	}
 }

--- a/test/e2e/required_protocol_data_path_test.go
+++ b/test/e2e/required_protocol_data_path_test.go
@@ -1,0 +1,330 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/net/proxy"
+)
+
+func requiredBinary(t *testing.T, name string) string {
+	t.Helper()
+	path, err := exec.LookPath(name)
+	if err != nil {
+		t.Fatalf("required real protocol binary %q is not installed: %v", name, err)
+	}
+	return path
+}
+
+func TestRequiredMieruTCPDataPath(t *testing.T) {
+	testRequiredMieruDataPath(t, "tcp")
+}
+
+func TestRequiredMieruUDPDataPath(t *testing.T) {
+	testRequiredMieruDataPath(t, "udp")
+}
+
+func testRequiredMieruDataPath(t *testing.T, transport string) {
+	t.Helper()
+	mitaPath := requiredBinary(t, "mita")
+	mieruPath := requiredBinary(t, "mieru")
+
+	expectedResponse := "hello from mieru over " + transport
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(expectedResponse))
+	}))
+	defer backend.Close()
+
+	srv := startServer(t, serverOptions{token: "e2e-secret-token"})
+	inboundPort := freePort(t)
+	resp := srv.do(http.MethodPut, "/api/settings", `{"panelListen":"127.0.0.1:2096","mode":"dev","domain":"127.0.0.1"}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("settings expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp))
+	}
+	drain(resp)
+
+	body := fmt.Sprintf(`{"name":"mieru-%s","protocol":"mieru","transport":%q,"port":%d,"enabled":true,"profiles":[{"name":"alice","password":"alice-pass","enabled":true}]}`, transport, transport, inboundPort)
+	resp = srv.do(http.MethodPost, "/api/inbounds", body)
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("inbound expected 201, got %d: %v", resp.StatusCode, readJSON(t, resp))
+	}
+	drain(resp)
+
+	resp = srv.do(http.MethodPost, "/api/apply/plan", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("apply plan expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp))
+	}
+	drain(resp)
+	resp = srv.do(http.MethodPost, "/api/apply", `{"confirm":true}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("apply expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp))
+	}
+	drain(resp)
+
+	serverConfig := filepath.Join(srv.applyRoot, "generated", "mieru", "server_config.json")
+	serverLogPath := filepath.Join(t.TempDir(), "mita.log")
+	serverLog, err := os.Create(serverLogPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer serverLog.Close()
+
+	cmdServer := exec.Command(mitaPath, "run")
+	cmdServer.Env = append(os.Environ(), "MITA_CONFIG_JSON_FILE="+serverConfig)
+	cmdServer.Stdout = serverLog
+	cmdServer.Stderr = serverLog
+	if err := cmdServer.Start(); err != nil {
+		t.Fatalf("start mita: %v", err)
+	}
+	defer func() { _ = cmdServer.Process.Kill() }()
+
+	resp = srv.do(http.MethodGet, "/api/client-links", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("client links expected 200, got %d", resp.StatusCode)
+	}
+	linksBody := readJSON(t, resp)
+	artifactsRaw, _ := json.Marshal(linksBody["artifacts"])
+	var artifacts []struct {
+		Protocol string `json:"protocol"`
+		Kind     string `json:"kind"`
+		Content  string `json:"content"`
+	}
+	if err := json.Unmarshal(artifactsRaw, &artifacts); err != nil {
+		t.Fatalf("decode artifacts: %v", err)
+	}
+	var clientConfigJSON string
+	for _, artifact := range artifacts {
+		if artifact.Protocol == "mieru" && artifact.Kind == "client_config" {
+			clientConfigJSON = artifact.Content
+			break
+		}
+	}
+	if clientConfigJSON == "" {
+		t.Fatal("panel did not return a Mieru client configuration")
+	}
+
+	var clientMap map[string]any
+	if err := json.Unmarshal([]byte(clientConfigJSON), &clientMap); err != nil {
+		t.Fatalf("unmarshal client config: %v", err)
+	}
+	socksPort := freePort(t)
+	clientMap["socks5Port"] = socksPort
+	clientMap["socks5ListenLAN"] = false
+
+	profiles, ok := clientMap["profiles"].([]any)
+	if !ok || len(profiles) == 0 {
+		t.Fatalf("Mieru config has no profiles: %s", clientConfigJSON)
+	}
+	profile, ok := profiles[0].(map[string]any)
+	if !ok {
+		t.Fatalf("Mieru profile has unexpected shape: %T", profiles[0])
+	}
+	servers, ok := profile["servers"].([]any)
+	if !ok || len(servers) == 0 {
+		t.Fatalf("Mieru profile has no servers: %s", clientConfigJSON)
+	}
+	server, ok := servers[0].(map[string]any)
+	if !ok {
+		t.Fatalf("Mieru server has unexpected shape: %T", servers[0])
+	}
+	delete(server, "domainName")
+	server["ipAddress"] = "127.0.0.1"
+
+	modifiedClientJSON, err := json.Marshal(clientMap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientFile := filepath.Join(t.TempDir(), "client.json")
+	if err := os.WriteFile(clientFile, modifiedClientJSON, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	clientLogPath := filepath.Join(t.TempDir(), "mieru.log")
+	clientLog, err := os.Create(clientLogPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clientLog.Close()
+	cmdClient := exec.Command(mieruPath, "run")
+	cmdClient.Env = append(os.Environ(), "MIERU_CONFIG_JSON_FILE="+clientFile)
+	cmdClient.Stdout = clientLog
+	cmdClient.Stderr = clientLog
+	if err := cmdClient.Start(); err != nil {
+		t.Fatalf("start mieru: %v", err)
+	}
+	defer func() { _ = cmdClient.Process.Kill() }()
+
+	socksAddr := fmt.Sprintf("127.0.0.1:%d", socksPort)
+	if err := waitListen(socksAddr, 15*time.Second); err != nil {
+		serverBytes, _ := os.ReadFile(serverLogPath)
+		clientBytes, _ := os.ReadFile(clientLogPath)
+		t.Fatalf("Mieru %s client did not listen: %v\nserver log:\n%s\nclient log:\n%s\nclient config:\n%s", transport, err, serverBytes, clientBytes, modifiedClientJSON)
+	}
+	assertHTTPThroughSOCKS(t, socksAddr, backend.URL, expectedResponse)
+}
+
+func TestRequiredNaiveProxyDataPath(t *testing.T) {
+	caddyPath := requiredBinary(t, "caddy")
+	naivePath := requiredBinary(t, "naive")
+
+	expectedResponse := "hello from naiveproxy"
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(expectedResponse))
+	}))
+	defer backend.Close()
+
+	srv := startServer(t, serverOptions{token: "e2e-secret-token"})
+	inboundPort := freePort(t)
+	resp := srv.do(http.MethodPut, "/api/settings", `{"panelListen":"127.0.0.1:2096","mode":"dev","domain":"vpn.example.com","email":"test@example.com"}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("settings expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp))
+	}
+	drain(resp)
+	resp = srv.do(http.MethodPost, "/api/inbounds", fmt.Sprintf(`{"name":"naive-tcp","protocol":"naiveproxy","transport":"tcp","port":%d,"enabled":true,"naiveUsername":"naive-user","naivePassword":"naive-pass"}`, inboundPort))
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("inbound expected 201, got %d: %v", resp.StatusCode, readJSON(t, resp))
+	}
+	drain(resp)
+	resp = srv.do(http.MethodPost, "/api/apply/plan", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("apply plan expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp))
+	}
+	drain(resp)
+	resp = srv.do(http.MethodPost, "/api/apply", `{"confirm":true}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("apply expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp))
+	}
+	drain(resp)
+
+	generatedPath := filepath.Join(srv.applyRoot, "generated", "caddy", "naive-tcp.Caddyfile")
+	generated, err := os.ReadFile(generatedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caddyfile := strings.Replace(string(generated), fmt.Sprintf(":%d, vpn.example.com", inboundPort), fmt.Sprintf("127.0.0.1:%d", inboundPort), 1)
+	// The data-path test runs on loopback without public DNS. Remove only the
+	// generated TLS block; renderer tests separately require public ACME and
+	// reject the production-incompatible internal issuer.
+	tlsBlock := regexp.MustCompile(`(?ms)^\s*tls\s*\{.*?^\s*\}\s*$`)
+	caddyfile = tlsBlock.ReplaceAllString(caddyfile, "")
+
+	tempDir := t.TempDir()
+	caddyfilePath := filepath.Join(tempDir, "Caddyfile")
+	if err := os.WriteFile(caddyfilePath, []byte(caddyfile), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	serverLogPath := filepath.Join(tempDir, "caddy.log")
+	serverLog, _ := os.Create(serverLogPath)
+	defer serverLog.Close()
+	cmdServer := exec.Command(caddyPath, "run", "--config", caddyfilePath, "--adapter", "caddyfile")
+	cmdServer.Stdout = serverLog
+	cmdServer.Stderr = serverLog
+	if err := cmdServer.Start(); err != nil {
+		t.Fatalf("start caddy: %v", err)
+	}
+	defer func() { _ = cmdServer.Process.Kill() }()
+	serverAddr := fmt.Sprintf("127.0.0.1:%d", inboundPort)
+	if err := waitListen(serverAddr, 15*time.Second); err != nil {
+		logBytes, _ := os.ReadFile(serverLogPath)
+		t.Fatalf("Caddy did not listen: %v\nCaddyfile:\n%s\nlog:\n%s", err, caddyfile, logBytes)
+	}
+
+	resp = srv.do(http.MethodGet, "/api/client-links", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("client links expected 200, got %d", resp.StatusCode)
+	}
+	linksBody := readJSON(t, resp)
+	linksRaw, _ := json.Marshal(linksBody["links"])
+	var links []struct {
+		Protocol string `json:"protocol"`
+		URI      string `json:"uri"`
+	}
+	if err := json.Unmarshal(linksRaw, &links); err != nil {
+		t.Fatal(err)
+	}
+	var accessURI string
+	for _, link := range links {
+		if link.Protocol == "naiveproxy" {
+			accessURI = link.URI
+			break
+		}
+	}
+	if accessURI == "" {
+		t.Fatal("panel did not return a NaiveProxy access URI")
+	}
+	parsed, err := url.Parse(accessURI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	username := parsed.User.Username()
+	password, _ := parsed.User.Password()
+	socksPort := freePort(t)
+	clientConfig := map[string]any{
+		"listen":  fmt.Sprintf("socks://127.0.0.1:%d", socksPort),
+		"proxy":   fmt.Sprintf("http://%s:%s@127.0.0.1:%d", url.QueryEscape(username), url.QueryEscape(password), inboundPort),
+		"padding": true,
+	}
+	clientJSON, _ := json.Marshal(clientConfig)
+	clientPath := filepath.Join(tempDir, "naive.json")
+	if err := os.WriteFile(clientPath, clientJSON, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	clientLogPath := filepath.Join(tempDir, "naive.log")
+	clientLog, _ := os.Create(clientLogPath)
+	defer clientLog.Close()
+	cmdClient := exec.Command(naivePath, clientPath)
+	cmdClient.Stdout = clientLog
+	cmdClient.Stderr = clientLog
+	if err := cmdClient.Start(); err != nil {
+		t.Fatalf("start naive: %v", err)
+	}
+	defer func() { _ = cmdClient.Process.Kill() }()
+	socksAddr := fmt.Sprintf("127.0.0.1:%d", socksPort)
+	if err := waitListen(socksAddr, 15*time.Second); err != nil {
+		clientBytes, _ := os.ReadFile(clientLogPath)
+		t.Fatalf("Naive client did not listen: %v\nclient log:\n%s\nconfig:\n%s", err, clientBytes, clientJSON)
+	}
+	assertHTTPThroughSOCKS(t, socksAddr, backend.URL, expectedResponse)
+}
+
+func assertHTTPThroughSOCKS(t *testing.T, socksAddr, targetURL, expected string) {
+	t.Helper()
+	dialer, err := proxy.SOCKS5("tcp", socksAddr, nil, proxy.Direct)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := &http.Client{
+		Transport: &http.Transport{DialContext: func(_ context.Context, network, addr string) (net.Conn, error) {
+			return dialer.Dial(network, addr)
+		}},
+		Timeout: 10 * time.Second,
+	}
+	resp, err := client.Get(targetURL)
+	if err != nil {
+		t.Fatalf("GET through SOCKS failed: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != expected {
+		t.Fatalf("response = %q, want %q", body, expected)
+	}
+}

--- a/test/e2e/required_protocol_data_path_test.go
+++ b/test/e2e/required_protocol_data_path_test.go
@@ -168,34 +168,23 @@ func testRequiredMieruDataPath(t *testing.T, transport string) {
 	if err := os.WriteFile(clientFile, modifiedClientJSON, 0o600); err != nil {
 		t.Fatal(err)
 	}
-	clientSocket := filepath.Join(clientRuntime, "mieru.sock")
-	clientPB := filepath.Join(clientRuntime, "client.conf.pb")
 	clientLogPath := filepath.Join(clientRuntime, "mieru.log")
 	clientLog, err := os.Create(clientLogPath)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer clientLog.Close()
-	clientEnv := append(os.Environ(),
-		"MIERU_CONFIG_FILE="+clientPB,
-		"MIERU_UDS_PATH="+clientSocket,
-		"MIERU_INSECURE_UDS=1",
+	cmdClient := exec.Command(mieruPath, "run")
+	cmdClient.Env = append(os.Environ(),
+		"MIERU_CONFIG_JSON_FILE="+clientFile,
 		"MIERU_LOG_NO_TIMESTAMP=true",
 	)
-	cmdClient := exec.Command(mieruPath, "run")
-	cmdClient.Env = clientEnv
 	cmdClient.Stdout = clientLog
 	cmdClient.Stderr = clientLog
 	if err := cmdClient.Start(); err != nil {
-		t.Fatalf("start mieru daemon: %v", err)
+		t.Fatalf("start mieru client: %v", err)
 	}
 	defer func() { _ = cmdClient.Process.Kill() }()
-	if err := waitUnixSocket(clientSocket, 15*time.Second); err != nil {
-		logBytes, _ := os.ReadFile(clientLogPath)
-		t.Fatalf("mieru control socket did not appear: %v\nlog:\n%s", err, logBytes)
-	}
-	runMieruControl(t, clientEnv, mieruPath, clientLogPath, "apply", "config", clientFile)
-	runMieruControl(t, clientEnv, mieruPath, clientLogPath, "start")
 
 	socksAddr := fmt.Sprintf("127.0.0.1:%d", socksPort)
 	if err := waitListen(socksAddr, 15*time.Second); err != nil {
@@ -208,7 +197,9 @@ func testRequiredMieruDataPath(t *testing.T, transport string) {
 
 func runMieruControl(t *testing.T, env []string, binary, logPath string, args ...string) {
 	t.Helper()
-	cmd := exec.Command(binary, args...)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binary, args...)
 	cmd.Env = env
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -268,7 +259,7 @@ func TestRequiredNaiveProxyDataPath(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	caddyfile := strings.Replace(string(generated), fmt.Sprintf(":%d, vpn.example.com", inboundPort), fmt.Sprintf("127.0.0.1:%d", inboundPort), 1)
+	caddyfile := strings.Replace(string(generated), fmt.Sprintf(":%d, vpn.example.com", inboundPort), fmt.Sprintf("http://127.0.0.1:%d", inboundPort), 1)
 	caddyfile, err = removeCaddyDirectiveBlock(caddyfile, "tls")
 	if err != nil {
 		t.Fatal(err)

--- a/test/e2e/required_protocol_data_path_test.go
+++ b/test/e2e/required_protocol_data_path_test.go
@@ -247,7 +247,7 @@ func TestRequiredNaiveProxyDataPath(t *testing.T) {
 
 	srv := startServer(t, serverOptions{token: "e2e-secret-token"})
 	inboundPort := freePort(t)
-	resp := srv.do(http.MethodPut, "/api/settings", `{"panelListen":"127.0.0.1:2096","mode":"dev","domain":"vpn.example.com","email":"test@example.com"}`)
+	resp := srv.do(http.MethodPut, "/api/settings", `{"panelListen":"127.0.0.1:2096","mode":"dev","domain":"vpn.example.com","defaultAcmeEmail":"test@example.com"}`)
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("settings expected 200, got %d: %v", resp.StatusCode, readJSON(t, resp))
 	}

--- a/test/e2e/required_protocol_data_path_test.go
+++ b/test/e2e/required_protocol_data_path_test.go
@@ -283,14 +283,23 @@ func testNaiveProxyDataPath(t *testing.T, caddyPath, naivePath string) {
 	if err := generateSelfSignedCert(certPath, keyPath); err != nil {
 		t.Fatalf("generate trusted test certificate: %v", err)
 	}
-	caPath := "/usr/local/share/ca-certificates/veil-naive-e2e.crt"
+	// The standalone naive binary (C++) has no flag to skip TLS verification or
+	// point at a custom CA bundle, so the only way to make it trust our
+	// self-signed server cert is the system trust store. Scope the damage: use a
+	// unique per-run CA filename, register removal via t.Cleanup (runs even on
+	// Fatal/panic), refresh the store on cleanup, and assert the file is gone.
+	caName := "veil-naive-e2e-" + strings.NewReplacer("-", "", ".", "", "/", "").Replace(t.Name()) + ".crt"
+	caPath := "/usr/local/share/ca-certificates/" + caName
 	if output, err := exec.Command("sudo", "install", "-m", "0644", certPath, caPath).CombinedOutput(); err != nil {
 		t.Fatalf("install test certificate: %v: %s", err, output)
 	}
-	defer func() {
+	t.Cleanup(func() {
 		_ = exec.Command("sudo", "rm", "-f", caPath).Run()
-		_ = exec.Command("sudo", "update-ca-certificates").Run()
-	}()
+		_ = exec.Command("sudo", "update-ca-certificates", "--fresh").Run()
+		if _, err := os.Lstat(caPath); !os.IsNotExist(err) {
+			t.Errorf("test CA %s was not removed from the system trust store", caPath)
+		}
+	})
 	if output, err := exec.Command("sudo", "update-ca-certificates").CombinedOutput(); err != nil {
 		t.Fatalf("refresh test trust store: %v: %s", err, output)
 	}
@@ -490,11 +499,14 @@ func caddyServerHandler(server map[string]any, handlerName string) map[string]an
 
 func registerLoopbackHostname(t *testing.T, hostname string) {
 	t.Helper()
-	if hostname == "" || strings.ContainsAny(hostname, " \t\r\n") {
+	if hostname == "" || strings.ContainsAny(hostname, " 	\r\n") {
 		t.Fatalf("invalid E2E hostname %q", hostname)
 	}
+	// Unique marker so cleanup removes only the exact line this invocation
+	// appended, never a pre-existing entry that merely shares the hostname.
+	marker := "veil-e2e-" + strings.NewReplacer("-", "", ".", "").Replace(t.Name()) + "-" + hostname
 	cmd := exec.Command("sudo", "tee", "-a", "/etc/hosts")
-	cmd.Stdin = strings.NewReader("127.0.0.1 " + hostname + "\n")
+	cmd.Stdin = strings.NewReader("127.0.0.1 " + hostname + " # " + marker + "\n")
 	if output, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("register local E2E hostname: %v: %s", err, output)
 	}
@@ -503,11 +515,11 @@ func registerLoopbackHostname(t *testing.T, hostname string) {
 from pathlib import Path
 import sys
 p = Path("/etc/hosts")
-hostname = sys.argv[1]
-lines = [line for line in p.read_text().splitlines() if hostname not in line.split()]
+marker = sys.argv[1]
+lines = [line for line in p.read_text().splitlines() if marker not in line]
 p.write_text("\n".join(lines) + "\n")
 `
-		if output, err := exec.Command("sudo", "python3", "-c", cleanup, hostname).CombinedOutput(); err != nil {
+		if output, err := exec.Command("sudo", "python3", "-c", cleanup, marker).CombinedOutput(); err != nil {
 			t.Errorf("remove local E2E hostname: %v: %s", err, output)
 		}
 	})

--- a/test/e2e/server_proc_alias_test.go
+++ b/test/e2e/server_proc_alias_test.go
@@ -1,0 +1,7 @@
+//go:build e2e
+
+package e2e
+
+// testServer keeps protocol helper signatures concise while using the
+// real subprocess-backed E2E harness.
+type testServer = serverProc


### PR DESCRIPTION
This PR introduces per-inbound domain and ACME email configuration for protocols (naiveproxy, hysteria2), centralizes domain/email resolution in the model layer, and aligns Caddy certificate paths and validation wiring.

Key changes:
- Per-inbound `domain` and `email` protocol fields with centralized resolution and validation.
- Hysteria2 certificates now use per-inbound domain cert paths when configured.
- Removed legacy `settings.Email` fallback for inbound-specific certificates.
- Centralized `domain` / `email` field constants in `internal/model`.
- Lowercased mieru client endpoint handling for consistency.
- Fixed gofmt across the branch.

All tests pass: `go test ./...`.