### PR TITLE
Add AGENTS.md with Cursor Cloud dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,61 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Veil is a single Go binary (`veil`) that bundles a CLI plus an HTTP API and an
+embedded React SPA (the "Panel"). There is no external database — state is an
+AES-encrypted JSON file. The repo has two parts: the Go backend (repo root) and
+the React frontend in `web/`.
+
+### Toolchain / versions (already provisioned in the base environment)
+
+- Go `1.27.0` (matches `go.mod`; `scripts/ci/versions.sh` is the source of truth).
+- Node `26.7.0` and pnpm `11.22.0` are the pinned frontend versions
+  (`web/package.json` `packageManager`, Dockerfile, and `scripts/ci/versions.sh`).
+  Node 26.7.0 is installed via `nvm`. The runner injects a different Node
+  (`/exec-daemon/node`, currently v22.x) at the front of `PATH`, so `node`
+  resolves to that by default. Before running any frontend command, activate the
+  pinned Node for the shell:
+
+  ```bash
+  export NVM_DIR="$HOME/.nvm"
+  export PATH="$HOME/.nvm/versions/node/v26.7.0/bin:$PATH"   # or: nvm use 26.7.0
+  ```
+
+  Use `corepack pnpm ...` so the pinned pnpm 11.22.0 (from `packageManager`) is
+  used rather than any globally installed pnpm.
+- `caddy` v2.11.4 built with the `klzgrad/forwardproxy` module is installed at
+  `/usr/local/bin/caddy`. It is required for the `internal/protocols` and
+  `internal/protocols/naiveproxy` Go tests (they probe `caddy list-modules
+  --json`). Without it those two packages fail; the rest of `go test ./...`
+  passes without any protocol runtimes.
+
+### Build / lint / test / run
+
+Commands are defined in the `Makefile` and `web/package.json` — prefer those.
+
+- Frontend (run from `web/`, with pinned Node active): `corepack pnpm install
+  --frozen-lockfile`, then `corepack pnpm build` (outputs `web/dist`),
+  `corepack pnpm typecheck`, `corepack pnpm check` (Biome lint),
+  `corepack pnpm test` (Vitest jsdom), `corepack pnpm gen` (regenerate API
+  client; CI checks `src/api/generated` for drift), `corepack pnpm i18n:check`.
+  The full frontend CI job is `scripts/ci/frontend.sh`.
+- Backend: `make build` (=> `bin/veil`), `go vet ./...`, `go test ./...`.
+  IMPORTANT: `web/web.go` embeds `web/dist` via `//go:embed all:dist`, so the
+  frontend MUST be built (`corepack pnpm build` or `make web`) before the Go
+  binary will compile.
+- Run the Panel: `./bin/veil serve --listen 127.0.0.1:2096`. On a loopback
+  listener with no configured admin, the Panel exposes a first-run setup page to
+  create the initial administrator. Non-loopback listeners refuse to start
+  unless an API token, a Panel user, authenticated metrics, and TLS are all
+  configured (see README "First-run admin setup").
+
+### Notes / gotchas
+
+- `docker compose up -d` runs the production image; for development, run the
+  locally built `bin/veil` directly instead.
+- Protocol runtimes (hysteria, mita/mieru, naive, sing-box) and Caddy are
+  optional integrations Veil installs/manages; only `caddy`-with-forwardproxy is
+  needed for the unit test suite (see above). The `test/e2e` and
+  `test/linuxintegration` suites are Linux/systemd-oriented and provision pinned
+  runtimes via `scripts/ci/runtimes.sh`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up and documents the Cloud Agent development environment for Veil, and adds an `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering the toolchain, build/lint/test/run commands, and non-obvious gotchas.

This PR only adds `AGENTS.md` — no application code is changed. The environment update script is configured separately (via the environment settings), not in the repo.

## Environment setup performed

- Toolchain: Go `1.27.0` (matches `go.mod`); Node `26.7.0` + pnpm `11.22.0` (matches `web/package.json` `packageManager`, Dockerfile, and `scripts/ci/versions.sh`). Node 26.7.0 installed via `nvm` (the runner injects a different `node` at the front of `PATH`, so it must be activated for frontend commands — documented in `AGENTS.md`).
- Built `caddy` v2.11.4 with the `klzgrad/forwardproxy` module into `/usr/local/bin/caddy`, which the `internal/protocols` and `internal/protocols/naiveproxy` Go tests require (they probe `caddy list-modules --json`).
- Update script (dependency refresh only): `go mod download`, then `corepack pnpm install --frozen-lockfile` in `web/`.

## Verification

| Area | Command | Result |
|---|---|---|
| Frontend deps | `corepack pnpm install --frozen-lockfile` | OK |
| Frontend build | `corepack pnpm build` (→ `web/dist`) | OK |
| Frontend typecheck | `corepack pnpm typecheck` | OK |
| Frontend lint | `corepack pnpm check` (Biome) | OK, no warnings |
| Frontend unit tests | `corepack pnpm test` (Vitest jsdom) | 73 passed |
| API client drift | `corepack pnpm gen` + git diff | No drift |
| i18n | `corepack pnpm i18n:check` | CLEAN |
| Backend build | `go build -o bin/veil ./cmd/veil` (embeds `web/dist`) | OK |
| Backend vet | `go vet ./...` | OK |
| Backend tests | `go test ./...` | All pass (incl. `internal/protocols*` once `caddy` is present) |
| Run app | `veil serve` + privileged helper | First-run admin created, login, authenticated Panel |

## Hello-world demo

Ran the Panel end-to-end (privileged helper as root + `veil serve` as the `veil` user), created the initial administrator via the first-run setup, logged in, and used the authenticated Panel (Overview + Users showing the `admin` user).

[veil_panel_clean_first_run_and_login_demo.mp4](https://cursor.com/agents/bc-4e19b5e0-e903-4d91-b79e-5a1577e997c6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fveil_panel_clean_first_run_and_login_demo.mp4)

[Authenticated Veil Panel Overview dashboard](https://cursor.com/agents/bc-4e19b5e0-e903-4d91-b79e-5a1577e997c6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fveil_authenticated_dashboard.webp)

[Veil Panel Users page listing the admin user](https://cursor.com/agents/bc-4e19b5e0-e903-4d91-b79e-5a1577e997c6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fveil_users_page_admin.webp)

Note: the demo surfaced minor post-login/logout routing quirks in the app UI. These are existing application behaviors, unrelated to environment setup, and are out of scope for this PR.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e19b5e0-e903-4d91-b79e-5a1577e997c6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e19b5e0-e903-4d91-b79e-5a1577e997c6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

